### PR TITLE
Set 1.3.6 ad reference Terraform version for qe-sap-deployment

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v2
       with:
-        terraform_version: 1.1.7
+        terraform_version: 1.3.6
     # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init
       run: terraform init

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud
     echo 'source ~/google-cloud-sdk/path.bash.inc' >> ~/.bashrc
 
 ## Terraform
-RUN curl https://releases.hashicorp.com/terraform/1.1.7/terraform_1.1.7_linux_amd64.zip -o terraform.zip && \
+RUN curl https://releases.hashicorp.com/terraform/1.3.6/terraform_1.3.6_linux_amd64.zip -o terraform.zip && \
     unzip terraform.zip -d /usr/local/bin && \
     terraform -install-autocomplete && \
     rm terraform.zip

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project is in a very early stage of development.
 Tools needed
 
 * Python 3.9
-* terraform v1.1.7
+* terraform v1.3.6
 * ansible 6.5.0 (ansible-core 2.13.5). Please refer to the **requirements.txt** file
 * cloud provider cli tools (`az`, `aws`, `gcloud`)
 


### PR DESCRIPTION
Ticket TEAM-7218

Verification 
Running qesap regression with *publiccloud_tools_0050.qcow2* and so *Terraform 1.3.6*

- Azure 
   -- SLES4SAP_15SP3
  *     -  [qesap_azure_sapconf_test|https://openqaworker15.qa.suse.cz/tests/134855] (/)
  *     -  [qesap_azure_saptune_test|https://openqaworker15.qa.suse.cz/tests/134856] (/)
   -- SLES4SAP_12SP5
 *     -  [qesap_azure_test|https://openqaworker15.qa.suse.cz/tests/134854] Failure in Terraform destroy, [retriggered|https://openqaworker15.qa.suse.cz/tests/134868] (/)
- Aws
   -- SLES4SAP_15SP3
  *     -  [qesap_azure_sapconf_test|https://openqaworker15.qa.suse.cz/tests/134857] (/)
  *     -  [qesap_azure_saptune_test|https://openqaworker15.qa.suse.cz/tests/134858] (/) 
- Gcp
   -- SLES4SAP_15SP3
    -  [qesap_azure_sapconf_test|https://openqaworker15.qa.suse.cz/tests/134866]  (/) Terraform is fine, failure is about Ansible TEAM-7382
    -  [qesap_azure_saptune_test|https://openqaworker15.qa.suse.cz/tests/134869] (/) Terraform is fine, failure is about Ansible TEAM-7382
