### PR TITLE
Update python in CI/CD

### DIFF
--- a/.github/workflows/gluescript.yml
+++ b/.github/workflows/gluescript.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-20.4]
-        python-version: ['3.6.15', '3.8']
+        python-version: ['3.6.15', '3.9.15']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/gluescript.yml
+++ b/.github/workflows/gluescript.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [ubuntu-latest]
+        platform: [ubuntu-20.4]
         python-version: ['3.6.15', '3.8']
 
     steps:

--- a/.github/workflows/gluescript.yml
+++ b/.github/workflows/gluescript.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [ubuntu-20.4]
+        platform: [ubuntu-20.04]
         python-version: ['3.6.15', '3.9.15']
 
     steps:

--- a/.github/workflows/gluescript.yml
+++ b/.github/workflows/gluescript.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        python-version: ['3.6', '3.8']
+        python-version: ['3.6.15', '3.8']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
The CI/CD of this project is using `ubuntu-latest` that has been recently promoted to 22.04 
https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/

But python 3.6 is not supported on this platform:
https://github.com/SUSE/qe-sap-deployment/actions/runs/3803551452/jobs/6470034547

```
Error: The version '3.6' with architecture 'x64' was not found for Ubuntu 22.04.
```

Fix Ubuntu to 20.4 and update python 3.6 to 3.6.15. Also update 3.8 to 3.9.15 to reflect what is used in openQA after https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/15895