### PR TITLE
Add tf variable for hana_log_disk_type

### DIFF
--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -202,6 +202,8 @@ module "hana_node" {
   iscsi_srv_ip          = module.iscsi_server.iscsisrv_ip
   hana_data_disk_type   = var.hana_data_disk_type
   hana_data_disk_size   = var.hana_data_disk_size
+  hana_log_disk_type    = var.hana_log_disk_type
+  hana_log_disk_size    = var.hana_log_disk_size
   hana_backup_disk_type = var.hana_backup_disk_type
   hana_backup_disk_size = var.hana_backup_disk_size
 }

--- a/terraform/gcp/modules/hana_node/variables.tf
+++ b/terraform/gcp/modules/hana_node/variables.tf
@@ -66,7 +66,7 @@ variable "hana_data_disk_type" {
 variable "hana_data_disk_size" {
   description = "Disk size of the data volume"
   type        = string
-  default     = "256"
+  default     = "350"
 }
 
 variable "hana_log_disk_type" {

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -197,7 +197,19 @@ variable "hana_data_disk_type" {
 variable "hana_data_disk_size" {
   description = "Disk size of the disks used to store hana database content"
   type        = string
-  default     = "896"
+  default     = "350"
+}
+
+variable "hana_log_disk_type" {
+  description = "Disk type of the disks used to store hana log"
+  type        = string
+  default     = "pd-ssd"
+}
+
+variable "hana_log_disk_size" {
+  description = "Disk size of the disks used to store hana log"
+  type        = string
+  default     = "128"
 }
 
 variable "hana_backup_disk_type" {


### PR DESCRIPTION
Add a GCP top level variable `hana_log_disk_type` and `hana_log_disk_size`. Now both _log_ and _data_ has the same configuration level.
Change the disk default, to have same default in the top level variable and in the HANA module variable. Both are accordingly to the reccomendation in the tfvars.example

Ticket: [TEAM-7761](https://jira.suse.com/browse/TEAM-7761)

