### PR TITLE
Fix logging format and don't separate stderr from stdout

### DIFF
--- a/scripts/qesap/qesap.py
+++ b/scripts/qesap/qesap.py
@@ -20,7 +20,7 @@ DESCRIBE = '''qe-sap-deployment helper script'''
 
 
 # Logging config
-logging.basicConfig()
+logging.basicConfig(format="%(levelname)-8s %(message)s")
 log = logging.getLogger('QESAPDEP')
 
 
@@ -66,18 +66,16 @@ def subprocess_run(cmd, env=None):
     if env is not None:
         log.info("with env %s", env)
 
-    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False, env=env)
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False, env=env)
     if proc.returncode != 0:
-        log.error("Error %d in %s", proc.returncode, ' '.join(cmd[0:1]))
-        for err_line in proc.stderr.decode('UTF-8').splitlines():
-            log.error("STDERR:          %s", err_line)
-        for err_line in proc.stdout.decode('UTF-8').splitlines():
-            log.error("STDOUT:          %s", err_line)
+        log.error("ERROR %d in %s", proc.returncode, ' '.join(cmd[0:1]))
+        for line in proc.stdout.decode('UTF-8').splitlines():
+            log.error("OUTPUT:          %s", line)
         return (proc.returncode, [])
     stdout = [line.decode("utf-8") for line in proc.stdout.splitlines()]
 
     for line in stdout:
-        log.debug('Stdout:%s', line)
+        log.debug('OUTPUT: %s', line)
     return (0, stdout)
 
 

--- a/scripts/qesap/test/unit/test_subprocess_run.py
+++ b/scripts/qesap/test/unit/test_subprocess_run.py
@@ -37,12 +37,12 @@ def test_multilines():
 
 def test_stderr():
     '''
-    Run subprocess_run redirect the stderr only on the log
+    Run subprocess_run redirect the stderr to stdout
     '''
     test_text = '"Banana"'
     exit_code, stdout_list = subprocess_run(['logger', '-s', test_text])
     assert exit_code == 0
-    assert stdout_list == []
+    assert stdout_list != []
 
 
 def test_err():


### PR DESCRIPTION
This PR:
  - Redirects stderr to stdout. When separating stderr from stdout we can miss the context of the error lines.  We should show it like it is.
  - Fix logging format so it's more pleasant.
  
VR: http://1b124.qa.suse.de/tests/270