### PR TITLE
Added dmidecode to detect AWS instance type as ec2xxx and 1.xamazon tags

### DIFF
--- a/ansible/playbooks/tasks/detect-cloud-platform.yaml
+++ b/ansible/playbooks/tasks/detect-cloud-platform.yaml
@@ -17,12 +17,16 @@
       register: probe_aws
 
     - name: "Probe for AWS 2"
+      become: true
+      become_user: root
       ansible.builtin.command: dmidecode -s bios-version  # | grep -iq "Amazon"
       changed_when: false
       failed_when: false
       register: probe_aws_2
 
     - name: "Probe for AWS 1"
+      become: true
+      become_user: root
       ansible.builtin.command: dmidecode --string system-uuid  # | grep -iq " EC2"
       changed_when: false
       failed_when: false

--- a/ansible/playbooks/tasks/detect-cloud-platform.yaml
+++ b/ansible/playbooks/tasks/detect-cloud-platform.yaml
@@ -9,27 +9,37 @@
   block:
 
     - name: "Probe for AWS"
-      become: true
-      become_user: root
       ansible.builtin.command: dmidecode -s system-manufacturer  # | grep -iq "Amazon EC2"
       changed_when: false
       failed_when: false
       register: probe_aws
 
+    - name: "Probe for AWS 2"
+      ansible.builtin.command: dmidecode -s bios-version  # | grep -iq "Amazon"
+      changed_when: false
+      failed_when: false
+      register: probe_aws_2
+
+    - name: "Probe for AWS 2"
+      ansible.builtin.command: dmidecode --string system-uuid  # | grep -iq " EC2"
+      changed_when: false
+      failed_when: false
+      register: probe_aws_1
+
     - name: Set AWS discovery fact
       ansible.builtin.set_fact:
         cloud_platform_is_aws: true
       when:
-        - probe_aws.rc == 0
-        - probe_aws.stdout | lower == 'amazon ec2'
+        - probe_aws.rc == 0 and probe_aws.stdout | lower == 'amazon ec2' or probe_aws_2.stdout is match(".*amazon") or probe_aws_1.stdout is match("ec.*")
+
+        
 
 # SEE: https://stackoverflow.com/questions/30911775/how-to-know-if-a-machine-is-an-google-compute-engine-instance
 - name: "Detect GCP"
   block:
 
+
     - name: "Probe for GCP"
-      become: true
-      become_user: root
       ansible.builtin.command: dmidecode -s bios-version  # | grep -iq "google"
       changed_when: false
       failed_when: false
@@ -40,23 +50,21 @@
         cloud_platform_is_gcp: true
       when:
         - probe_gcp.rc == 0
-        - probe_gcp.stdout | lower == 'google'
+        - probe_gcp.stdout | lower == 'google' 
+
 
 # SEE: https://stackoverflow.com/questions/11570965/how-to-detect-azure-amazon-vm
 - name: "Detect Azure"
   block:
 
+    
     - name: "Probe for Azure 1/2"
-      become: true
-      become_user: root
       ansible.builtin.command: dmidecode -s system-manufacturer  # | grep -iq "microsoft corporation"
       changed_when: false
       failed_when: false
       register: probe_azure_1
 
     - name: "Probe for Azure 2/2"
-      become: true
-      become_user: root
       ansible.builtin.command: dmidecode -s system-product-name  # | grep -iq "virtual machine"
       changed_when: false
       failed_when: false
@@ -65,7 +73,7 @@
     - name: Set Azure Discovery Fact
       ansible.builtin.set_fact:
         cloud_platform_is_azure: true
-      when: probe_azure_1.rc == 0 and probe_azure_1.stdout | lower == 'microsoft corporation' or probe_azure_2.rc == 0 and probe_azure_2.stdout | lower == 'virtual machine'
+      when: probe_azure_1.rc == 0 and probe_azure_1.stdout | lower == 'microsoft corporation' or probe_azure_2.rc == 0 and probe_azure_2.stdout | lower == 'virtual machine' 
 
 - name: "Set Cloud Platform"
   set_fact:

--- a/ansible/playbooks/tasks/detect-cloud-platform.yaml
+++ b/ansible/playbooks/tasks/detect-cloud-platform.yaml
@@ -16,6 +16,14 @@
       failed_when: false
       register: probe_aws
 
+    - name: "Probe for AWS 1"
+      become: true
+      become_user: root
+      ansible.builtin.command: dmidecode --string system-uuid  # | grep -iq "EC2"
+      changed_when: false
+      failed_when: false
+      register: probe_aws_1
+
     - name: "Probe for AWS 2"
       become: true
       become_user: root
@@ -24,21 +32,13 @@
       failed_when: false
       register: probe_aws_2
 
