### PR TITLE
Configure cloudadmin as the admin user for EC2 instances

### DIFF
--- a/terraform/aws/cloudadmin.tpl
+++ b/terraform/aws/cloudadmin.tpl
@@ -1,0 +1,11 @@
+#cloud-config to deploy cloudadmin user in EC2 instances
+cloud_final_modules:
+- [users-groups,always]
+users:
+  - name: cloudadmin
+    groups: [ wheel ]
+    sudo:
+      - "ALL=(ALL) NOPASSWD:ALL"
+    shell: /bin/bash
+    ssh-authorized-keys: 
+    - ${publickey}

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -72,7 +72,7 @@ module "common_variables" {
   public_key                          = var.public_key
   private_key                         = var.private_key
   authorized_keys                     = var.authorized_keys
-  authorized_user                     = "ec2-user"
+  authorized_user                     = "cloudadmin"
   provisioner                         = var.provisioner
   provisioning_output_colored         = var.provisioning_output_colored
   background                          = var.background

--- a/terraform/aws/modules/drbd_node/main.tf
+++ b/terraform/aws/modules/drbd_node/main.tf
@@ -46,6 +46,7 @@ resource "aws_instance" "drbd" {
   vpc_security_group_ids      = [var.security_group_id]
   availability_zone           = element(var.availability_zones, count.index)
   source_dest_check           = false
+  user_data                   = templatefile("${path.root}/cloudadmin.tpl", { publickey = var.common_variables["public_key"] })
 
   root_block_device {
     volume_type = "gp2"
@@ -73,7 +74,7 @@ module "drbd_on_destroy" {
   source       = "../../../generic_modules/on_destroy"
   node_count   = var.drbd_count
   instance_ids = aws_instance.drbd.*.id
-  user         = "ec2-user"
+  user         = "cloudadmin"
   private_key  = var.common_variables["private_key"]
   public_ips   = aws_instance.drbd.*.public_ip
   dependencies = var.on_destroy_dependencies

--- a/terraform/aws/modules/hana_node/main.tf
+++ b/terraform/aws/modules/hana_node/main.tf
@@ -57,6 +57,7 @@ resource "aws_instance" "hana" {
   vpc_security_group_ids      = [var.security_group_id]
   availability_zone           = element(var.availability_zones, count.index)
   source_dest_check           = false
+  user_data                   = templatefile("${path.root}/cloudadmin.tpl", { publickey = var.common_variables["public_key"] })
 
   root_block_device {
     volume_type = "gp2"
@@ -84,7 +85,7 @@ module "hana_on_destroy" {
   source       = "../../../generic_modules/on_destroy"
   node_count   = var.hana_count
   instance_ids = aws_instance.hana.*.id
-  user         = "ec2-user"
+  user         = "cloudadmin"
   private_key  = var.common_variables["private_key"]
   public_ips   = aws_instance.hana.*.public_ip
   dependencies = concat(

--- a/terraform/aws/modules/iscsi_server/main.tf
+++ b/terraform/aws/modules/iscsi_server/main.tf
@@ -20,6 +20,7 @@ resource "aws_instance" "iscsisrv" {
   private_ip                  = element(var.host_ips, count.index)
   vpc_security_group_ids      = [var.security_group_id]
   availability_zone           = element(var.availability_zones, count.index)
+  user_data                   = templatefile("${path.root}/cloudadmin.tpl", { publickey = var.common_variables["public_key"] })
 
   root_block_device {
     volume_type = "gp2"
@@ -46,7 +47,7 @@ module "iscsi_on_destroy" {
   source       = "../../../generic_modules/on_destroy"
   node_count   = var.iscsi_count
   instance_ids = aws_instance.iscsisrv.*.id
-  user         = "ec2-user"
+  user         = "cloudadmin"
   private_key  = var.common_variables["private_key"]
   public_ips   = aws_instance.iscsisrv.*.public_ip
   dependencies = var.on_destroy_dependencies

--- a/terraform/aws/modules/monitoring/main.tf
+++ b/terraform/aws/modules/monitoring/main.tf
@@ -18,6 +18,7 @@ resource "aws_instance" "monitoring" {
   private_ip                  = var.monitoring_srv_ip
   vpc_security_group_ids      = [var.security_group_id]
   availability_zone           = element(var.availability_zones, 0)
+  user_data                   = templatefile("${path.root}/cloudadmin.tpl", { publickey = var.common_variables["public_key"] })
 
   root_block_device {
     volume_type = "gp2"
@@ -44,7 +45,7 @@ module "monitoring_on_destroy" {
   source       = "../../../generic_modules/on_destroy"
   node_count   = var.monitoring_enabled ? 1 : 0
   instance_ids = aws_instance.monitoring.*.id
-  user         = "ec2-user"
+  user         = "cloudadmin"
   private_key  = var.common_variables["private_key"]
   public_ips   = aws_instance.monitoring.*.public_ip
   dependencies = var.on_destroy_dependencies

--- a/terraform/aws/modules/netweaver_node/main.tf
+++ b/terraform/aws/modules/netweaver_node/main.tf
@@ -91,6 +91,7 @@ resource "aws_instance" "netweaver" {
   vpc_security_group_ids      = [var.security_group_id]
   availability_zone           = element(var.availability_zones, count.index % 2)
   source_dest_check           = false
+  user_data                   = templatefile("${path.root}/cloudadmin.tpl", { publickey = var.common_variables["public_key"] })
 
   root_block_device {
     volume_type = "gp2"
@@ -119,7 +120,7 @@ module "netweaver_on_destroy" {
   source       = "../../../generic_modules/on_destroy"
   node_count   = local.vm_count
   instance_ids = aws_instance.netweaver.*.id
-  user         = "ec2-user"
+  user         = "cloudadmin"
   private_key  = var.common_variables["private_key"]
   public_ips   = aws_instance.netweaver.*.public_ip
   dependencies = concat(

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -76,7 +76,7 @@ variable "private_key" {
 }
 
 variable "authorized_keys" {
-  description = "List of additional authorized SSH public keys content or path to already existing SSH public keys to access the created machines with the used admin user (ec2-user in this case)"
+  description = "List of additional authorized SSH public keys content or path to already existing SSH public keys to access the created machines with the used admin user (cloudadmin in this case)"
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
This project is already using the `cloudadmin` user as the admin user for remote systems in Azure and GCP, so AWS/EC2 was the outlier by having the `ec2-user` provided by default in EC2 as the admin user. This commit adds `cloudadmin` as the admin user instead of `ec2-user` via the `user_data` option in the AWS EC2 instances configuration. At the same time, `ec2-user` is being dropped from the remote systems as a consequence.

`user_data` configuration for `cloudadmin` as a substitute to `ec2-user`
was taken from: https://aws.amazon.com/premiumsupport/knowledge-center/ec2-user-account-cloud-init-user-data/

Tested with:
```
# cd qe-sap-deployment/terraform/aws
# cp terraform.tfvars.example terraform.tfvars
# patch terraform.tfvars ~/tfvars.patch
# terraform init
# terraform workspace new myworkspace
# terraform plan
# terraform apply --auto-approve
# terraform output -json | jq -rc '.cluster_nodes_public_ip.value, .iscsisrv_public_ip.value'
["X.X.X.X","Y.Y.Y.Y"]
Z.Z.Z.Z
# ssh -i ~/.ssh/id_rsa cloudadmin@X.X.X.X
cloudadmin@ip-10-0-1-10:~> id
uid=1000(cloudadmin) gid=100(users) groups=100(users),1000(wheel)
cloudadmin@ip-10-0-1-10:~> sudo su -
ip-10-0-1-10:~ # exit
# terraform destroy --auto-approve
```
The terraform.tfvars files used were the same as described in #24 