### PR TITLE
Exchange cloudadmin ssh keys

### DIFF
--- a/ansible/playbooks/pre-cluster.yaml
+++ b/ansible/playbooks/pre-cluster.yaml
@@ -20,7 +20,6 @@
       line: "{{ hostvars[item]['ansible_default_ipv4']['address'] }}    {{ hostvars[item]['ansible_hostname'] }}    {{ hostvars[item]['ansible_hostname'] }}"
       state: present
       backup: true
-    when: ansible_hostname != item
     with_items: "{{ groups['all'] }}"
 
   - name: Ensure that /root/.ssh exists on hana
@@ -31,6 +30,15 @@
       state: directory
       owner: root
       group: root
+      mode: '0700'
+    when: inventory_hostname in groups.hana
+
+  - name: Ensure that /home/cloudadmin/.ssh exists on hana
+    ansible.builtin.file:
+      path: "{{ ansible_env.HOME }}/.ssh"
+      state: directory
+      owner: "{{ansible_user}}"
+      group: users
       mode: '0700'
     when: inventory_hostname in groups.hana
 
@@ -47,6 +55,17 @@
     register: ssh_root_keys
     when: inventory_hostname in groups.hana
 
+  - name: Generate public/private keys for cloudadmin on hana hosts
+    community.crypto.openssh_keypair:
+      owner: "{{ansible_user}}"
+      group: users
+      mode: '0600'
+      path: "{{ ansible_env.HOME }}/.ssh/id_rsa"
+      type: rsa
+      size: 4096
+    register: ssh_user_keys
+    when: inventory_hostname in groups.hana
+
   - name: Apply root key to root Authorised Keys
     become: true
     become_user: root
@@ -59,17 +78,11 @@
       loop_var: idx
     when: inventory_hostname in groups.hana
 
-  - name: Slurp cloudadmin public key
-    ansible.builtin.slurp:
-      src: "{{ ansible_env.HOME }}/.ssh/id_rsa.pub"
-    register: userpubkeys
-    when: inventory_hostname in groups.hana
-
-  - name: "Apply cloudadmin pub key to other node cloudadmin Authorised Keys"
+  - name: Apply cloudadmin pub key to other node cloudadmin Authorised Keys
     ansible.posix.authorized_key:
       user: "{{ansible_user}}"
       state: present
-      key: "{{ (hostvars[item].userpubkeys.content | b64decode) }}"
+      key: "{{ hostvars[item].ssh_user_keys.public_key }}"
     when: inventory_hostname in groups.hana and hostvars[item]['ansible_hostname'] in groups.hana and ansible_hostname != item
     with_items: "{{ groups['all'] }}"
 

--- a/ansible/playbooks/pre-cluster.yaml
+++ b/ansible/playbooks/pre-cluster.yaml
@@ -2,8 +2,6 @@
 - hosts: all
   name: Cluster preparation
   remote_user: cloudadmin
-  become: true
-  become_user: root
   pre_tasks:
   - name: Detect cloud platform
     ansible.builtin.include_tasks:
@@ -14,16 +12,20 @@
 
   tasks:
   - name: Ensure all hosts are present in all hosts /etc/hosts files
+    become: true
+    become_user: root
     ansible.builtin.lineinfile:
       path: "/etc/hosts"
       regexp: ".*{{ hostvars[item]['ansible_hostname'] }}.*{{ hostvars[item]['ansible_hostname'] }}"
       line: "{{ hostvars[item]['ansible_default_ipv4']['address'] }}    {{ hostvars[item]['ansible_hostname'] }}    {{ hostvars[item]['ansible_hostname'] }}"
       state: present
       backup: true
-    when: ansible_hostname != item or ansible_hostname == item
+    when: ansible_hostname != item
     with_items: "{{ groups['all'] }}"
 
   - name: Ensure that /root/.ssh exists on hana
+    become: true
+    become_user: root
     ansible.builtin.file:
       path: /root/.ssh
       state: directory
@@ -33,6 +35,8 @@
     when: inventory_hostname in groups.hana
 
   - name: Generate public/private keys for root on hana hosts
+    become: true
+    become_user: root
     community.crypto.openssh_keypair:
       group: root
       owner: root
@@ -40,27 +44,34 @@
       path: /root/.ssh/id_rsa
       type: rsa
       size: 4096
-    register: ssh_keys
+    register: ssh_root_keys
     when: inventory_hostname in groups.hana
 
