### PR TITLE
Terraform variable for Ansible python in gcp and aws

### DIFF
--- a/terraform/aws/inventory.tmpl
+++ b/terraform/aws/inventory.tmpl
@@ -5,7 +5,7 @@ all:
 %{ for index, value in hana-pip ~}
         ${hana_hostname}${format("%02d", index + 1)}:
           ansible_host: ${value}
-          %{ if hana-major-version == "12" }ansible_python_interpreter: /usr/bin/python2.7%{ else }ansible_python_interpreter: /usr/bin/python3 %{ endif }
+          ansible_python_interpreter: ${hana-remote-python}
 %{ endfor ~}
 %{ if iscsi-enabled }
     iscsi:
@@ -13,7 +13,7 @@ all:
 %{ for index, value in iscsi-pip ~}
         ${iscsi_hostname}${format("%02d", index + 1)}:
           ansible_host: ${value}
-          %{ if iscsi-major-version == "12" }ansible_python_interpreter: /usr/bin/python2.7%{ else }ansible_python_interpreter: /usr/bin/python3%{ endif }
+          ansible_python_interpreter: ${iscsi-remote-python}
 %{ endfor ~}
 %{ endif }
   hosts: null

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -56,16 +56,6 @@ locals {
   netweaver_os_image  = var.netweaver_os_image != "" ? var.netweaver_os_image : var.os_image
   netweaver_os_owner  = var.netweaver_os_owner != "" ? var.netweaver_os_owner : var.os_owner
 
-
-  # For SLES 12 we need to instruct ansible to use python2.7 and for SLES 15 it's python3.
-  # These locals calculate the major version of the os from the OS image but assumes the OS image format is consistent
-  # The regex is only used if the var.x_os_major is not set, so if the regex is failing, the user can manually set their major OS.
-  hana_major_version       = var.hana_os_major_version != "" ? var.hana_os_major_version : regex("-([0-9]+)-", local.hana_os_image)[0]
-  iscsi_major_version      = var.iscsi_os_major_version != "" ? var.iscsi_os_major_version : regex("-([0-9]+)-", local.iscsi_os_image)[0]
-  monitoring_major_version = var.monitoring_os_major_version != "" ? var.monitoring_os_major_version : regex("-([0-9]+)-", local.monitoring_os_image)[0]
-  drbd_major_version       = var.drdb_os_major_version != "" ? var.drdb_os_major_version : regex("-([0-9]+)-", local.drbd_os_image)[0]
-  netweaver_major_version  = var.netweaver_os_major_version != "" ? var.netweaver_os_major_version : regex("-([0-9]+)-", local.netweaver_os_image)[0]
-
   # Netweaver password checking
   # If Netweaver is not enabled, a dummy password is passed to pass the variable validation and not require
   # a password in this case

--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -100,11 +100,11 @@ resource "local_file" "ansible_inventory" {
     {
       hana_hostname       = var.hana_name,
       hana-pip            = module.hana_node.hana_public_ip,
-      hana-major-version  = local.hana_major_version,
+      hana-remote-python  = var.hana_remote_python,
       iscsi_hostname      = var.iscsi_name,
       iscsi-pip           = module.iscsi_server.iscsisrv_public_ip,
       iscsi-enabled       = local.iscsi_enabled,
-      iscsi-major-version = local.iscsi_major_version
+      iscsi-remote-python = var.iscsi_remote_python
   })
   filename = "inventory.yaml"
 }

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -797,36 +797,14 @@ variable "pre_deployment" {
   default     = false
 }
 
