### PR TITLE
Added wrapper to add weak idempotency to non-idempotent roles

### DIFF
--- a/ansible/playbooks/sap-hana-install.yaml
+++ b/ansible/playbooks/sap-hana-install.yaml
@@ -6,5 +6,40 @@
   pre_tasks:
     - name: Source hana install variables
       include_vars: ./vars/sap-hana-install_vars.yaml
-  roles:
-    - { role: ../roles/sap_hana_install }
+  vars:
+    install_path: /var/lib/qedep
+    install_file: "{{ install_path }}/{{ sap_hana_install_sid }}_install"
+  
+  tasks:
+
+  - name: Check for previous installation of HANA SID
+    ansible.builtin.file:
+      path: "{{ install_file }}"
+      state: file
+    check_mode: yes
+    register: sid_file_check
+    changed_when: no
+    failed_when: no
+
+  - name: Set install facts
+    ansible.builtin.set_fact:
+      hana_installed: "{{ sid_file_check.state }}"
+  
+  - name: Execute hana install role
+    ansible.builtin.include_role:
+      name: ../roles/sap_hana_install 
+    when: hana_installed == 'absent'
+
+  - name: Write status file
+    ansible.builtin.file:
+      path: "{{ item.path }}"
+      state: "{{ item.state }}"
+      owner: root
+      group: root
+      mode: '0700'
+    with_items:
+     - { 'path': "{{ install_path }}",     'state': 'directory' }
+     - { 'path': "{{ install_file }}", 'state': 'touch' }
+    when: hana_installed == 'absent'
+  
+    

--- a/ansible/playbooks/sap-hana-system-replication.yaml
+++ b/ansible/playbooks/sap-hana-system-replication.yaml
@@ -6,5 +6,39 @@
   pre_tasks:
     - name: Include hana system replication variables
       include_vars: ./vars/hana_hsr_parameters.yaml
-  roles:
-    - { role: ../roles/sap_ha_install_hana_hsr }
+      
+  vars:
+    install_path: /var/lib/qedep
+    hsr_cnf_file: "{{ install_path }}/{{ sap_hana_sid }}_hsr_configured"
+
+  tasks:
+
+  - name: Check for previous HSR configuration
+    ansible.builtin.file:
+      path: "{{ hsr_cnf_file }}"
+      state: file
+    check_mode: yes
+    register: hsr_file_check
+    changed_when: no
+    failed_when: no
+
+  - name: Set install facts
+    ansible.builtin.set_fact:
+      hsr_configured: "{{ hsr_file_check.state }}"
+
+  - name: Execute hana system replication role
+    ansible.builtin.include_role:
+      role: ../roles/sap_ha_install_hana_hsr
+    when: hsr_configured == 'absent'
+
+  - name: Write status file
+    ansible.builtin.file:
+      path: "{{ item.path }}"
+      state: "{{ item.state }}"
+      owner: root
+      group: root
+      mode: '0700'
+    with_items:
+     - { 'path': "{{ install_path }}",     'state': 'directory' }
+     - { 'path': "{{ hsr_cnf_file }}", 'state': 'touch' }
+    when: hsr_configured == 'absent'


### PR DESCRIPTION
This PR allows the HANA install and HANA System Replication playbooks to be run several times without changing the system.

Now the HANA install playbook and the HANA System Replication playbook touch files in /var/lib/qedep when run.  If this file is found by the playbook, running the role is skipped.

This means that the role won't fail, but it is not currently perfect, and it will prevent some operations in the future.  For example, if a user wants to manually uninstall HANA and run the automation again, the action will fail unless they know to remove the files in /var/lib/qedep.