### PR TITLE
qesap terraform tfvars template strings

### DIFF
--- a/scripts/qesap/lib/config.py
+++ b/scripts/qesap/lib/config.py
@@ -109,6 +109,16 @@ class CONF:
         Takes data structure collected from yaml config.
         Values are converted into tfvars format and checked against terraform.tfvars.template.
         Variables from yaml config are overwritten by values from template file.
+        Whatever .tfvars.template content is in the file, is copied in the final terraform.tfvars.
+        This function only eventually care about strings that
+        are in a valid terraform variable format like:
+
+        ```
+        aaa = bbb
+        ```
+
+        They are also copied in the final .tfvars. Eventually values for them is updated if
+        same variable is also specified in the conf.yaml
 
         Args:
             tfvars_template (str): path to the tfvars template file
@@ -132,7 +142,7 @@ class CONF:
                 for index, line in enumerate(tfvar_content):
                     if re.search(rf'{key}\s*=.*', line):
                         log.debug("Replace template %s with [%s = %s]", line, key, value)
-                        tfvar_content[index] = f"{key} = {value}\n"
+                        tfvar_content[index] = yaml_to_tfvars_entry(key, value) + '\n'
                         key_replace = True
                 # add the new key/value pair
                 if not key_replace:

--- a/scripts/qesap/test/unit/test_qesap_ansible.py
+++ b/scripts/qesap/test/unit/test_qesap_ansible.py
@@ -76,8 +76,9 @@ def test_ansible_verbose(run, _, base_args, tmpdir, create_inventory, create_pla
     run.assert_has_calls(calls)
 
 
+@mock.patch('shutil.which', side_effect=[(ANSIBLEPB_EXE), (ANSIBLE_EXE)])
 @mock.patch("lib.process_manager.subprocess_run")
-def test_ansible_dryrun(run, base_args, tmpdir, create_inventory, create_playbooks, ansible_config):
+def test_ansible_dryrun(run, _, base_args, tmpdir, create_inventory, create_playbooks, ansible_config):
     """
     Command ansible does not call the Ansible executable in dryrun mode
     """

--- a/scripts/qesap/test/unit/test_qesap_configure_terraform.py
+++ b/scripts/qesap/test/unit/test_qesap_configure_terraform.py
@@ -5,7 +5,6 @@ import yaml
 
 from qesap import main
 
-
 log = logging.getLogger(__name__)
 
 
@@ -187,16 +186,16 @@ terraform:
     something : yamlrulez"""
 
     tfvar_template = [
-        "something = static\n",
-        "somethingelse = keep\n"]
+        'something = static\n',
+        'somethingelse = keep\n']
     conf = config_yaml_sample_for_terraform(terraform_section, provider)
     args, tfvar_path, *_ = configure_helper(provider, conf, tfvar_template)
 
     assert main(args) == 0
 
     expected_tfvars = [
-        "something = yamlrulez\n",
-        "somethingelse = keep\n"]
+        'something = "yamlrulez"\n',
+        'somethingelse = keep\n']
     with open(tfvar_path, 'r', encoding='utf-8') as file:
         data = file.readlines()
         assert expected_tfvars == data

--- a/scripts/qesap/test/unit/test_qesap_lib_cmd_terraform.py
+++ b/scripts/qesap/test/unit/test_qesap_lib_cmd_terraform.py
@@ -1,0 +1,149 @@
+import os
+import re
+import logging
+import yaml
+
+from lib.config import CONF
+from lib.cmds import create_tfvars
+
+log = logging.getLogger(__name__)
+
+
+def test_create_tfvars_string():
+    '''
+    Try .tfvars generation for string terraform variables format in config.yaml
+    '''
+
+    # This test overlap a little but with test_tfvars_yaml
+    conf_yaml = '''---
+terraform:
+  variables:
+    az_region: "westeurope"
+'''
+    data = yaml.load(conf_yaml, Loader=yaml.FullLoader)
+    config = CONF(data)
+    tfvar_content, err = create_tfvars(config, None)
+
+    assert err is None, "Unexpected err from create_tfvars:" + str(err)
+    assert tfvar_content == '\naz_region = "westeurope"'
+
+
+def test_create_tfvars_int():
+    '''
+    Try .tfvars generation for int terraform variables format in config.yaml
+    '''
+    conf_yaml = '''---
+terraform:
+  variables:
+    sandwiches: 5
+'''
+    data = yaml.load(conf_yaml, Loader=yaml.FullLoader)
+    config = CONF(data)
+    tfvar_content, err = create_tfvars(config, None)
+
+    assert err is None, "Unexpected err from create_tfvars:" + str(err)
+    assert tfvar_content == '\nsandwiches = "5"'
+
+
+def test_create_tfvars_list():
+    '''
+    Try .tfvars generation for list terraform variables format in config.yaml
+    '''
+    conf_yaml = '''---
+terraform:
+  variables:
+    sandwiches:
+      - tuna
+      - club
+'''
+    data = yaml.load(conf_yaml, Loader=yaml.FullLoader)
+    config = CONF(data)
+    tfvar_content, err = create_tfvars(config, None)
+
+    assert err is None, "Unexpected err from create_tfvars:" + str(err)
+    assert tfvar_content == '\nsandwiches = ["tuna", "club"]'
+
+
+def test_create_tfvars_unsupported_format():
+    '''
+    Try .tfvars generation for float in conf.yaml result in an error
+    '''
+    conf_yaml = '''---
+terraform:
+  variables:
+    sandwiches: 3.14
+'''
+    data = yaml.load(conf_yaml, Loader=yaml.FullLoader)
+    config = CONF(data)
+    tfvar_content, err = create_tfvars(config, None)
+
+    assert err is not None, "Unexpected None err"
+
+
+def test_create_tfvars_string_with_template(tmpdir):
+    '''
+    Try .tfvars generation from .tfvar.template and conf.yaml without overlapping variables
+    '''
+    conf_yaml = '''---
+terraform:
+  variables:
+    sandwiches: "club"
+'''
+    data = yaml.load(conf_yaml, Loader=yaml.FullLoader)
+    config = CONF(data)
+    tfvar_template_file = str(tmpdir / 'gnocchi.txt')
+    with open(tfvar_template_file, 'w', encoding='utf-8') as file:
+        file.write('# This is a comment')
+
+    tfvar_content, err = create_tfvars(config, tfvar_template_file)
+
+    log.error(tfvar_content)
+    assert err is None, "Unexpected err from create_tfvars:" + str(err)
+    assert '# This is a comment\n' in tfvar_content
+    assert 'sandwiches = "club"\n' in tfvar_content
+
+
+def test_create_tfvars_string_with_template_and_substitution(tmpdir):
+    '''
+    Try .tfvars generation from .tfvar.template and conf.yaml with overlapping string variables
+    '''
+    conf_yaml = '''---
+terraform:
+  variables:
+    sandwiches: "club"
+'''
+    data = yaml.load(conf_yaml, Loader=yaml.FullLoader)
+    config = CONF(data)
+    tfvar_template_file = str(tmpdir / 'gnocchi.txt')
+    with open(tfvar_template_file, 'w', encoding='utf-8') as file:
+        file.write('sandwiches = "cheese"')
+
+    tfvar_content, err = create_tfvars(config, tfvar_template_file)
+
+    log.error(tfvar_content)
+    assert err is None, "Unexpected err from create_tfvars:" + str(err)
+    assert 'sandwiches = "club"\n' in tfvar_content
+
+
+def test_create_tfvars_list_with_template_and_substitution(tmpdir):
+    '''
+    Try .tfvars generation from .tfvar.template and conf.yaml with overlapping list variables
+    '''
+    conf_yaml = '''---
+terraform:
+  variables:
+    sandwiches:
+      - club
+      - cheese
+'''
+    data = yaml.load(conf_yaml, Loader=yaml.FullLoader)
+    config = CONF(data)
+    tfvar_template_file = str(tmpdir / 'gnocchi.txt')
+    with open(tfvar_template_file, 'w', encoding='utf-8') as file:
+        file.write('sandwiches = ["tuna", "vegan"]')
+
+    tfvar_content, err = create_tfvars(config, tfvar_template_file)
+
+    log.error(tfvar_content)
+    assert err is None, "Unexpected err from create_tfvars:" + str(err)
+    assert 'sandwiches = ["club", "cheese"]\n' in tfvar_content

--- a/scripts/qesap/test/unit/test_qesap_lib_config.py
+++ b/scripts/qesap/test/unit/test_qesap_lib_config.py
@@ -46,3 +46,4 @@ def test_tfvars_yaml_dict(config_data_sample):
     c = CONF(config_data_sample(hana_disk_configuration))
     actual_result = c.yaml_to_tfvars()
     assert re.search(expected_result, actual_result)
+


### PR DESCRIPTION
Improve how terraform.tfvars generation manage variable substitution between the conf.yaml and the template.
Fix an Ansible dryrun unit test.
Add more unit tests about tfvars.

Ticket : [TEAM-7785](https://jira.suse.com/browse/TEAM-7785)