### PR TITLE
Move --workspace as a sub argument to terraform command

### DIFF
--- a/scripts/qesap/qesap.py
+++ b/scripts/qesap/qesap.py
@@ -77,10 +77,6 @@ def cli(command_line=None):
     parser.add_argument('--dryrun', action='store_true', help="Dry run execution mode")
 
     parser.add_argument(
-        '-w', '--workspace', dest='workspace', default='default',
-        help="""Workspace to use in terraform commands. Defaults to 'default'""")
-
-    parser.add_argument(
         '-c', '--config-file', dest='configfile',
         type=is_yaml,
         required=True,
@@ -113,6 +109,11 @@ def cli(command_line=None):
                                   '--destroy',
                                   action='store_true',
                                   help='Call terraform destroy')
+    parser_terraform.add_argument('-w',
+                                  '--workspace',
+                                  dest='workspace',
+                                  default='default',
+                                  help="""Workspace to use in terraform commands. Defaults to 'default'""")
     parser_ansible = subparsers.add_parser('ansible', help="Run the Ansible part of the deployment")
     parser_ansible.add_argument('-d',
                                 '--destroy',
@@ -167,7 +168,7 @@ def main(command_line=None):  # pylint: disable=too-many-return-statements
             parsed_args.configfile,
             parsed_args.basedir,
             parsed_args.dryrun,
-            parsed_args.workspace,
+            workspace=parsed_args.workspace,
             destroy=parsed_args.destroy
         )
         if res != 0:


### PR DESCRIPTION
Move `--workspace` as a sub argument to terraform command.

This is a followup to #122 

Verification Runs: [HanaSR Regression Test-15-SP3@Azure](https://openqaworker15.qa.suse.cz/tests/129438), [saptune test-15-SP4@Azure](http://openqaworker15.qa.suse.cz/tests/129437), [saptune test-12-SP4@EC2](http://openqaworker15.qa.suse.cz/tests/129439)