### PR TITLE
Generate tfvars from yaml

### DIFF
--- a/scripts/qesap/lib/config.py
+++ b/scripts/qesap/lib/config.py
@@ -1,0 +1,77 @@
+"""
+configuration file related libraries
+"""
+import logging
+import re
+
+log = logging.getLogger('QESAPDEP')
+
+
+def yaml_to_tfvars(yaml_data):
+    """ Takes data structure collected from yaml config,
+    converts into tfvars format and writes it into the final tfvars file
+
+    Args:
+        yaml_data (dict): data structure returned from is_yaml
+        tfvars_file (str): path to the target tfvars file
+
+    Returns:
+        bool: True(pass)/False(failure)
+    """
+    config_out = ''
+    terraform_variables = yaml_data['terraform']['variables']
+    print(yaml_data)
+    for key, value in terraform_variables.items():
+        if isinstance(value, (str, int)):
+            entry = f'{key} = "{str(value)}"'
+        elif isinstance(value, bool):
+            entry = f'{key} = "{str(value).lower()}"'
+        elif isinstance(value, list):
+            entry = '", "'.join(value)
+            entry = f'{key} = ["{entry}"]'
+        elif isinstance(value, dict):
+            param_value = ''
+            for dict_key, dict_value in value.items():
+                param_value = f'{param_value}\t{dict_key} = "{dict_value}"\n'
+            entry = f'{key} = {{\n' \
+                    f'{param_value}' \
+                    f'}}'
+        else:
+            log.error(f'Unrecognized value type in yaml file: {key} = {value}')
+            return False
+        config_out = f'{config_out}\n{entry}'
+
+    return config_out
+
+
+def template_to_tfvars(tfvars_template, configure_data):
+    """ takes
+
+    Args:
+        configure_data (dict): configuration data sctructure
+        tfvars_template (str): path to the tfvars template file
+
+    Returns:
+        bool: True(pass)/False(failure)
+    """
+    with open(tfvars_template, 'r') as f:
+        tfvar_content = f.readlines()
+        log.debug("Template:%s", tfvar_content)
+
+        if 'variables' in configure_data['terraform'].keys():
+            log.debug("Config has terraform variables")
+            for k,v in configure_data['terraform']['variables'].items():
+                key_replace = False
+                # Look for k in the template file content
+                for index, line in enumerate(tfvar_content):
+                    match = re.search(k+r'\s?=.*', line)
+                    if match:
+                        log.debug("Replace template %s with [%s = %s]", line, k, v)
+                        tfvar_content[index] = f"{k} = {v}\n"
+                        key_replace = True
+                # add the new key/value pair
+                if not key_replace:
+                    log.debug("[k:%s = v:%s] is not in the template, append it", k, v)
+                    tfvar_content.append(f"{k} = {v}\n")
+        log.debug("Result terraform.tfvars:\n%s", tfvar_content)
+        return tfvar_content

--- a/scripts/qesap/test/conftest.py
+++ b/scripts/qesap/test/conftest.py
@@ -4,6 +4,42 @@ import os
 
 import pytest
 
+
+@pytest.fixture()
+def config_data_sample():
+    """
+    Config data as if obtained from yaml file.
+    'variables' section must contains only one string, list and dict.
+    :return:
+    dict based data structure
+    """
+    def _callback(provider='pinocchio',
+                  az_region='westeurope',
+                  hana_ips=None,
+                  hana_disk_configuration=None):
+
+        # Default values
+        hana_ips = hana_ips if hana_ips else ['10.0.0.2', '10.0.0.3']
+        hana_disk_configuration = hana_disk_configuration if \
+            hana_disk_configuration else {'disk_type': 'hdd,hdd,hdd',  'disks_size': '64,64,64'}
+
+        # Config template
+        config = {'name': 'geppetto',
+                  'terraform': {
+                      'provider': provider,
+                      'variables': {
+                          'az_region': az_region,
+                          'hana_ips': hana_ips,
+                          'hana_data_disks_configuration': hana_disk_configuration
+                      }
+                  },
+                  'ansible': {'hana_urls': ['SAPCAR_URL', 'SAP_HANA_URL', 'SAP_CLIENT_SAR_URL']}
+                  }
+
+        return config
+    return _callback
+
+
 @pytest.fixture
 def config_yaml_sample():
     """
@@ -21,7 +57,11 @@ terraform:
       disk_type: "hdd,hdd,hdd"
       disks_size: "64,64,64"
 ansible:
-    hana_urls: onlyone"""
+  hana_urls:
+    - SAPCAR_URL
+    - SAP_HANA_URL
+    - SAP_CLIENT_SAR_URL"""
+
     def _callback(provider=None):
         internal_prov = provider
         if internal_prov is None:

--- a/scripts/qesap/test/unit/test_qesap_configure.py
+++ b/scripts/qesap/test/unit/test_qesap_configure.py
@@ -156,22 +156,14 @@ def test_configure_create_ansible_vars(configure_helper, config_yaml_sample):
     assert os.path.isfile(hana_vars)
 
 
-def test_configure_ansible_vars_content(configure_helper):
+def test_configure_ansible_vars_content(configure_helper, config_yaml_sample):
     """
     Test that 'configure' write an azure_hana_media.yaml with
     expected content
     """
     provider = 'pinocchio'
-    conf = f"""---
-terraform:
-  provider: {provider}
-ansible:
-  hana_urls:
-    - SAPCAR_URL
-    - SAP_HANA_URL
-    - SAP_CLIENT_SAR_URL"""
+    conf = config_yaml_sample(provider)
     args, _, hana_vars = configure_helper(provider, conf, [])
-
     main(args)
 
     with open(hana_vars, 'r') as file:

--- a/scripts/qesap/test/unit/test_qesap_lib_config.py
+++ b/scripts/qesap/test/unit/test_qesap_lib_config.py
@@ -1,0 +1,46 @@
+import pytest
+import re
+from lib.config import yaml_to_tfvars
+
+
+def test_tfvars_yaml_string(config_data_sample):
+    """
+    Check string based variable format tfvars output
+    :param config_data_sample:
+    input similar to yaml config file
+    :return:
+    true or false
+    """
+    az_region = 'westeurope'
+    expected_result = rf'az_region = \"{az_region}\"'
+    actual_result = yaml_to_tfvars(config_data_sample())
+    assert re.search(expected_result, actual_result)
+
+
+def test_tfvars_yaml_list(config_data_sample):
+    """
+    Check list based variable format tfvars output
+    :param config_data_sample:
+    input similar to yaml config file
+    :return:
+    true or false
+    """
+    hana_ips = ['10.0.0.2', '10.0.0.3']
+    expected_result = r'hana_ips = \["10.0.0.2", "10.0.0.3"]'
+    actual_result = yaml_to_tfvars(config_data_sample(hana_ips))
+    assert re.search(expected_result, actual_result)
+
+
+def test_tfvars_yaml_dict(config_data_sample):
+    """
+    Check dict based variable format tfvars output
+    :param config_data_sample:
+    :return:
+    """
+    hana_disk_configuration = {'disk_type': 'hdd,hdd,hdd', 'disks_size': '64,64,64'}
+
+    expected_result = r'hana_data_disks_configuration = {' \
+                      r'(\s|\t)+disk_type = "hdd,hdd,hdd"' \
+                      r'(\s|\t)+disks_size = "64,64,64"'
+    actual_result = yaml_to_tfvars(config_data_sample(hana_disk_configuration))
+    assert re.search(expected_result, actual_result)


### PR DESCRIPTION
This PR adds function to generate tfvars file only from yaml config 
values without the need of tfvars template file. It also includes 
pytests with fixes.