### PR TITLE
Use new name of reboot handler

### DIFF
--- a/ansible/playbooks/tasks/sapconf.yaml
+++ b/ansible/playbooks/tasks/sapconf.yaml
@@ -73,7 +73,7 @@
     block: |
       [Login]
       UserTasksMax=infinity
-  notify: reboot
+  notify: Reboot
 
 - name: Ensure Governor is set to Performance
   ansible.builtin.lineinfile:
@@ -83,7 +83,7 @@
   with_items:
     - {'regexp': '^GOVERNOR=', 'line': 'GOVERNOR=performance'}
     - {'regexp': '^PERF_BIAS=', 'line': 'PERF_BIAS=performance'}
-  notify: reboot
+  notify: Reboot
 
 # Usually handled by SAP tune and only really an issue on Azure
 - name: Turn off TCP timestamps


### PR DESCRIPTION
Fix a bug introduced by https://github.com/SUSE/qe-sap-deployment/pull/112

Ticket:  https://jira.suse.com/browse/TEAM-7187
VR: http://openqaworker15.qa.suse.cz/tests/122811

Test is failing but later and for another issue. Fix effect is in file http://openqaworker15.qa.suse.cz/tests/122811/logfile?filename=deploy-qesap_exec_ansible.log.txt at 

```
DEBUG    OUTPUT: TASK [Configure UserTasksMax] **************************************************
...
DEBUG    OUTPUT: NOTIFIED HANDLER Reboot for vmhana02
```