### PR TITLE
Update broken saptune package

### DIFF
--- a/ansible/playbooks/tasks/sapconf.yaml
+++ b/ansible/playbooks/tasks/sapconf.yaml
@@ -8,6 +8,12 @@
     saptune_inst: "{{ ansible_facts.packages.saptune[0].version | default('not-installed') }}"
     tuned_inst: "{{ ansible_facts.packages.tuned[0].version | default('not-installed') }}"
 
+- name: Ensure saptune is on latest version. Fix for failing service check.
+  community.general.zypper:
+    name: saptune
+    state: latest
+  when: saptune_inst != 'not-installed'
+
 - name: Ensure saptune is stopped and disabled (if installed)
   ansible.builtin.systemd:
     name: saptune


### PR DESCRIPTION
Openqa test fails with missing saptune systemd service while package is installed.
Solution is to update package which will add systemd unit as well. Package is updated only if it already exists.

Details in ticket: https://github.com/SUSE/qe-sap-deployment/issues/64
VR:  https://mordor.suse.cz/tests/4396

Test continues past problematic part, fails later because another issue. 

