### PR TITLE
Add two targets to run KICS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 # Flake8 codes:
 # E501 line too long (XX > 79 characters)
 
+base_dir := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
 all: static test
 
 static: static-bash static-py static-ansible
@@ -28,6 +30,12 @@ static-ansible-syntax:
 
 static-ansible-lint:
 	@ansible-lint ansible/
+
+static-ansible-kics:
+	@podman run -t -v $(base_dir)/ansible:/path -v $(base_dir):/kics --env DISABLE_CRASH_REPORT=0  checkmarx/kics:v1.6.14 scan -p /path -o "/path/" --config /kics/kics-config.json
+
+static-terraform-kics:
+	@podman run -t -v $(base_dir)/terraform:/path -v $(base_dir):/kics --env DISABLE_CRASH_REPORT=0  checkmarx/kics:v1.6.14 scan -p /path -o "/path/" --config /kics/kics-config.json
 
 static-ansible: static-ansible-yaml static-ansible-lint static-ansible-syntax
 

--- a/kics-config.json
+++ b/kics-config.json
@@ -1,0 +1,8 @@
+{
+  "exclude-queries": "b3de4e4c-14be-4159-b99d-9ad194365e4c,5a2486aa-facf-477d-a5c1-b010789459ce",
+  "exclude-paths": [
+     "*/azure/terraform.tfvars",
+     "*/aws/terraform.tfvars",
+     "*/gcp/terraform.tfvars",
+  ],
+}


### PR DESCRIPTION
Add two optional targets to the main Makefile to run KICS on Ansible and Terraform separately. Add a configuration file and some error suppression about public IPs.

Ticket: [TEAM-7231](https://jira.suse.com/browse/TEAM-7231)