### PR TITLE
Decrease ansible output verbosity

### DIFF
--- a/scripts/qesap/lib/cmds.py
+++ b/scripts/qesap/lib/cmds.py
@@ -258,7 +258,7 @@ def cmd_ansible(configure_data, base_project, dryrun, verbose, destroy=False):
         return Status("Missing inventory")
 
     ansible_common = [shutil.which('ansible-playbook')]
-    if verbose:
+    if 'verbosity' in configure_data['ansible'] and configure_data['ansible']['verbosity']:
         ansible_common.append('-vvvv')
 
     ansible_common.append('-i')

--- a/scripts/qesap/test/conftest.py
+++ b/scripts/qesap/test/conftest.py
@@ -150,17 +150,17 @@ def create_playbooks(playbooks_dir):
                 file.write("")
             playbook_filename_list.append(playbook_filename)
         return playbook_filename_list
-
     return _callback
 
 
 @pytest.fixture
 def ansible_config():
-    def _callback(provider, playbooks):
+    def _callback(provider, playbooks, verbosity=False):
         config_content = f"""---
 apiver: 2
 provider: {provider}
 ansible:
+    verbosity: {verbosity}
     hana_urls: somesome"""
 
         for seq in ['create', 'destroy']:

--- a/scripts/qesap/test/unit/test_qesap_ansible.py
+++ b/scripts/qesap/test/unit/test_qesap_ansible.py
@@ -44,9 +44,9 @@ def test_ansible_create(run, _, base_args, tmpdir, create_inventory, create_play
 
 @mock.patch('shutil.which', side_effect = [(ANSIBLEPB_EXE),(ANSIBLE_EXE)])
 @mock.patch("lib.process_manager.subprocess_run")
-def test_ansible_verbose(run, _, base_args, tmpdir, create_inventory, create_playbooks, ansible_config, mock_call_ansibleplaybook):
+def test_ansible_verbose_cmd(run, _, base_args, tmpdir, create_inventory, create_playbooks, ansible_config, mock_call_ansibleplaybook):
     """
-    run with -vvvv if qesap ansible --verbose
+    running - 'qesap ansible --verbose' should not trigger '-vvvv'.
     (probably not supported in qesap deploy/destroy)
     """
     provider = 'grilloparlante'
@@ -66,7 +66,7 @@ def test_ansible_verbose(run, _, base_args, tmpdir, create_inventory, create_pla
     playbook_list = create_playbooks(playbooks['create'])
     calls = []
     for playbook in playbook_list:
-        cmd = [ANSIBLEPB_EXE, '-vvvv', '-i', inventory, playbook]
+        cmd = [ANSIBLEPB_EXE, '-i', inventory, playbook]
         calls.append(mock_call_ansibleplaybook(cmd))
 
     assert main(args) == 0


### PR DESCRIPTION
This PR decreases default ansible output verbosity while using 
--verbose cmd option. Adds option "verbosity" into yaml config file, 
if value is "true" output verbosity is increased to "-vvvv" 

VR:
https://mordor.suse.cz/tests/5147#

```
🐧 [lpalovsky@toolbox qesap/] PYTHONPATH=. pytest test/unit/
============================================================== test session starts ===============================================================
platform linux -- Python 3.10.4, pytest-6.2.4, py-1.11.0, pluggy-0.13.1
rootdir: /var/home/lpalovsky/GIT/qe-sap-deployment/scripts/qesap
collected 64 items                                                                                                                               

test/unit/test_qesap_ansible.py ............                                                                                               [ 18%]
test/unit/test_qesap_cli.py .............                                                                                                  [ 39%]
test/unit/test_qesap_configure.py ...............                                                                                          [ 62%]
test/unit/test_qesap_deploy.py .                                                                                                           [ 64%]
test/unit/test_qesap_destroy.py .                                                                                                          [ 65%]
test/unit/test_qesap_lib_config.py ...                                                                                                     [ 70%]
test/unit/test_qesap_terraform.py ..........s..                                                                                            [ 90%]
test/unit/test_subprocess_run.py ......                                                                                                    [100%]

========================================================= 63 passed, 1 skipped in 0.31s ==========================================================

```