### PR TITLE
Add wait if zypper is locked

### DIFF
--- a/ansible/playbooks/registration.yaml
+++ b/ansible/playbooks/registration.yaml
@@ -61,14 +61,14 @@
         - ansible_facts['distribution_major_version'] == "12"
 
     - name: Add SLES 12 public cloud module
-      ansible.builtin.command: SUSEConnect -p sle-module-public-cloud/12/{{ ansible_facts['architecture'] }} -r "{{ reg_code }}"
+      ansible.builtin.command: SUSEConnect -p sle-module-public-cloud/12/{{ ansible_facts['architecture'] }}
       when:
         - rcg.rc != 0
         - repos.rc != 0
         - ansible_facts['distribution_major_version'] == "12"
     
     - name: Add SLES 15 public cloud module
-      ansible.builtin.command: SUSEConnect -p sle-module-public-cloud/{{ ansible_facts['distribution_major_version']}}/{{ ansible_facts['architecture'] }} -r "{{ reg_code }}"
+      ansible.builtin.command: SUSEConnect -p sle-module-public-cloud/{{ ansible_facts['distribution_version'] }}/{{ ansible_facts['architecture'] }}
       when:
         - rcg.rc != 0
         - repos.rc != 0


### PR DESCRIPTION
I was testing it on local SLES4SAP VMs 15sp3 & 12sp5 e.g.
```
PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
10.100.51.137              : ok=4    changed=1    unreachable=0    failed=0    skipped=6    rescued=0    ignored=0   
10.162.31.181              : ok=4    changed=1    unreachable=0    failed=0    skipped=6    rescued=0    ignored=0   
10.162.31.186              : ok=6    changed=3    unreachable=0    failed=0    skipped=4    rescued=0    ignored=0
```
The email thing is just proposal, I can drop it if we want to use email, but it's not required and I never use it. :innocent: 
I'm not sure is `registercloudguest` is same as `SUSEConnect`