### PR TITLE
Switch jmespath version to 0.9.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ansible==4.10.0
 ansible-core==2.11.12
 awscli==1.19.48
-jmespath==1.0.1
+jmespath==0.9.3


### PR DESCRIPTION
This PR lowers jmespath version to 0.9.3 in requirements.txt.
It is the highest working version on OpenQA qcow image.

VR:
https://mordor.suse.cz/tests/4209#step/hana_sr_deployment/137
* test failed because of cluster test at the end of deployment. 

Seems like the jmespath is already included in qcow:
Requirement already satisfied: jmespath==0.9.3 in /usr/lib/python3.6/site-packages (from -r /root/qe_sap_deployment/requirements.txt (line 4)) (0.9.3)