### PR TITLE
Introduce 'admin_user' variable to GCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ ansible/playbooks/tmp
 ansible/playbooks/sap-hana-storage.yml
 ansible/playbooks/roles/sap_storage
 .DS_Store
+/terraform/libvirt/.terraform.lock.hcl
+/terraform/gcp/.terraform.tfstate.lock.info

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -69,6 +69,7 @@ variable "subnet_netapp_address_range" {
 variable "admin_user" {
   description = "Administration user used to create the machines"
   type        = string
+  default     = "cloudadmin"
   validation {
     condition = (
       var.admin_user != "admin"

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -88,7 +88,7 @@ module "common_variables" {
   public_key                          = var.public_key
   private_key                         = var.private_key
   authorized_keys                     = var.authorized_keys
-  authorized_user                     = "root"
+  authorized_user                     = var.admin_user
   bastion_enabled                     = var.bastion_enabled
   bastion_public_key                  = var.bastion_public_key
   bastion_private_key                 = var.bastion_private_key

--- a/terraform/gcp/terraform.tfvars.example
+++ b/terraform/gcp/terraform.tfvars.example
@@ -35,6 +35,9 @@ region = "europe-west1"
 # The name must be unique among different deployments
 # deployment_name = "mydeployment"
 
+# Admin user for the created machines (default = cloudadmin)
+# admin_user = "cloudadmin"
+
 # Add the "deployment_name" as a prefix to the hostname.
 #deployment_name_in_hostname = true
 

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -61,6 +61,18 @@ variable "authorized_keys" {
   default     = []
 }
 
+variable "admin_user" {
+  description = "Administration user used to create the machines"
+  type        = string
+  default = "cloudadmin"
+  validation {
+    condition = (
+      var.admin_user != "admin"
+    )
+    error_message = "The value 'admin' cannot be used for admin_user, input a different value."
+  }
+}
+
 variable "bastion_name" {
   description = "hostname, without the domain part"
   type        = string


### PR DESCRIPTION
GCP does not currently have an option to define 'admin_user'. It only uses static var for root user. 
This PR allows defining admin user via tfvars file and adds default value "cloudadmin".