-    - name: "Probe for AWS 1"
-      become: true
-      become_user: root
-      ansible.builtin.command: dmidecode --string system-uuid  # | grep -iq " EC2"
-      changed_when: false
-      failed_when: false
-      register: probe_aws_1
-
 
     - name: Set AWS discovery fact
       ansible.builtin.set_fact:
         cloud_platform_is_aws: true
       when:
         - probe_aws.rc == 0
-        - probe_aws.stdout | lower == 'amazon ec2' or probe_aws_2.stdout is match(".*amazon") or probe_aws_1.stdout is match("ec.*")
+        - probe_aws.stdout | lower == 'amazon ec2' or probe_aws_1.stdout is match("ec.*") or probe_aws_2.stdout is match(".*amazon") 
 
 # SEE: https://stackoverflow.com/questions/30911775/how-to-know-if-a-machine-is-an-google-compute-engine-instance
 - name: "Detect GCP"

--- a/ansible/playbooks/tasks/detect-cloud-platform.yaml
+++ b/ansible/playbooks/tasks/detect-cloud-platform.yaml
@@ -9,6 +9,8 @@
   block:
 
     - name: "Probe for AWS"
+      become: true
+      become_user: root
       ansible.builtin.command: dmidecode -s system-manufacturer  # | grep -iq "Amazon EC2"
       changed_when: false
       failed_when: false
@@ -20,26 +22,27 @@
       failed_when: false
       register: probe_aws_2
 
-    - name: "Probe for AWS 2"
+    - name: "Probe for AWS 1"
       ansible.builtin.command: dmidecode --string system-uuid  # | grep -iq " EC2"
       changed_when: false
       failed_when: false
       register: probe_aws_1
 
+
     - name: Set AWS discovery fact
       ansible.builtin.set_fact:
         cloud_platform_is_aws: true
       when:
-        - probe_aws.rc == 0 and probe_aws.stdout | lower == 'amazon ec2' or probe_aws_2.stdout is match(".*amazon") or probe_aws_1.stdout is match("ec.*")
-
-        
+        - probe_aws.rc == 0
+        - probe_aws.stdout | lower == 'amazon ec2' or probe_aws_2.stdout is match(".*amazon") or probe_aws_1.stdout is match("ec.*")
 
 # SEE: https://stackoverflow.com/questions/30911775/how-to-know-if-a-machine-is-an-google-compute-engine-instance
 - name: "Detect GCP"
   block:
 
-
     - name: "Probe for GCP"
+      become: true
+      become_user: root
       ansible.builtin.command: dmidecode -s bios-version  # | grep -iq "google"
       changed_when: false
       failed_when: false
@@ -50,21 +53,23 @@
         cloud_platform_is_gcp: true
       when:
         - probe_gcp.rc == 0
-        - probe_gcp.stdout | lower == 'google' 
-
+        - probe_gcp.stdout | lower == 'google'
 
 # SEE: https://stackoverflow.com/questions/11570965/how-to-detect-azure-amazon-vm
 - name: "Detect Azure"
   block:
 
-    
     - name: "Probe for Azure 1/2"
+      become: true
+      become_user: root
       ansible.builtin.command: dmidecode -s system-manufacturer  # | grep -iq "microsoft corporation"
       changed_when: false
       failed_when: false
       register: probe_azure_1
 
     - name: "Probe for Azure 2/2"
+      become: true
+      become_user: root
       ansible.builtin.command: dmidecode -s system-product-name  # | grep -iq "virtual machine"
       changed_when: false
       failed_when: false
@@ -73,7 +78,7 @@
     - name: Set Azure Discovery Fact
       ansible.builtin.set_fact:
         cloud_platform_is_azure: true
-      when: probe_azure_1.rc == 0 and probe_azure_1.stdout | lower == 'microsoft corporation' or probe_azure_2.rc == 0 and probe_azure_2.stdout | lower == 'virtual machine' 
+      when: probe_azure_1.rc == 0 and probe_azure_1.stdout | lower == 'microsoft corporation' or probe_azure_2.rc == 0 and probe_azure_2.stdout | lower == 'virtual machine'
 
 - name: "Set Cloud Platform"
   set_fact:


### PR DESCRIPTION
Added below dmidecodes to detect cloud type in  ansible/playbooks/tasks/detect-cloud-platform.yaml

**"dmidecode --string system-uuid  # | grep -iq "EC2"
dmidecode -s bios-version  # | grep -iq "Amazon"** 

Ticket : TEAM-7589

Verification links:
VR for r48xlarge : http://openqaworker15.qa.suse.cz/tests/151837 ( Failure expected in Storage partiton but fix is to detect AWS instance and it is working)
Pass Links:
VR for r5.8xlarge : http://openqaworker15.qa.suse.cz/tests/151841
VR for r5b.metal : http://openqaworker15.qa.suse.cz/tests/151842
VR for sap_conf : http://openqaworker15.qa.suse.cz/tests/151843
VR for saptune_test@64bit: http://openqaworker15.qa.suse.cz/tests/151844