### PR TITLE
Add --profile to ansible

### DIFF
--- a/scripts/qesap/lib/cmds.py
+++ b/scripts/qesap/lib/cmds.py
@@ -226,7 +226,7 @@ def cmd_terraform(configure_data, base_project, dryrun, destroy=False):
     return Status('ok')
 
 
-def cmd_ansible(configure_data, base_project, dryrun, verbose, destroy=False):
+def cmd_ansible(configure_data, base_project, dryrun, verbose, destroy=False, profile=False):
     """ Main executor for the deploy sub-command
 
     Args:
@@ -234,6 +234,9 @@ def cmd_ansible(configure_data, base_project, dryrun, verbose, destroy=False):
         base_project (str): base project path where to
                       look for the Ansible files
         dryrun (bool): enable dryrun execution mode
+        verbose (bool): enable more verbosity
+        destroy (bool): select the playbook list
+        profile (bool): enable task profile
 
     Returns:
         Status: execution result, 0 means OK. It is mind to be used as script exit code
@@ -274,6 +277,8 @@ def cmd_ansible(configure_data, base_project, dryrun, verbose, destroy=False):
     ansible_cmd_seq.append({'cmd': ssh_share})
     original_env = dict(os.environ)
     original_env['ANSIBLE_PIPELINING'] = 'True'
+    if profile:
+        original_env['ANSIBLE_CALLBACK_WHITELIST'] = 'ansible.posix.profile_tasks'
 
     for playbook in configure_data['ansible'][sequence]:
         ansible_cmd = ansible_common.copy()

--- a/scripts/qesap/qesap.py
+++ b/scripts/qesap/qesap.py
@@ -108,12 +108,16 @@ def cli(command_line=None):
     parser_terraform.add_argument('-d',
                                   '--destroy',
                                   action='store_true',
-                                  help='Only destroy terraform setup, without executing ansible')
-    parser_ansible = subparsers.add_parser('ansible', help="Only run the Ansible part of the deployment")
+                                  help='Call terraform destroy')
+    parser_ansible = subparsers.add_parser('ansible', help="Run the Ansible part of the deployment")
     parser_ansible.add_argument('-d',
                                 '--destroy',
                                 action='store_true',
-                                help='Only destroy terraform setup, without executing ansible')
+                                help='Play ansible deregister playoooks')
+
+    parser_ansible.add_argument('--profile',
+                                action='store_true',
+                                help='Run Ansible with ansible.posix.profile_tasks')
 
     parsed_args = parser.parse_args(command_line)
     return parsed_args
@@ -171,7 +175,8 @@ def main(command_line=None):  # pylint: disable=too-many-return-statements
             parsed_args.basedir,
             parsed_args.dryrun,
             parsed_args.verbose,
-            destroy=parsed_args.destroy
+            destroy=parsed_args.destroy,
+            profile=parsed_args.profile
         )
     else:
         res = Status(f"Unknown command:{parsed_args.command}")

--- a/scripts/qesap/test/unit/test_qesap_cli.py
+++ b/scripts/qesap/test/unit/test_qesap_cli.py
@@ -156,3 +156,23 @@ def test_cli_ansible(base_args):
     args = base_args()
     args.append('ansible')
     cli(args)
+
+
+def test_cli_ansible_destroy(base_args):
+    '''
+    Test ansible with -d to run destroy mode
+    '''
+    args = base_args()
+    args.append('ansible')
+    args.append('-d')
+    cli(args)
+
+
+def test_cli_ansible_profile(base_args):
+    '''
+    Test ansible with --profile mode
+    '''
+    args = base_args()
+    args.append('ansible')
+    args.append('--profile')
+    cli(args)


### PR DESCRIPTION
Add a command option to enable the task profile during the Ansible execution. It is obtained by setting ANSIBLE_CALLBACK_WHITELIST=ansible.posix.profile_tasks as environment variable.

For [TEAM-6829](https://jira.suse.com/browse/TEAM-6829) debug