### PR TITLE
Provide GCP terraform dynamic resource names to ansible

### DIFF
--- a/ansible/playbooks/sap-hana-cluster.yaml
+++ b/ansible/playbooks/sap-hana-cluster.yaml
@@ -46,10 +46,6 @@
     ansible.builtin.include_vars: ../../terraform/aws/aws_cluster_data.yaml
     when: cloud_platform_is_aws
 
-  - name: Include GCP variables
-    ansible.builtin.include_vars: ../../terraform/gcp/gcp_cluster_data.yaml
-    when: cloud_platform_is_gcp      
-
   - name: Base Cluster Configuration [azure]
     ansible.builtin.include_tasks: ./tasks/azure-cluster-bootstrap.yaml
     when: cloud_platform_is_azure

--- a/ansible/playbooks/vars/gcp_hana_storage_profile.yaml
+++ b/ansible/playbooks/vars/gcp_hana_storage_profile.yaml
@@ -5,7 +5,7 @@ sap_storage_dict:
     directory: '/hana/data'
     vg: 'hanadatavg'
     lv: 'hanadatalv'
-    pv: ["/dev/disk/by-id/google-hana-data"]
+    pv: ["/dev/disk/by-id/google-{{ prefix }}-hana-data"]
     numluns: '1'
     stripesize: ''
   # LVM striped partition
@@ -14,7 +14,7 @@ sap_storage_dict:
     directory: '/hana/log'
     vg: 'hanalogvg'
     lv: 'hanaloglv'
-    pv: ["/dev/disk/by-id/google-hana-log"]
+    pv: ["/dev/disk/by-id/google-{{ prefix }}-hana-log"]
     numluns: '1'
     stripesize: ''
   hanashared:
@@ -22,7 +22,7 @@ sap_storage_dict:
     directory: '/hana/shared'
     vg: 'hanasharedvg'
     lv: 'hanasharedlv'
-    pv: ["/dev/disk/by-id/google-hana-shared"]
+    pv: ["/dev/disk/by-id/google-{{ prefix }}-hana-shared"]
     numluns: '1'
     stripesize: ''
   usrsap:
@@ -30,7 +30,7 @@ sap_storage_dict:
     directory: '/usr/sap'
     vg: 'usrsapvg'
     lv: 'usrsaplv'
-    pv: ["/dev/disk/by-id/google-usr-sap"]
+    pv: ["/dev/disk/by-id/google-{{ prefix }}-usr-sap"]
     numluns: '1'
     stripesize: ''
   backup:
@@ -38,7 +38,7 @@ sap_storage_dict:
     directory: '/backup'
     vg: 'backupvg'
     lv: 'backuplv'
-    pv: ["/dev/disk/by-id/google-hana-backup"]
+    pv: ["/dev/disk/by-id/google-{{ prefix }}-hana-backup"]
     numluns: '1'
     stripesize: ''
   install:
@@ -46,6 +46,6 @@ sap_storage_dict:
     directory: '/hana/install'
     vg: 'installvg'
     lv: 'installlv'
-    pv: ["/dev/disk/by-id/google-hana-software"]
+    pv: ["/dev/disk/by-id/google-{{ prefix }}-hana-software"]
     numluns: '1'
     stripesize: ''

--- a/terraform/gcp/gcp_cluster_data.tfpl
+++ b/terraform/gcp/gcp_cluster_data.tfpl
@@ -1,1 +1,0 @@
-gcp_cluster_ip: ${virtual_ip}

--- a/terraform/gcp/inventory.tmpl
+++ b/terraform/gcp/inventory.tmpl
@@ -16,4 +16,7 @@ all:
           ansible_python_interpreter: ${iscsi-remote-python}
 %{ endfor ~}
 %{ endif }
+      vars:
+        gcp_cluster_ip: ${hana-vip}
+        prefix: ${name_prefix}
   hosts: null

--- a/terraform/gcp/outputs.tf
+++ b/terraform/gcp/outputs.tf
@@ -100,20 +100,13 @@ resource "local_file" "ansible_inventory" {
     {
       hana-name           = module.hana_node.hana_name,
       hana-pip            = module.hana_node.hana_public_ip,
+      hana-vip            = module.hana_node.hana_vip,
       hana-remote-python  = var.hana_remote_python,
+      name_prefix         = local.deployment_name,
       iscsi-name          = module.iscsi_server.iscsisrv_name,
       iscsi-pip           = module.iscsi_server.iscsisrv_public_ip,
       iscsi-enabled       = local.iscsi_enabled,
       iscsi-remote-python = var.iscsi_remote_python
   })
   filename = "inventory.yaml"
-}
-
-# Cluster data for ansible
-resource "local_file" "cluster_data" {
-  content = templatefile("gcp_cluster_data.tfpl",
-    {
-      virtual_ip = module.hana_node.hana_vip
-  })
-  filename = "gcp_cluster_data.yaml"
 }


### PR DESCRIPTION
This pr introduces the following changes:

- Makes terraform write the `gcp_cluster_ip` and `deployment_name` variables to the generated inventory, instead of using a separate local file (which was `gcp_cluster_data.yaml`)
- Enables ansible to grab the dynamic deployment name to use in locating the correct resources, as this was hardcoded in both terraform and ansible in the past

- Ticket: https://jira.suse.com/browse/TEAM-7131
- Verification runs:
GCP: http://openqaworker15.qa.suse.cz/tests/139501
AWS: http://openqaworker15.qa.suse.cz/tests/139483
Azure: http://openqaworker15.qa.suse.cz/tests/139502