### PR TITLE
Introduce os_image_uri Terraform variable in Azure

### DIFF
--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -50,6 +50,12 @@ locals {
   drbd_os_image       = var.drbd_os_image != "" ? var.drbd_os_image : var.os_image
   netweaver_os_image  = var.netweaver_os_image != "" ? var.netweaver_os_image : var.os_image
 
+  hana_os_image_uri       = var.sles4sap_uri != "" ? var.sles4sap_uri : var.os_image_uri
+  iscsi_os_image_uri      = var.iscsi_srv_uri != "" ? var.iscsi_srv_uri : var.os_image_uri
+  monitoring_os_image_uri = var.monitoring_uri != "" ? var.monitoring_uri : var.os_image_uri
+  drbd_os_image_uri       = var.drbd_image_uri != "" ? var.drbd_image_uri : var.os_image_uri
+  netweaver_os_image_uri  = var.netweaver_image_uri != "" ? var.netweaver_image_uri : var.os_image_uri
+
   # Netweaver password checking
   # If Netweaver is not enabled, a dummy password is passed to pass the variable validation and not require
   # a password in this case
@@ -139,7 +145,7 @@ module "drbd_node" {
   az_region           = var.az_region
   drbd_count          = var.drbd_enabled == true ? 2 : 0
   vm_size             = var.drbd_vm_size
-  drbd_image_uri      = var.drbd_image_uri
+  drbd_image_uri      = local.drbd_os_image_uri
   os_image            = local.drbd_os_image
   resource_group_name = local.resource_group_name
   network_subnet_id   = local.subnet_id
@@ -171,7 +177,7 @@ module "netweaver_node" {
   data_disk_caching           = var.netweaver_data_disk_caching
   data_disk_size              = var.netweaver_data_disk_size
   data_disk_type              = var.netweaver_data_disk_type
-  netweaver_image_uri         = var.netweaver_image_uri
+  netweaver_image_uri         = local.netweaver_os_image_uri
   os_image                    = local.netweaver_os_image
   resource_group_name         = local.resource_group_name
   network_subnet_id           = local.subnet_id
@@ -209,7 +215,7 @@ module "hana_node" {
   network_subnet_netapp_id      = local.subnet_netapp_id
   storage_account               = azurerm_storage_account.mytfstorageacc.primary_blob_endpoint
   enable_accelerated_networking = var.hana_enable_accelerated_networking
-  sles4sap_uri                  = var.sles4sap_uri
+  sles4sap_uri                  = local.hana_os_image_uri
   hana_instance_number          = var.hana_instance_number
   hana_data_disks_configuration = var.hana_data_disks_configuration
   os_image                      = local.hana_os_image
@@ -244,7 +250,7 @@ module "monitoring" {
   resource_group_name = local.resource_group_name
   network_subnet_id   = local.subnet_id
   storage_account     = azurerm_storage_account.mytfstorageacc.primary_blob_endpoint
-  monitoring_uri      = var.monitoring_uri
+  monitoring_uri      = local.monitoring_os_image_uri
   os_image            = local.monitoring_os_image
   monitoring_srv_ip   = local.monitoring_ip
 }
@@ -261,7 +267,7 @@ module "iscsi_server" {
   resource_group_name = local.resource_group_name
   network_subnet_id   = local.subnet_id
   storage_account     = azurerm_storage_account.mytfstorageacc.primary_blob_endpoint
-  iscsi_srv_uri       = var.iscsi_srv_uri
+  iscsi_srv_uri       = local.iscsi_os_image_uri
   os_image            = local.iscsi_os_image
   host_ips            = local.iscsi_ips
   lun_count           = var.iscsi_lun_count

--- a/terraform/azure/modules/bastion/main.tf
+++ b/terraform/azure/modules/bastion/main.tf
@@ -98,6 +98,7 @@ resource "azurerm_public_ip" "bastion" {
 }
 
 module "os_image_reference" {
+  count    = 0
   source   = "../../modules/os_image_reference"
   os_image = var.os_image
 }

--- a/terraform/azure/modules/drbd_node/main.tf
+++ b/terraform/azure/modules/drbd_node/main.tf
@@ -166,10 +166,10 @@ resource "azurerm_image" "drbd-image" {
 }
 
 # drbd instances
-
 module "os_image_reference" {
-  source   = "../../modules/os_image_reference"
-  os_image = var.os_image
+  source           = "../../modules/os_image_reference"
+  os_image         = var.os_image
+  os_image_srv_uri = var.drbd_image_uri != ""
 }
 
 resource "azurerm_virtual_machine" "drbd" {

--- a/terraform/azure/modules/hana_node/main.tf
+++ b/terraform/azure/modules/hana_node/main.tf
@@ -351,10 +351,10 @@ resource "azurerm_netapp_volume" "hana-netapp-volume-shared" {
 
 
 # hana instances
-
 module "os_image_reference" {
-  source   = "../../modules/os_image_reference"
-  os_image = var.os_image
+  source           = "../../modules/os_image_reference"
+  os_image         = var.os_image
+  os_image_srv_uri = var.sles4sap_uri != ""
 }
 
 locals {

--- a/terraform/azure/modules/iscsi_server/main.tf
+++ b/terraform/azure/modules/iscsi_server/main.tf
@@ -59,10 +59,10 @@ resource "azurerm_image" "iscsi_srv" {
 }
 
 # iSCSI server VM
-
 module "os_image_reference" {
-  source   = "../../modules/os_image_reference"
-  os_image = var.os_image
+  source           = "../../modules/os_image_reference"
+  os_image         = var.os_image
+  os_image_srv_uri = var.iscsi_srv_uri != ""
 }
 
 resource "azurerm_virtual_machine" "iscsisrv" {

--- a/terraform/azure/modules/majority_maker_node/main.tf
+++ b/terraform/azure/modules/majority_maker_node/main.tf
@@ -60,8 +60,9 @@ resource "azurerm_image" "sles4sap" {
 }
 
 module "os_image_reference" {
-  source   = "../../modules/os_image_reference"
-  os_image = var.os_image
+  source           = "../../modules/os_image_reference"
+  os_image         = var.os_image
+  os_image_srv_uri = var.sles4sap_uri != ""
 }
 
 resource "azurerm_virtual_machine" "majority_maker" {

--- a/terraform/azure/modules/monitoring/main.tf
+++ b/terraform/azure/modules/monitoring/main.tf
@@ -59,10 +59,10 @@ resource "azurerm_image" "monitoring" {
 }
 
 # monitoring VM
-
 module "os_image_reference" {
-  source   = "../../modules/os_image_reference"
-  os_image = var.os_image
+  source           = "../../modules/os_image_reference"
+  os_image         = var.os_image
+  os_image_srv_uri = var.monitoring_uri != ""
 }
 
 resource "azurerm_virtual_machine" "monitoring" {

--- a/terraform/azure/modules/netweaver_node/main.tf
+++ b/terraform/azure/modules/netweaver_node/main.tf
@@ -339,8 +339,9 @@ resource "azurerm_virtual_machine_data_disk_attachment" "app_server_disk" {
 # netweaver instances
 
 module "os_image_reference" {
-  source   = "../../modules/os_image_reference"
-  os_image = var.os_image
+  source           = "../../modules/os_image_reference"
+  os_image         = var.os_image
+  os_image_srv_uri = var.netweaver_image_uri != ""
 }
 
 resource "azurerm_virtual_machine" "netweaver" {

--- a/terraform/azure/modules/os_image_reference/outputs.tf
+++ b/terraform/azure/modules/os_image_reference/outputs.tf
@@ -7,6 +7,7 @@
 #module "os_image" {
 #  source   = "../../modules/os_image_reference"
 #  os_image = var.os_image
+#  os_image_srv_uri = var.image_uri != ""
 #}
 #
 #storage_image_reference {
@@ -17,11 +18,12 @@
 #}
 
 locals {
-  data      = split(":", var.os_image)
-  publisher = local.data[0]
-  offer     = local.data[1]
-  sku       = local.data[2]
-  version   = local.data[3]
+  local_os_name = var.os_image_srv_uri ? ":::" : var.os_image
+  data          = split(":", local.local_os_name)
+  publisher     = local.data[0]
+  offer         = local.data[1]
+  sku           = local.data[2]
+  version       = local.data[3]
 }
 
 output "publisher" {

--- a/terraform/azure/modules/os_image_reference/variables.tf
+++ b/terraform/azure/modules/os_image_reference/variables.tf
@@ -2,3 +2,10 @@ variable "os_image" {
   description = "sles4sap image used to create the this module machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
   type        = string
 }
+
+variable "os_image_srv_uri" {
+  description = "image_uri is used"
+  type        = bool
+  default     = false
+}
+

--- a/terraform/azure/terraform.tfvars.example
+++ b/terraform/azure/terraform.tfvars.example
@@ -78,17 +78,8 @@ public_key  = "/home/user/.ssh/id.rsa.key"
 # Otherwise use a specific SLE version:
 #ha_sap_deployment_repo = "https://download.opensuse.org/repositories/network:ha-clustering:sap-deployments:devel/SLE_15_SP3/"
 
-# Provisioning log level (error by default)
-#provisioning_log_level = "info"
-
-# Print colored output of the provisioning execution (true by default)
-#provisioning_output_colored = false
-
 # Enable pre deployment steps (disabled by default)
 #pre_deployment = true
-
-# To disable the provisioning process
-#provisioner = ""
 
 # Run provisioner execution in background
 #background = true
@@ -123,10 +114,6 @@ public_key  = "/home/user/.ssh/id.rsa.key"
 # Bastion SSH keys. If they are not set the public_key and private_key are used
 #bastion_public_key  = "/home/myuser/.ssh/id_rsa_bastion.pub"
 #bastion_private_key = "/home/myuser/.ssh/id_rsa_bastion"
-
-# Bastion machine os image. If it is not provided, the os_image variable data is used
-# BYOS example
-# bastion_os_image = "SUSE:sles-sap-15-sp3-byos:gen2:latest"
 
 #########################
 # HANA machines variables

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -154,6 +154,13 @@ variable "network_domain" {
 variable "os_image" {
   description = "Default OS image for all the machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: 'SUSE:sles-sap-15-sp3:gen2:latest'. This value is not used if the specific nodes os_image is set (e.g. hana_os_image)"
   type        = string
+  default     = ""
+}
+
+variable "os_image_uri" {
+  description = "Path to a custom azure image in a storage account. Used for all the machines."
+  type        = string
+  default     = ""
 }
 
 variable "timezone" {


### PR DESCRIPTION
Add a new Terraform variable `os_image_uri` that is similar to `os_image` but for custom images. It is on top of module specific _uri variables.
Change the code to allow to run an Azure deployment only with _uri variables and without any os_image