### PR TITLE
Fix deregister output handling

### DIFF
--- a/ansible/playbooks/deregister.yaml
+++ b/ansible/playbooks/deregister.yaml
@@ -34,12 +34,12 @@
 
     - name: Append delete list
       ansible.builtin.set_fact:
-        files_to_delete: "{{ files_to_delete + ['/etc/SUSEConnect'] }}"
+        files_to_delete: "{{ files_to_delete.files | map(attribute='path') | list + ['/etc/SUSEConnect'] }}"
       when: rcg.rc != 0
 
     - name: File Cleanup
       ansible.builtin.file:
         state: absent
-        path: "{{ item.path }}"
+        path: "{{ item }}"
       with_items: "{{ files_to_delete }}"
       when: rcg.rc != 0


### PR DESCRIPTION
There was a mistake in the handling of files in the last tasks of `deregister.yml` ansible playbook, leading to the constant failure of the `destroy` module (see http://openqaworker15.qa.suse.cz/tests/126742#next_previous)

_Note: In some cases the `destroy` module doesn't fail, but it's because the failing tasks are skipped entirely due to the condition `when: rcg.rc != 0` (see https://openqaworker15.qa.suse.cz/tests/122196#step/destroy/7)_

This is addressed with this pr.

- Relevant ticket: https://jira.suse.com/browse/TEAM-7279
- Verification Run: http://openqaworker15.qa.suse.cz/tests/129079