### PR TITLE
added saptune support

### DIFF
--- a/ansible/playbooks/sap-hana-preconfigure.yaml
+++ b/ansible/playbooks/sap-hana-preconfigure.yaml
@@ -4,8 +4,11 @@
   become: true
   become_user : root
   vars:
-    scale_out: False
-    use_sapconf: False
+    scale_out: false
+    use_sapconf: false
+    saptune_solution: HANA
+    platform: azure
+    cluster_node: true
     hana_download_path: /hana/shared/install
     url_timeout: 30
     url_retries_cnt: 5
@@ -35,6 +38,9 @@
       when: use_sapconf | bool
 
     # saptune to be handled here with more included tasks!
+    - name: Configure saptune based systems
+      ansible.builtin.include_tasks: ./tasks/saptune.yaml
+      when: not use_sapconf | bool 
     
   handlers:
     - name: reboot

--- a/ansible/playbooks/tasks/saptune.yaml
+++ b/ansible/playbooks/tasks/saptune.yaml
@@ -1,0 +1,79 @@
+---
+- name: Ensure that saptune 3.0 or greater is installed
+  community.general.zypper:
+    name: 'saptune>=3.0'
+    state: present
+
+- name: Ensure conflicting services are stopped and disabled
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    state: stopped
+    enabled: no
+  loop:
+    - sapconf
+    - tuned
+
+- name: Ensure saptune is running and enabled
+  ansible.builtin.systemd:
+    name: saptune
+    state: started
+    enabled: yes
+
+- name: Ensure saptune_check executes correctly
+  ansible.builtin.command: saptune_check
+  changed_when: no    
+
+- name: Discover active solution
+  ansible.builtin.command: saptune solution enabled
+  register: saptune_status
+  changed_when: no
+
+- name: Set fact for active solution
+  ansible.builtin.set_fact:
+    solution_configured: "{{ (saptune_status.stdout | regex_search('(\\S+)', '\\1' ))[0] | default('NONE') }}" # Capture the first block on none whitespace
+    
+- name: Show configured solution
+  ansible.builtin.debug:
+    var: solution_configured
+
+# If this is a cluster node on Azure, we need to override to disable tcp timestamps, reuse and recycle.
+# This can be done by copying the sapnote file 2382421 from /usr/share/saptune/notes to /etc/saptune/override
+# The value can then override in the in the new file
+
+- name: Disable TCP timestamps, recycle & reuse
+  ansible.builtin.blockinfile:
+    path: /etc/saptune/override/2382421
+    create: yes
+    backup: yes
+    owner: root
+    group: root
+    mode: '0640'
+    marker: "<!-- {mark} ANSIBLE MANAGED BLOCK -->"
+    block: |
+     [sysctl]
+     net.ipv4.tcp_timestamps = 0
+     net.ipv4.tcp_tw_reuse = 0
+     net.ipv4.tcp_timestamps = 0
+  when: 
+    - cluster_node
+    - platform == 'azure'    
+
+- name: Check if saptune solution needs to be applied
+  ansible.builtin.command: "saptune solution verify {{ saptune_solution }}"
+  register: verify
+  changed_when: no # We're only checking, not changing!
+  failed_when: no # We expect this to fail if it has not previously been applied
+
+- name: Ensure no solution is currently applied
+  ansible.builtin.command: "saptune solution revert {{ solution_configured }}"
+  when: 
+    - solution_configured != 'NONE'
+    - verify.rc != 0
+
+- name: Ensure saptune solution is applied
+  ansible.builtin.command: "saptune solution apply {{ saptune_solution }}"
+  when: verify.rc != 0
+
+- name: Ensure solution was successful 
+  ansible.builtin.command: "saptune solution verify {{ saptune_solution }}"
+  changed_when: no # We're only checking, not changing!    

--- a/ansible/playbooks/tasks/saptune.yaml
+++ b/ansible/playbooks/tasks/saptune.yaml
@@ -53,7 +53,7 @@
      [sysctl]
      net.ipv4.tcp_timestamps = 0
      net.ipv4.tcp_tw_reuse = 0
-     net.ipv4.tcp_timestamps = 0
+     net.ipv4.tcp_tw_recycle = 0
   when: 
     - cluster_node
     - platform == 'azure'    


### PR DESCRIPTION
saptune support is now added and is the default tuning tool.  sapconf can still be used by setting use_sapconf to 'yes' with sap-hana-preconfigure.yaml.