### PR TITLE
Allow qesap.py to parse lines with more than one space in tfvars templates

### DIFF
--- a/scripts/qesap/lib/config.py
+++ b/scripts/qesap/lib/config.py
@@ -130,7 +130,7 @@ class CONF:
                 key_replace = False
                 # Look for key in the template file content
                 for index, line in enumerate(tfvar_content):
-                    if re.search(rf'{key}\s?=.*', line):
+                    if re.search(rf'{key}\s*=.*', line):
                         log.debug("Replace template %s with [%s = %s]", line, key, value)
                         tfvar_content[index] = f"{key} = {value}\n"
                         key_replace = True


### PR DESCRIPTION
Current version of glue script expects 0 or 1 spaces between a variable name and the equal sign that follows while parsing the lines from the tfvars template file to properly identify the variable name and its value. This causes problems when more than one space is used, as in L5 from https://github.com/SUSE/qe-sap-deployment/blob/main/terraform/azure/terraform.tfvars.template which is:
```
vnet_address_range   = "10.10.0.0/16"
```
Lines such as this could cause variables defined in such a way to be duplicated in the resulting terraform.tfvars file, causing terraform to fail due to duplicate variable definitions.

This PR introduces a fix to allow 0 or more spaces between the variable name and the equal sign.

---

With a YAML configuration file that has:
```
provider: "azure"
apiver: 3
terraform:
  variables:
    az_region: "westeurope"
    deployment_name: "qesapval145847"
    os_image: "SUSE:sles-sap-15-sp4-byos:gen2:2023.02.05"
    public_key: "/root/.ssh/id_rsa.pub"
    hana_remote_python: "/usr/bin/python3"
    iscsi_remote_python: "/usr/bin/python3"
    vnet_address_range: "10.26.0.0/16"
    subnet_address_range: "10.26.1.0/24"
<snip>
```
And using the current version of qesap.py as:
```
install:~/qe-sap-deployment # ./scripts/qesap/qesap.py --verbose -c /root/qe-sap-deployment/terraform/azure/qesap_azure_sapconf.yaml -b /root/qe-sap-deployment configure
```
This results in a tfvars like:
```
#################################
# qe-sap-deployments project configuration file
# Find all the available variables and definitions in the variables.tf file
#################################
vnet_address_range   = "10.10.0.0/16"
subnet_address_range = 10.26.1.0/24
hana_name = "vmhana"
hana_vm_size = "Standard_E4s_v3"
hana_count = "2"
az_region = "westeurope"
deployment_name = "qesapval145847"
os_image = "SUSE:sles-sap-15-sp4-byos:gen2:2023.02.05"
public_key = "/root/.ssh/id_rsa.pub"
hana_remote_python = "/usr/bin/python3"
iscsi_remote_python = "/usr/bin/python3"
vnet_address_range = "10.26.0.0/16"
```
Notice there the duplicated definition of `vnet_address_range`, one taken from `qesap_azure_sapconf.yaml` and the other from the terraform.tfvars.template supplied in this repository.

Relevant output from the command is:
```
INFO     Read /root/qe-sap-deployment/terraform/azure/terraform.tfvars.template
DEBUG    Template:['#################################\n', '# qe-sap-deployments project configuration file\n', '# Find all the available variables and definitions in the variables.tf file\n', '#################################\n', 'vnet_address_range   = "10.10.0.0/16"\n', 'subnet_address_range = "10.10.1.0/24"\n', 'hana_name = "vmhana"\n', 'hana_vm_size = "Standard_E4s_v3"\n', 'hana_count = "2"\n']
DEBUG    Config has terraform variables
DEBUG    [k:az_region = v:westeurope] is not in the template, append it
DEBUG    [k:deployment_name = v:qesapval145847] is not in the template, append it
DEBUG    [k:os_image = v:SUSE:sles-sap-15-sp4-byos:gen2:2023.02.05] is not in the template, append it
DEBUG    [k:public_key = v:/root/.ssh/id_rsa.pub] is not in the template, append it
DEBUG    [k:hana_remote_python = v:/usr/bin/python3] is not in the template, append it
DEBUG    [k:iscsi_remote_python = v:/usr/bin/python3] is not in the template, append it
DEBUG    [k:vnet_address_range = v:10.26.0.0/16] is not in the template, append it
DEBUG    Replace template subnet_address_range = "10.10.1.0/24"
 with [subnet_address_range = 10.26.1.0/24]
DEBUG    Result terraform.tfvars:
```
Running the same command with the change from this PR applied results in:
```
#################################
# qe-sap-deployments project configuration file
# Find all the available variables and definitions in the variables.tf file
#################################
vnet_address_range = 10.26.0.0/16
subnet_address_range = 10.26.1.0/24
hana_name = "vmhana"
hana_vm_size = "Standard_E4s_v3"
hana_count = "2"
az_region = "westeurope"
deployment_name = "qesapval145847"
os_image = "SUSE:sles-sap-15-sp4-byos:gen2:2023.02.05"
public_key = "/root/.ssh/id_rsa.pub"
hana_remote_python = "/usr/bin/python3"
iscsi_remote_python = "/usr/bin/python3"
```
Relevant output from the command is:
```
INFO     Read /root/qe-sap-deployment/terraform/azure/terraform.tfvars.template
DEBUG    Template:['#################################\n', '# qe-sap-deployments project configuration file\n', '# Find all the available variables and definitions in the variables.tf file\n', '#################################\n', 'vnet_address_range   = "10.10.0.0/16"\n', 'subnet_address_range = "10.10.1.0/24"\n', 'hana_name = "vmhana"\n', 'hana_vm_size = "Standard_E4s_v3"\n', 'hana_count = "2"\n']
DEBUG    Config has terraform variables
DEBUG    [k:az_region = v:westeurope] is not in the template, append it
DEBUG    [k:deployment_name = v:qesapval145847] is not in the template, append it
DEBUG    [k:os_image = v:SUSE:sles-sap-15-sp4-byos:gen2:2023.02.05] is not in the template, append it
DEBUG    [k:public_key = v:/root/.ssh/id_rsa.pub] is not in the template, append it
DEBUG    [k:hana_remote_python = v:/usr/bin/python3] is not in the template, append it
DEBUG    [k:iscsi_remote_python = v:/usr/bin/python3] is not in the template, append it
DEBUG    Replace template vnet_address_range   = "10.10.0.0/16"
 with [vnet_address_range = 10.26.0.0/16]
DEBUG    Replace template subnet_address_range = "10.10.1.0/24"
 with [subnet_address_range = 10.26.1.0/24]
DEBUG    Result terraform.tfvars:
```