-  - name: Add all hana root public keys to all hana nodes
-    ansible.builtin.lineinfile:
-      path: /root/.ssh/authorized_keys
-      line: "{{ hostvars[item].ssh_keys.public_key }}"
-      create: true
-      mode: '0600'
-    with_items: "{{ groups['hana'] }}"
-    when: inventory_hostname in groups.hana
-
-  - name: Apply to Authorised Keys
+  - name: Apply root key to root Authorised Keys
+    become: true
+    become_user: root
     ansible.posix.authorized_key:
       user: root
       state: present
-      key: "{{ hostvars[idx].ssh_keys.public_key }}"
+      key: "{{ hostvars[idx].ssh_root_keys.public_key }}"
     loop: "{{ groups['hana'] }}"
     loop_control:
       loop_var: idx
     when: inventory_hostname in groups.hana
+
+  - name: Slurp cloudadmin public key
+    ansible.builtin.slurp:
+      src: "{{ ansible_env.HOME }}/.ssh/id_rsa.pub"
+    register: userpubkeys
+    when: inventory_hostname in groups.hana
+
+  - name: "Apply cloudadmin pub key to other node cloudadmin Authorised Keys"
+    ansible.posix.authorized_key:
+      user: "{{ansible_user}}"
+      state: present
+      key: "{{ (hostvars[item].userpubkeys.content | b64decode) }}"
+    when: inventory_hostname in groups.hana and hostvars[item]['ansible_hostname'] in groups.hana and ansible_hostname != item
+    with_items: "{{ groups['all'] }}"
 
   - name: Slurp ssh daemon public key
     ansible.builtin.slurp:
@@ -69,6 +80,8 @@
     when: inventory_hostname in groups.hana
 
   - name: Populate /root/.ssh/known_hosts
+    become: true
+    become_user: root
     ansible.builtin.known_hosts:
       path: /root/.ssh/known_hosts
       name: "{{ hostvars[idx]['ansible_hostname'] }}"
@@ -80,6 +93,8 @@
     when: inventory_hostname in groups.hana
 
   - name: Ensure hostnames are preserved [aws]
+    become: true
+    become_user: root
     ansible.builtin.lineinfile:
       path: /etc/cloud/cloud.cfg
       regexp: '^preserve_hostname:'

--- a/ansible/playbooks/tasks/detect-cloud-platform.yaml
+++ b/ansible/playbooks/tasks/detect-cloud-platform.yaml
@@ -9,6 +9,8 @@
   block:
 
     - name: "Probe for AWS"
+      become: true
+      become_user: root
       ansible.builtin.command: dmidecode -s system-manufacturer  # | grep -iq "Amazon EC2"
       changed_when: false
       failed_when: false
@@ -26,6 +28,8 @@
   block:
 
     - name: "Probe for GCP"
+      become: true
+      become_user: root
       ansible.builtin.command: dmidecode -s bios-version  # | grep -iq "google"
       changed_when: false
       failed_when: false
@@ -43,12 +47,16 @@
   block:
 
     - name: "Probe for Azure 1/2"
+      become: true
+      become_user: root
       ansible.builtin.command: dmidecode -s system-manufacturer  # | grep -iq "microsoft corporation"
       changed_when: false
       failed_when: false
       register: probe_azure_1
 
     - name: "Probe for Azure 2/2"
+      become: true
+      become_user: root
       ansible.builtin.command: dmidecode -s system-product-name  # | grep -iq "virtual machine"
       changed_when: false
       failed_when: false


### PR DESCRIPTION
Change precluster not to be all executed as root, but add `become` only where needed.
Remove always true `when` condition
Remove duplicated task both implemented with command line and ssh lib Add `become` where needed in the detect cloud

Ticket TEAM-7867

Verification:
 - qesap regression Azure 15sp4 http://openqaworker15.qa.suse.cz/tests/149836 (first commit only, failure to confirm that more Ansible code is needed, check 2nd commit in the PR).  http://openqaworker15.qa.suse.cz/tests/149874 , http://openqaworker15.qa.suse.cz/tests/151198 , http://openqaworker15.qa.suse.cz/tests/151203 (both commits)
 - qesap regression Azure 15sp5 http://openqaworker15.qa.suse.cz/tests/151201 PASS
 - qesap regression GCP 15sp3 sapconf http://openqaworker15.qa.suse.cz/tests/149873 , http://openqaworker15.qa.suse.cz/tests/151206
 - qesap regression AWS 15sp3 http://openqaworker15.qa.suse.cz/tests/151202