### PR TITLE
Give standard name to Hana VMs

### DIFF
--- a/terraform/gcp/inventory.tmpl
+++ b/terraform/gcp/inventory.tmpl
@@ -3,7 +3,7 @@ all:
     hana:
       hosts:
 %{ for index, value in hana-pip ~}
-        ${hana-name[index]}:
+        ${hana-base-name}${format("%02d", index + 1)}:
           ansible_host: ${value}
           ansible_python_interpreter: ${hana-remote-python}
 %{ endfor ~}

--- a/terraform/gcp/outputs.tf
+++ b/terraform/gcp/outputs.tf
@@ -98,7 +98,7 @@ output "netweaver_public_name" {
 resource "local_file" "ansible_inventory" {
   content = templatefile("inventory.tmpl",
     {
-      hana-name           = module.hana_node.hana_name,
+      hana-base-name      = var.hana_name,
       hana-pip            = module.hana_node.hana_public_ip,
       hana-vip            = module.hana_node.hana_vip,
       hana-remote-python  = var.hana_remote_python,


### PR DESCRIPTION
Use same name used in AWS and Azure deployment like `vmhana01`.

Ticket [TEAM-7627](https://jira.suse.com/browse/TEAM-7627)

Verification: http://openqaworker15.qa.suse.cz/tests/141285 http://openqaworker15.qa.suse.cz/tests/141286