### PR TITLE
Remove os regexp mechanism to select remote python interpreter for Azure

### DIFF
--- a/terraform/azure/inventory.tmpl
+++ b/terraform/azure/inventory.tmpl
@@ -5,7 +5,7 @@ all:
 %{ for index, value in hana-pip ~}
         ${hana-name[index]}:
           ansible_host: ${value}
-          %{ if hana-major-version == "12" }ansible_python_interpreter: /usr/bin/python2.7%{ else }ansible_python_interpreter: /usr/bin/python3 %{ endif }
+          ansible_python_interpreter: ${hana-remote-python}
 %{ endfor ~}
 %{ if iscsi-enabled }
     iscsi:
@@ -13,7 +13,7 @@ all:
 %{ for index, value in iscsi-pip ~}
         ${iscsi-name[index]}:
           ansible_host: ${value}
-          %{ if iscsi-major-version == "12" }ansible_python_interpreter: /usr/bin/python2.7%{ else }ansible_python_interpreter: /usr/bin/python3%{ endif }
+          ansible_python_interpreter: ${iscsi-remote-python}
 %{ endfor ~}
 %{ endif }
   hosts: null

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -51,16 +51,6 @@ locals {
   netweaver_os_image  = var.netweaver_os_image != "" ? var.netweaver_os_image : var.os_image
   bastion_os_image    = var.bastion_os_image != "" ? var.bastion_os_image : var.os_image
 
-  # For SLES 12 we need to instruct ansible to use python2.7 and for SLES 15 it's python3.
-  # These locals calculate the major version of the os from the OS image but assumes the OS image format is consistent
-  # The regex is only used if the var.x_os_major is not set, so if the regex is failing, the user can manually set their major OS.
-  hana_major_version       = var.hana_os_major_version != "" ? var.hana_os_major_version : regex("[a-zA-Z]+:[a-zA-Z]+-[a-zA-Z]+-([0-9]+)-", local.hana_os_image)[0]
-  iscsi_major_version      = var.iscsi_os_major_version != "" ? var.iscsi_os_major_version : regex("[a-zA-Z]+:[a-zA-Z]+-[a-zA-Z]+-([0-9]+)-", local.iscsi_os_image)[0]
-  monitoring_major_version = var.monitoring_os_major_version != "" ? var.monitoring_os_major_version : regex("[a-zA-Z]+:[a-zA-Z]+-[a-zA-Z]+-([0-9]+)-", local.monitoring_os_image)[0]
-  drbd_major_version       = var.drdb_os_major_version != "" ? var.drdb_os_major_version : regex("[a-zA-Z]+:[a-zA-Z]+-[a-zA-Z]+-([0-9]+)-", local.drbd_os_image)[0]
-  netweaver_major_version  = var.netweaver_os_major_version != "" ? var.netweaver_os_major_version : regex("[a-zA-Z]+:[a-zA-Z]+-[a-zA-Z]+-([0-9]+)-", local.netweaver_os_image)[0]
-  bastion_major_version    = var.bastion_os_major_version != "" ? var.bastion_os_major_version : regex("[a-zA-Z]+:[a-zA-Z]+-[a-zA-Z]+-([0-9]+)-", local.bastion_os_image)[0]
-
   # Netweaver password checking
   # If Netweaver is not enabled, a dummy password is passed to pass the variable validation and not require
   # a password in this case

--- a/terraform/azure/outputs.tf
+++ b/terraform/azure/outputs.tf
@@ -4,13 +4,6 @@
 # - Private node name
 # - Public node name
 
-# iSCSI server
-output "hana_os_major_verion" {
-  description = "The major version of the HANA OS"
-  value       = local.hana_major_version
-}
-
-
 output "iscsisrv_ip" {
   value = module.iscsi_server.iscsisrv_ip
 }
@@ -111,11 +104,11 @@ resource "local_file" "ansible_inventory" {
     {
       hana-name           = module.hana_node.hana_name,
       hana-pip            = module.hana_node.hana_public_ip,
-      hana-major-version  = local.hana_major_version
+      hana-remote-python  = var.hana_remote_python
       iscsi-name          = module.iscsi_server.iscsisrv_name,
       iscsi-pip           = module.iscsi_server.iscsisrv_public_ip,
-      iscsi-major-version = local.iscsi_major_version
       iscsi-enabled       = local.iscsi_enabled
+      iscsi-remote-python = var.iscsi_remote_python
   })
   filename = "inventory.yaml"
 }

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -1018,3 +1018,15 @@ variable "hana_scale_out_anf_quota_shared" {
   default     = "2000"
 }
 
+variable "hana_remote_python" {
+  description = "Remote python interpreter that Ansible will use on HANA nodes"
+  type        = string
+  default     = "/usr/bin/python3"
+}
+
+variable "iscsi_remote_python" {
+  description = "Remote python interpreter that Ansible will use on iscsi nodes"
+  type        = string
+  default     = "/usr/bin/python3"
+}
+


### PR DESCRIPTION
Removed regexp and major os version setting
Add new variable that user can use to specify a python interpreter other then python3
Change the inventory template to use this new variable

:warning:  it require a config.yaml change if deploying with SLES12 images (or images that does not have by default python3 > 3.7 installed) Here an example about how to manage it in the test code https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/16406

Ticket: TEAM-6956
VR:  
  SLES15 http://openqaworker15.qa.suse.cz/tests/128835#
  SLES12 with custom python configured  http://openqaworker15.qa.suse.cz/tests/128833#