### PR TITLE
Fix outputs for Azure

### DIFF
--- a/terraform/azure/modules/hana_node/outputs.tf
+++ b/terraform/azure/modules/hana_node/outputs.tf
@@ -15,17 +15,17 @@ data "azurerm_network_interface" "hana" {
 }
 
 output "hana_ip" {
-  value = [data.azurerm_network_interface.hana.*.private_ip_address]
+  value = data.azurerm_network_interface.hana.*.private_ip_address
 }
 
 output "hana_public_ip" {
-  value = [data.azurerm_public_ip.hana.*.ip_address]
+  value = data.azurerm_public_ip.hana.*.ip_address
 }
 
 output "hana_name" {
-  value = [azurerm_virtual_machine.hana.*.name]
+  value = azurerm_virtual_machine.hana.*.name
 }
 
 output "hana_public_name" {
-  value = [data.azurerm_public_ip.hana.*.fqdn]
+  value = data.azurerm_public_ip.hana.*.fqdn
 }

--- a/terraform/azure/outputs.tf
+++ b/terraform/azure/outputs.tf
@@ -30,19 +30,19 @@ output "iscsisrv_public_name" {
 # Hana nodes
 
 output "hana_ip" {
-  value = module.hana_node.hana_ip
+  value = compact(module.hana_node.hana_ip)
 }
 
 output "hana_public_ip" {
-  value = module.hana_node.hana_public_ip
+  value = compact(module.hana_node.hana_public_ip)
 }
 
 output "hana_name" {
-  value = module.hana_node.hana_name
+  value = compact(module.hana_node.hana_name)
 }
 
 output "hana_public_name" {
-  value = module.hana_node.hana_public_name
+  value = compact(module.hana_node.hana_public_name)
 }
 
 # Monitoring
@@ -109,8 +109,8 @@ output "bastion_public_ip" {
 resource "local_file" "ansible_inventory" {
   content = templatefile("inventory.tmpl",
     {
-      hana-name           = module.hana_node.hana_name[0],
-      hana-pip            = module.hana_node.hana_public_ip[0],
+      hana-name           = module.hana_node.hana_name,
+      hana-pip            = module.hana_node.hana_public_ip,
       hana-major-version  = local.hana_major_version
       iscsi-name          = module.iscsi_server.iscsisrv_name,
       iscsi-pip           = module.iscsi_server.iscsisrv_public_ip,


### PR DESCRIPTION
Currently azure outputs for hana nodes (ip addr, hostnames ... ) are not compatible with openqa requirements.
Data is structured inside nested lists which is not expected by openqa.
This PR makes the output same as previous ha-sap-terraform-deployment project.

Failed test output:
https://mordor.suse.cz/tests/4640#step/hana_sr_deployment/235

VR:
https://mordor.suse.cz/tests/4653