-#Different versions of python are used by ansible in SLES 12 and SLES 15.  The code will try and indetify the correct
-#version of SLES installed and select the appropriate version of the python interpretor for the inventory.yaml file
-#SLES 12 needs to user 2.7 and SLES 15 uses 3.0.
-#However, if the automatic selection proves problematic, the following values can be used as overrides
-variable "hana_os_major_version" {
-  description = "The major OS version of SLES for the HANA VMs.  If not set, this value will be computed.  Example: 15"
+variable "hana_remote_python" {
+  description = "Remote python interpreter that Ansible will use on HANA nodes"
   type        = string
-  default     = ""
+  default     = "/usr/bin/python3"
 }
 
-variable "iscsi_os_major_version" {
-  description = "The major OS version of SLES for the iscsi VMs.  If not set, this value will be computed.  Example: 15"
+variable "iscsi_remote_python" {
+  description = "Remote python interpreter that Ansible will use on iscsi nodes"
   type        = string
-  default     = ""
-}
-
-variable "monitoring_os_major_version" {
-  description = "The major OS version of SLES for the monitoring VMs.  If not set, this value will be computed.  Example: 15"
-  type        = string
-  default     = ""
-}
-
-variable "drdb_os_major_version" {
-  description = "The major OS version of SLES for the drdb VMs.  If not set, this value will be computed.  Example: 15"
-  type        = string
-  default     = ""
-}
-
-variable "netweaver_os_major_version" {
-  description = "The major OS version of SLES for the netweaver VMs.  If not set, this value will be computed.  Example: 15"
-  type        = string
-  default     = ""
+  default     = "/usr/bin/python3"
 }

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -76,7 +76,6 @@ module "common_variables" {
   public_key                          = var.public_key
   authorized_keys                     = var.authorized_keys
   authorized_user                     = var.admin_user
-  bastion_enabled                     = var.bastion_enabled
   background                          = var.background
   monitoring_enabled                  = var.monitoring_enabled
   monitoring_srv_ip                   = var.monitoring_enabled ? local.monitoring_ip : ""

--- a/terraform/azure/modules/bastion/main.tf
+++ b/terraform/azure/modules/bastion/main.tf
@@ -1,5 +1,5 @@
 locals {
-  bastion_count      = var.common_variables["bastion_enabled"] ? 1 : 0
+  bastion_count      = 0
   private_ip_address = cidrhost(var.snet_address_range, 5)
   hostname           = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }

--- a/terraform/azure/modules/drbd_node/main.tf
+++ b/terraform/azure/modules/drbd_node/main.tf
@@ -3,8 +3,7 @@
 # disclaimer: only supports a single NW installation
 
 locals {
-  bastion_enabled        = var.common_variables["bastion_enabled"]
-  provisioning_addresses = local.bastion_enabled ? data.azurerm_network_interface.drbd.*.private_ip_address : data.azurerm_public_ip.drbd.*.ip_address
+  provisioning_addresses = data.azurerm_public_ip.drbd.*.ip_address
   hostname               = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
@@ -114,7 +113,7 @@ resource "azurerm_lb_rule" "drbd-lb-udp-2049" {
 # drbd network configuration
 
 resource "azurerm_public_ip" "drbd" {
-  count                   = local.bastion_enabled ? 0 : var.drbd_count
+  count                   = var.drbd_count
   name                    = "pip-drbd${format("%02d", count.index + 1)}"
   location                = var.az_region
   resource_group_name     = var.resource_group_name
@@ -137,7 +136,7 @@ resource "azurerm_network_interface" "drbd" {
     subnet_id                     = var.network_subnet_id
     private_ip_address_allocation = "static"
     private_ip_address            = element(var.host_ips, count.index)
-    public_ip_address_id          = local.bastion_enabled ? null : element(azurerm_public_ip.drbd.*.id, count.index)
+    public_ip_address_id          = element(azurerm_public_ip.drbd.*.id, count.index)
   }
 
   tags = {

--- a/terraform/azure/modules/drbd_node/outputs.tf
+++ b/terraform/azure/modules/drbd_node/outputs.tf
@@ -1,5 +1,5 @@
 data "azurerm_public_ip" "drbd" {
-  count               = local.bastion_enabled ? 0 : var.drbd_count
+  count               = var.drbd_count
   name                = element(azurerm_public_ip.drbd.*.name, count.index)
   resource_group_name = element(azurerm_virtual_machine.drbd.*.resource_group_name, count.index)
   # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476

--- a/terraform/azure/modules/hana_node/outputs.tf
+++ b/terraform/azure/modules/hana_node/outputs.tf
@@ -1,5 +1,5 @@
 data "azurerm_public_ip" "hana" {
-  count               = local.bastion_enabled ? 0 : var.hana_count
+  count               = var.hana_count
   name                = element(azurerm_public_ip.hana.*.name, count.index)
   resource_group_name = element(azurerm_virtual_machine.hana.*.resource_group_name, count.index)
   # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476

--- a/terraform/azure/modules/iscsi_server/main.tf
+++ b/terraform/azure/modules/iscsi_server/main.tf
@@ -1,8 +1,7 @@
 # iscsi server network configuration
 
 locals {
-  bastion_enabled        = var.common_variables["bastion_enabled"]
-  provisioning_addresses = local.bastion_enabled ? data.azurerm_network_interface.iscsisrv.*.private_ip_address : data.azurerm_public_ip.iscsisrv.*.ip_address
+  provisioning_addresses = data.azurerm_public_ip.iscsisrv.*.ip_address
   hostname               = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
@@ -17,7 +16,7 @@ resource "azurerm_network_interface" "iscsisrv" {
     subnet_id                     = var.network_subnet_id
     private_ip_address_allocation = "Static"
     private_ip_address            = element(var.host_ips, count.index)
-    public_ip_address_id          = local.bastion_enabled ? null : element(azurerm_public_ip.iscsisrv.*.id, count.index)
+    public_ip_address_id          = element(azurerm_public_ip.iscsisrv.*.id, count.index)
   }
 
   tags = {
@@ -26,7 +25,7 @@ resource "azurerm_network_interface" "iscsisrv" {
 }
 
 resource "azurerm_public_ip" "iscsisrv" {
-  count                   = local.bastion_enabled ? 0 : var.iscsi_count
+  count                   = var.iscsi_count
   name                    = "pip-iscsisrv${format("%02d", count.index + 1)}"
   location                = var.az_region
   resource_group_name     = var.resource_group_name

--- a/terraform/azure/modules/iscsi_server/outputs.tf
+++ b/terraform/azure/modules/iscsi_server/outputs.tf
@@ -1,5 +1,5 @@
 data "azurerm_public_ip" "iscsisrv" {
-  count               = local.bastion_enabled ? 0 : var.iscsi_count
+  count               = var.iscsi_count
   name                = element(azurerm_public_ip.iscsisrv.*.name, count.index)
   resource_group_name = element(azurerm_virtual_machine.iscsisrv.*.resource_group_name, count.index)
   # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476

--- a/terraform/azure/modules/majority_maker_node/main.tf
+++ b/terraform/azure/modules/majority_maker_node/main.tf
@@ -1,6 +1,5 @@
 locals {
-  bastion_enabled      = var.common_variables["bastion_enabled"]
-  provisioning_address = local.bastion_enabled ? data.azurerm_network_interface.majority_maker.*.private_ip_address : data.azurerm_public_ip.majority_maker.*.ip_address
+  provisioning_address = data.azurerm_public_ip.majority_maker.*.ip_address
 }
 
 
@@ -18,7 +17,7 @@ resource "azurerm_network_interface" "majority_maker" {
     subnet_id                     = var.network_subnet_id
     private_ip_address_allocation = "static"
     private_ip_address            = var.majority_maker_ip
-    public_ip_address_id          = local.bastion_enabled ? null : element(azurerm_public_ip.majority_maker.*.id, count.index)
+    public_ip_address_id          = element(azurerm_public_ip.majority_maker.*.id, count.index)
   }
 
   tags = {

--- a/terraform/azure/modules/majority_maker_node/outputs.tf
+++ b/terraform/azure/modules/majority_maker_node/outputs.tf
@@ -1,5 +1,5 @@
 data "azurerm_public_ip" "majority_maker" {
-  count               = local.bastion_enabled ? 0 : var.node_count
+  count               = var.node_count
   name                = element(azurerm_public_ip.majority_maker.*.name, count.index)
   resource_group_name = element(azurerm_virtual_machine.majority_maker.*.resource_group_name, count.index)
   # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476

--- a/terraform/azure/modules/monitoring/main.tf
+++ b/terraform/azure/modules/monitoring/main.tf
@@ -1,8 +1,7 @@
 # monitoring network configuration
 
 locals {
-  bastion_enabled        = var.common_variables["bastion_enabled"]
-  provisioning_addresses = local.bastion_enabled ? data.azurerm_network_interface.monitoring.*.private_ip_address : data.azurerm_public_ip.monitoring.*.ip_address
+  provisioning_addresses = data.azurerm_public_ip.monitoring.*.ip_address
   hostname               = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
@@ -17,7 +16,7 @@ resource "azurerm_network_interface" "monitoring" {
     subnet_id                     = var.network_subnet_id
     private_ip_address_allocation = "static"
     private_ip_address            = var.monitoring_srv_ip
-    public_ip_address_id          = local.bastion_enabled ? null : azurerm_public_ip.monitoring.0.id
+    public_ip_address_id          = azurerm_public_ip.monitoring.0.id
   }
 
   tags = {
@@ -27,7 +26,7 @@ resource "azurerm_network_interface" "monitoring" {
 
 resource "azurerm_public_ip" "monitoring" {
   name                    = "pip-monitoring"
-  count                   = local.bastion_enabled ? 0 : (var.monitoring_enabled ? 1 : 0)
+  count                   = var.monitoring_enabled ? 1 : 0
   location                = var.az_region
   resource_group_name     = var.resource_group_name
   allocation_method       = "Dynamic"

--- a/terraform/azure/modules/monitoring/outputs.tf
+++ b/terraform/azure/modules/monitoring/outputs.tf
@@ -1,5 +1,5 @@
 data "azurerm_public_ip" "monitoring" {
-  count               = local.bastion_enabled == false && var.monitoring_enabled == true ? 1 : 0
+  count               = var.monitoring_enabled == true ? 1 : 0
   name                = azurerm_public_ip.monitoring.0.name
   resource_group_name = azurerm_virtual_machine.monitoring.0.resource_group_name
   # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476

--- a/terraform/azure/modules/netweaver_node/outputs.tf
+++ b/terraform/azure/modules/netweaver_node/outputs.tf
@@ -1,5 +1,5 @@
 data "azurerm_public_ip" "netweaver" {
-  count               = local.bastion_enabled ? 0 : local.vm_count
+  count               = local.vm_count
   name                = element(azurerm_public_ip.netweaver.*.name, count.index)
   resource_group_name = element(azurerm_virtual_machine.netweaver.*.resource_group_name, count.index)
   # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476

--- a/terraform/azure/outputs.tf
+++ b/terraform/azure/outputs.tf
@@ -4,6 +4,8 @@
 # - Private node name
 # - Public node name
 
+# iSCSI server
+
 output "iscsisrv_ip" {
   value = module.iscsi_server.iscsisrv_ip
 }
@@ -98,10 +100,10 @@ resource "local_file" "ansible_inventory" {
     {
       hana-name           = module.hana_node.hana_name,
       hana-pip            = module.hana_node.hana_public_ip,
-      hana-remote-python  = var.hana_remote_python
+      hana-remote-python  = var.hana_remote_python,
       iscsi-name          = module.iscsi_server.iscsisrv_name,
       iscsi-pip           = module.iscsi_server.iscsisrv_public_ip,
-      iscsi-enabled       = local.iscsi_enabled
+      iscsi-enabled       = local.iscsi_enabled,
       iscsi-remote-python = var.iscsi_remote_python
   })
   filename = "inventory.yaml"

--- a/terraform/azure/terraform.tfvars.example
+++ b/terraform/azure/terraform.tfvars.example
@@ -103,18 +103,6 @@ public_key  = "/home/user/.ssh/id.rsa.key"
 # fence_agent_app_id = "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"       # login
 # fence_agent_client_secret = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"  # password
 
-##########################
-# Bastion (jumpbox) machine variables
-##########################
-
-# Enable bastion usage. If this option is enabled, it will create a unique public ip address that is attached to the bastion machine.
-# The rest of the machines won't have a public ip address and the SSH connection must be done through the bastion
-#bastion_enabled = true
-
-# Bastion SSH keys. If they are not set the public_key and private_key are used
-#bastion_public_key  = "/home/myuser/.ssh/id_rsa_bastion.pub"
-#bastion_private_key = "/home/myuser/.ssh/id_rsa_bastion"
-
 #########################
 # HANA machines variables
 # This example shows the demo option values.Find more options in the README file

--- a/terraform/azure/terraform.tfvars.openqa
+++ b/terraform/azure/terraform.tfvars.openqa
@@ -10,7 +10,6 @@ deployment_name = "%DEPLOYMENTNAME%"
 os_image = "%OSVER%"
 public_key  = "%SSHKEY%"
 
-bastion_enabled = false
 hana_name = "vmhana"
 hana_vm_size = "Standard_E4s_v3"
 hana_count = "2"

--- a/terraform/azure/terraform.tfvars.template
+++ b/terraform/azure/terraform.tfvars.template
@@ -4,7 +4,6 @@
 #################################
 vnet_address_range   = "10.10.0.0/16"
 subnet_address_range = "10.10.1.0/24"
-bastion_enabled = false
 hana_name = "vmhana"
 hana_vm_size = "Standard_E4s_v3"
 hana_count = "2"

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -101,20 +101,7 @@ variable "bastion_network_domain" {
   default     = ""
 }
 
-variable "bastion_enabled" {
-  description = "Create a VM to work as a bastion to avoid the usage of public ip addresses and manage the ssh connection to the other machines"
-  type        = bool
-  default     = false
-}
-
-variable "bastion_os_major_version" {
-  description = "The major OS version of SLES for the bastion.  If not set, this value will be computed.  Example: 15"
-  type        = string
-  default     = ""
-}
-
 # Deployment variables
-
 variable "deployment_name" {
   description = "Suffix string added to some of the infrastructure resources names. If it is not provided, the terraform workspace string is used as suffix"
   type        = string
@@ -218,12 +205,6 @@ variable "hana_count" {
 
 variable "hana_os_image" {
   description = "sles4sap image used to create the HANA machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp3:gen2:latest"
-  type        = string
-  default     = ""
-}
-
-variable "hana_os_major_version" {
-  description = "The major OS version of SLES for the HANA VMs.  If not set, this value will be computed.  Example: 15"
   type        = string
   default     = ""
 }
@@ -486,12 +467,6 @@ variable "iscsi_os_image" {
   default     = ""
 }
 
-variable "iscsi_os_major_version" {
-  description = "The major OS version of SLES for the iscsi VMs.  If not set, this value will be computed.  Example: 15"
-  type        = string
-  default     = ""
-}
-
 variable "iscsi_srv_uri" {
   description = "Path to a custom azure image in a storage account used to create the iscsi machines"
   type        = string
@@ -569,12 +544,6 @@ variable "monitoring_vm_size" {
 
 variable "monitoring_os_image" {
   description = "sles4sap image used to create the Monitoring server machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp3:gen2:latest"
-  type        = string
-  default     = ""
-}
-
-variable "monitoring_os_major_version" {
-  description = "The major OS version of SLES for the monitoring VM.  If not set, this value will be computed.  Example: 15"
   type        = string
   default     = ""
 }
@@ -705,12 +674,6 @@ variable "netweaver_app_server_count" {
 
 variable "netweaver_os_image" {
   description = "sles4sap image used to create the Netweaver machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp3:gen2:latest"
-  type        = string
-  default     = ""
-}
-
-variable "netweaver_os_major_version" {
-  description = "The major OS version of SLES for the netweaver VMs.  If not set, this value will be computed.  Example: 15"
   type        = string
   default     = ""
 }

--- a/terraform/gcp/README.md
+++ b/terraform/gcp/README.md
@@ -94,12 +94,6 @@ To log to hana and others instances, use:
 ssh -o ProxyCommand="ssh -W %h:%p {admin_user}@{bastion_ip} -i {private_key_location} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" {admin_user}@{private_hana_instance_ip} -i {private_key_location} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
 ```
 
-To enable the bastion use:
-
-```
-bastion_enabled = true
-```
-
 Destroy the created infrastructure with:
 
 ```

--- a/terraform/gcp/infrastructure.tf
+++ b/terraform/gcp/infrastructure.tf
@@ -20,7 +20,7 @@ locals {
   subnet_name          = var.subnet_name == "" ? google_compute_subnetwork.ha_subnet.0.name : var.subnet_name
   subnet_address_range = var.subnet_name == "" ? var.ip_cidr_range : (var.ip_cidr_range == "" ? data.google_compute_subnetwork.current-subnet.0.ip_cidr_range : var.ip_cidr_range)
 
-  create_firewall = !var.bastion_enabled && var.create_firewall_rules ? 1 : 0
+  create_firewall = var.create_firewall_rules ? 1 : 0
 }
 
 # Network resources: Network, Subnet
@@ -90,7 +90,7 @@ module "bastion" {
   name               = var.bastion_name
   network_domain     = var.bastion_network_domain == "" ? var.network_domain : var.bastion_network_domain
   region             = var.region
-  os_image           = local.bastion_os_image
+  os_image           = ""
   vm_size            = "custom-1-2048"
   compute_zones      = local.compute_zones
   network_link       = local.network_link
@@ -101,14 +101,14 @@ module "bastion" {
 # This is just a basic NAT, more advanced configuration is possible
 # Based on: https://cloud.google.com/solutions/sap/docs/sap-hana-ha-dm-deployment-sles#setting-up-a-nat-gateway
 resource "google_compute_router" "router" {
-  count   = var.bastion_enabled ? 1 : 0
+  count   = 0
   name    = "${local.deployment_name}-router"
   region  = var.region
   network = local.network_link
 }
 
 resource "google_compute_router_nat" "nat" {
-  count  = var.bastion_enabled ? 1 : 0
+  count  = 0
   name   = "${local.deployment_name}-nat"
   router = google_compute_router.router.*.name[0]
   region = var.region

--- a/terraform/gcp/inventory.tmpl
+++ b/terraform/gcp/inventory.tmpl
@@ -5,7 +5,7 @@ all:
 %{ for index, value in hana-pip ~}
         ${hana-name[index]}:
           ansible_host: ${value}
-          %{ if hana-major-version == "12" }ansible_python_interpreter: /usr/bin/python2.7%{ else }ansible_python_interpreter: /usr/bin/python3 %{ endif }
+          ansible_python_interpreter: ${hana-remote-python}
 %{ endfor ~}
 %{ if iscsi-enabled }
     iscsi:
@@ -13,7 +13,7 @@ all:
 %{ for index, value in iscsi-pip ~}
         ${iscsi-name[index]}:
           ansible_host: ${value}
-          %{ if iscsi-major-version == "12" }ansible_python_interpreter: /usr/bin/python2.7%{ else }ansible_python_interpreter: /usr/bin/python3%{ endif }
+          ansible_python_interpreter: ${iscsi-remote-python}
 %{ endfor ~}
 %{ endif }
   hosts: null

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -66,18 +66,6 @@ locals {
   monitoring_os_image = var.monitoring_os_image != "" ? var.monitoring_os_image : var.os_image
   drbd_os_image       = var.drbd_os_image != "" ? var.drbd_os_image : var.os_image
   netweaver_os_image  = var.netweaver_os_image != "" ? var.netweaver_os_image : var.os_image
-  bastion_os_image    = var.bastion_os_image != "" ? var.bastion_os_image : var.os_image
-
-  # For SLES 12 we need to instruct ansible to use python2.7 and for SLES 15 it's python3.
-  # These locals calculate the major version of the os from the OS image but assumes the OS image format is consistent
-  # The regex is only used if the var.x_os_major is not set, so if the regex is failing, the user can manually set their major OS.
-  hana_major_version       = var.hana_os_major_version != "" ? var.hana_os_major_version : regex(".+sles-([0-9]+)-", local.hana_os_image)[0]
-  iscsi_major_version      = var.iscsi_os_major_version != "" ? var.iscsi_os_major_version : regex(".+sles-([0-9]+)-", local.iscsi_os_image)[0]
-  monitoring_major_version = var.monitoring_os_major_version != "" ? var.monitoring_os_major_version : regex(".+sles-([0-9]+)-", local.monitoring_os_image)[0]
-  drbd_major_version       = var.drdb_os_major_version != "" ? var.drdb_os_major_version : regex(".+sles-([0-9]+)-", local.drbd_os_image)[0]
-  netweaver_major_version  = var.netweaver_os_major_version != "" ? var.netweaver_os_major_version : regex(".+sles-([0-9]+)-", local.netweaver_os_image)[0]
-  bastion_major_version    = var.bastion_os_major_version != "" ? var.bastion_os_major_version : regex(".+sles-([0-9]+)-", local.bastion_os_image)[0]
-
 
   # Netweaver password checking
   # If Netweaver is not enabled, a dummy password is passed to pass the variable validation and not require
@@ -101,14 +89,9 @@ module "common_variables" {
   private_key                 = var.private_key
   authorized_keys             = var.authorized_keys
   authorized_user             = var.admin_user
-  bastion_enabled             = var.bastion_enabled
   bastion_public_key          = var.bastion_public_key
   bastion_private_key         = var.bastion_private_key
-  /*
-  provisioner                         = var.provisioner
-  provisioning_log_level              = var.provisioning_log_level
-  provisioning_output_colored         = var.provisioning_output_colored
-*/
+
   #background                          = var.background
   monitoring_enabled                  = var.monitoring_enabled
   monitoring_srv_ip                   = var.monitoring_enabled ? local.monitoring_srv_ip : ""

--- a/terraform/gcp/modules/bastion/main.tf
+++ b/terraform/gcp/modules/bastion/main.tf
@@ -1,5 +1,5 @@
 locals {
-  bastion_count      = var.common_variables["bastion_enabled"] ? 1 : 0
+  bastion_count      = 0
   deployment_name    = var.common_variables["deployment_name"]
   private_ip_address = cidrhost(var.snet_address_range, 5)
   firewall_ports     = var.common_variables["monitoring_enabled"] ? ["22", "3000"] : ["22"]

--- a/terraform/gcp/modules/drbd_node/main.tf
+++ b/terraform/gcp/modules/drbd_node/main.tf
@@ -2,8 +2,7 @@
 # disclaimer: only supports a single NW installation
 
 locals {
-  bastion_enabled        = var.common_variables["bastion_enabled"]
-  provisioning_addresses = local.bastion_enabled ? google_compute_instance.drbd.*.network_interface.0.network_ip : google_compute_instance.drbd.*.network_interface.0.access_config.0.nat_ip
+  provisioning_addresses = google_compute_instance.drbd.*.network_interface.0.access_config.0.nat_ip
   hostname               = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
@@ -70,7 +69,7 @@ resource "google_compute_instance" "drbd" {
 
     # Set public IP address. Only if the bastion is not used
     dynamic "access_config" {
-      for_each = local.bastion_enabled ? [] : [1]
+      for_each = [1]
       content {
         nat_ip = ""
       }

--- a/terraform/gcp/modules/drbd_node/outputs.tf
+++ b/terraform/gcp/modules/drbd_node/outputs.tf
@@ -3,7 +3,7 @@ output "drbd_ip" {
 }
 
 output "drbd_public_ip" {
-  value = local.bastion_enabled ? [] : google_compute_instance.drbd.*.network_interface.0.access_config.0.nat_ip
+  value = google_compute_instance.drbd.*.network_interface.0.access_config.0.nat_ip
 }
 
 output "drbd_name" {

--- a/terraform/gcp/modules/iscsi_server/main.tf
+++ b/terraform/gcp/modules/iscsi_server/main.tf
@@ -1,6 +1,5 @@
 locals {
-  bastion_enabled        = var.common_variables["bastion_enabled"]
-  provisioning_addresses = local.bastion_enabled ? google_compute_instance.iscsisrv.*.network_interface.0.network_ip : google_compute_instance.iscsisrv.*.network_interface.0.access_config.0.nat_ip
+  provisioning_addresses = google_compute_instance.iscsisrv.*.network_interface.0.access_config.0.nat_ip
   hostname               = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
@@ -27,7 +26,7 @@ resource "google_compute_instance" "iscsisrv" {
 
     # Set public IP address. Only if the bastion is not used
     dynamic "access_config" {
-      for_each = local.bastion_enabled ? [] : [1]
+      for_each = [1]
       content {
         nat_ip = ""
       }

--- a/terraform/gcp/modules/iscsi_server/outputs.tf
+++ b/terraform/gcp/modules/iscsi_server/outputs.tf
@@ -3,7 +3,7 @@ output "iscsisrv_ip" {
 }
 
 output "iscsisrv_public_ip" {
-  value = local.bastion_enabled ? [""] : google_compute_instance.iscsisrv.*.network_interface.0.access_config.0.nat_ip
+  value = google_compute_instance.iscsisrv.*.network_interface.0.access_config.0.nat_ip
 }
 
 output "iscsisrv_name" {

--- a/terraform/gcp/modules/monitoring/main.tf
+++ b/terraform/gcp/modules/monitoring/main.tf
@@ -2,8 +2,7 @@
 # to monitor the various components of the HA SAP cluster
 
 locals {
-  bastion_enabled        = var.common_variables["bastion_enabled"]
-  provisioning_addresses = local.bastion_enabled ? google_compute_instance.monitoring.*.network_interface.0.network_ip : google_compute_instance.monitoring.*.network_interface.0.access_config.0.nat_ip
+  provisioning_addresses = google_compute_instance.monitoring.*.network_interface.0.access_config.0.nat_ip
   hostname               = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
@@ -30,7 +29,7 @@ resource "google_compute_instance" "monitoring" {
 
     # Set public IP address. Only if the bastion is not used
     dynamic "access_config" {
-      for_each = local.bastion_enabled ? [] : [1]
+      for_each = [1]
       content {
         nat_ip = ""
       }

--- a/terraform/gcp/modules/monitoring/outputs.tf
+++ b/terraform/gcp/modules/monitoring/outputs.tf
@@ -3,7 +3,7 @@ output "monitoring_ip" {
 }
 
 output "monitoring_public_ip" {
-  value = local.bastion_enabled ? "" : join("", google_compute_instance.monitoring.*.network_interface.0.access_config.0.nat_ip)
+  value = join("", google_compute_instance.monitoring.*.network_interface.0.access_config.0.nat_ip)
 }
 
 output "monitoring_name" {

--- a/terraform/gcp/modules/netweaver_node/main.tf
+++ b/terraform/gcp/modules/netweaver_node/main.tf
@@ -5,8 +5,7 @@ locals {
   vm_count               = var.xscs_server_count + var.app_server_count
   create_ha_infra        = local.vm_count > 1 && var.common_variables["netweaver"]["ha_enabled"] ? 1 : 0
   app_start_index        = local.create_ha_infra == 1 ? 2 : 1
-  bastion_enabled        = var.common_variables["bastion_enabled"]
-  provisioning_addresses = local.bastion_enabled ? google_compute_instance.netweaver.*.network_interface.0.network_ip : google_compute_instance.netweaver.*.network_interface.0.access_config.0.nat_ip
+  provisioning_addresses = google_compute_instance.netweaver.*.network_interface.0.access_config.0.nat_ip
   hostname               = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
@@ -119,7 +118,7 @@ resource "google_compute_instance" "netweaver" {
 
     # Set public IP address. Only if the bastion is not used
     dynamic "access_config" {
-      for_each = local.bastion_enabled ? [] : [1]
+      for_each = [1]
       content {
         nat_ip = ""
       }

--- a/terraform/gcp/modules/netweaver_node/outputs.tf
+++ b/terraform/gcp/modules/netweaver_node/outputs.tf
@@ -3,7 +3,7 @@ output "netweaver_ip" {
 }
 
 output "netweaver_public_ip" {
-  value = local.bastion_enabled ? [] : google_compute_instance.netweaver.*.network_interface.0.access_config.0.nat_ip
+  value = google_compute_instance.netweaver.*.network_interface.0.access_config.0.nat_ip
 }
 
 output "netweaver_name" {

--- a/terraform/gcp/outputs.tf
+++ b/terraform/gcp/outputs.tf
@@ -94,23 +94,17 @@ output "netweaver_public_name" {
   value = module.netweaver_node.netweaver_public_name
 }
 
-# bastion
-
-output "bastion_public_ip" {
-  value = module.bastion.public_ip
-}
-
 # Ansible inventory
 resource "local_file" "ansible_inventory" {
   content = templatefile("inventory.tmpl",
     {
       hana-name           = module.hana_node.hana_name,
       hana-pip            = module.hana_node.hana_public_ip,
+      hana-remote-python  = var.hana_remote_python,
       iscsi-name          = module.iscsi_server.iscsisrv_name,
       iscsi-pip           = module.iscsi_server.iscsisrv_public_ip,
-      iscsi-enabled       = local.iscsi_enabled
-      hana-major-version  = local.hana_major_version
-      iscsi-major-version = local.iscsi_major_version
+      iscsi-enabled       = local.iscsi_enabled,
+      iscsi-remote-python = var.iscsi_remote_python
   })
   filename = "inventory.yaml"
 }

--- a/terraform/gcp/terraform.tfvars.example
+++ b/terraform/gcp/terraform.tfvars.example
@@ -128,27 +128,6 @@ private_key = "/home/myuser/.ssh/id_rsa"
 # true or false (default)
 #hwcct = false
 
-##########################
-# Bastion (jumpbox) machine variables
-##########################
-
-# Enable bastion usage. If this option is enabled, it will create a unique public ip address that is attached to the bastion machine.
-# The rest of the machines won't have a public ip address and the SSH connection must be done through the bastion
-#bastion_enabled = true
-
-# Bastion SSH keys. If they are not set the public_key and private_key are used
-#bastion_public_key  = "/home/myuser/.ssh/id_rsa_bastion.pub"
-#bastion_private_key = "/home/myuser/.ssh/id_rsa_bastion"
-
-# Bastion machine os image. If it is not provided, the os_image variable data is used
-# BYOS example
-# bastion_os_image = """suse-byos-cloud/sles-15-sp3-sap-byos""
-
-# Minimum ports per VM instance for the NAT router. Decreasing this value can compromise the deployment and make it fail
-# This value is a number between 1 and 1024
-# Find more information at: https://cloud.google.com/nat/docs/ports-and-addresses#port-reservation-procedure
-#bastion_nat_min_ports_per_vm = 1204
-
 #########################
 # HANA machines variables
 #########################

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -85,18 +85,6 @@ variable "bastion_network_domain" {
   default     = ""
 }
 
-variable "bastion_enabled" {
-  description = "Create a VM to work as a bastion to avoid the usage of public ip addresses and manage the ssh connection to the other machines"
-  type        = bool
-  default     = false
-}
-
-variable "bastion_os_image" {
-  description = "sles4sap image used to create the bastion machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp3:gen2:latest"
-  type        = string
-  default     = ""
-}
-
 variable "bastion_public_key" {
   description = "Content of a SSH public key or path to an already existing SSH public key to the bastion. If it's not set the key provided in public_key will be used"
   type        = string
@@ -832,40 +820,14 @@ variable "pre_deployment" {
   default     = false
 }
 
-# The following variables provide an opportunity to override the automatic major os detection if it proves problematic
-
-variable "hana_os_major_version" {
-  description = "The major OS version of SLES HANA VMs.  If not set, this value will be computed.  Example: 15"
+variable "hana_remote_python" {
+  description = "Remote python interpreter that Ansible will use on HANA nodes"
   type        = string
-  default     = ""
+  default     = "/usr/bin/python3"
 }
 
-variable "iscsi_os_major_version" {
-  description = "The major OS version of iscsi HANA VMs.  If not set, this value will be computed.  Example: 15"
+variable "iscsi_remote_python" {
+  description = "Remote python interpreter that Ansible will use on iscsi nodes"
   type        = string
-  default     = ""
-}
-
-variable "drdb_os_major_version" {
-  description = "The major OS version of iscsi drdb VMs.  If not set, this value will be computed.  Example: 15"
-  type        = string
-  default     = ""
-}
-
-variable "netweaver_os_major_version" {
-  description = "The major OS version of netweaver drdb VMs.  If not set, this value will be computed.  Example: 15"
-  type        = string
-  default     = ""
-}
-
-variable "bastion_os_major_version" {
-  description = "The major OS version of SLES bastion VMs.  If not set, this value will be computed.  Example: 15"
-  type        = string
-  default     = ""
-}
-
-variable "monitoring_os_major_version" {
-  description = "The major OS version of SLES monitoring VMs.  If not set, this value will be computed.  Example: 15"
-  type        = string
-  default     = ""
+  default     = "/usr/bin/python3"
 }

--- a/terraform/generic_modules/common_variables/outputs.tf
+++ b/terraform/generic_modules/common_variables/outputs.tf
@@ -30,7 +30,6 @@ output "configuration" {
     public_key                  = local.public_key
     private_key                 = local.private_key
     authorized_keys             = var.authorized_keys
-    bastion_enabled             = var.bastion_enabled
     bastion_public_key          = local.bastion_public_key
     bastion_private_key         = local.bastion_private_key
     authorized_user             = var.authorized_user

--- a/terraform/generic_modules/common_variables/variables.tf
+++ b/terraform/generic_modules/common_variables/variables.tf
@@ -77,12 +77,6 @@ variable "authorized_user" {
   type        = string
 }
 
-variable "bastion_enabled" {
-  description = "Create a VM to work as a bastion to avoid the usage of public ip addresses and manage the ssh connection to the other machines"
-  type        = bool
-  default     = false
-}
-
 variable "bastion_public_key" {
   description = "Path to a SSH public key used to connect to the bastion. If it's not set the key provided in public_key_location will be used"
   type        = string


### PR DESCRIPTION
Add same variables added for Azure in gcp and aws
Remove more bastion code

Ticket TEAM-6956
Verification:
 - qesap regression GCP http://openqaworker15.qa.suse.cz/tests/133677 the generated inventory is fine http://openqaworker15.qa.suse.cz/tests/133677/file/deploy-inventory.yaml
 - qesap regression AWS http://openqaworker15.qa.suse.cz/tests/133678
 - qesap regression AZURE http://openqaworker15.qa.suse.cz/tests/133679
 - qesap regression AZURE SLES12SP5 http://openqaworker15.qa.suse.cz/tests/133680 build is performed with 
QESAPDEPLOY_ANSIBLE_REMOTE_PYTHON  /usr/bin/python2.7 and so inventory is fine too http://openqaworker15.qa.suse.cz/tests/133680/file/deploy-inventory.yaml


