### PR TITLE
Use community.general.zypper instead ansible.builtin.command

### DIFF
--- a/ansible/playbooks/sap-hana-preconfigure.yaml
+++ b/ansible/playbooks/sap-hana-preconfigure.yaml
@@ -19,9 +19,11 @@
         state: present
       when: scale_out | bool
 
-    # https://jira.suse.com/browse/TEAM-6887
     - name: Update old SAPHanaSR on SLE 15-SP1
-      ansible.builtin.command: zypper -n in --replacefiles 'SAPHanaSR=0.154.0'
+      community.general.zypper:
+        name: SAPHanaSR=0.154.0
+        state: present
+        replacefiles: true
       when:
         - ansible_facts['distribution_version'] == '15.1'
       register: result

--- a/ansible/playbooks/tasks/sapconf.yaml
+++ b/ansible/playbooks/tasks/sapconf.yaml
@@ -35,8 +35,9 @@
   when: tuned_inst != 'not-installed' and ansible_facts['distribution_major_version'] != "12"
 
 - name: Ensure sapconf is installed
-  # using command instead of zypper module as workaround
-  ansible.builtin.command: zypper -n in --replacefiles 'sapconf=5.0.3'
+  community.general.zypper:
+    name: sapconf=5.0.3
+    state: present
   register: result
   until: result is succeeded
   retries: 3


### PR DESCRIPTION
Issue with zypper module was fixed in newer ansible version c98978a6160fffbbea86cf5115f2e44e4540514b

https://jira.suse.com/browse/TEAM-6978

VRs:
https://openqaworker15.qa.suse.cz/tests/100264 12sp5
https://openqaworker15.qa.suse.cz/tests/100223 15sp1
https://openqaworker15.qa.suse.cz/tests/100226 15sp3
https://openqaworker15.qa.suse.cz/tests/100239 15sp4