### PR TITLE
Make reboot timeout configurable

### DIFF
--- a/ansible/playbooks/sap-hana-preconfigure.yaml
+++ b/ansible/playbooks/sap-hana-preconfigure.yaml
@@ -7,6 +7,7 @@
   vars:
     scale_out: false
     use_sapconf: false
+    use_reboottimeout: 600
     saptune_solution: HANA
     platform: azure
     cluster_node: true
@@ -100,6 +101,10 @@
       ansible.builtin.include_tasks: ./tasks/saptune.yaml
       when: not use_sapconf | bool
 
+
+   # https://docs.ansible.com/ansible/latest/collections/ansible/builtin/reboot_module.html#parameters
+   # reboot_timeout Maximum seconds to wait for machine to reboot and respond to a test command.  Default: 600
   handlers:
     - name: Reboot
       ansible.builtin.reboot:
+        reboot_timeout: "{{ use_reboottimeout | int }}"


### PR DESCRIPTION
Increase Timeout from Default 600 to 900 to overcome the reboot timeout failures in deployments   
REBOOT_TIMEOUT: 900
 - preconfigure.yaml -e use_sapconf=${SAPCONF} -e use_reboottimeout=${REBOOT_TIMEOUT}

Ticket[TEAM-6829](https://jira.suse.com/browse/TEAM-6829)

VR link on Azure: http://openqaworker15.qa.suse.cz/tests/179777
http://openqaworker15.qa.suse.cz/tests/179786
