### PR TITLE
Fix for Azure is detecting aws ecxx in QESAP deployment ansible along with the Azure.

### DIFF
--- a/ansible/playbooks/tasks/detect-cloud-platform.yaml
+++ b/ansible/playbooks/tasks/detect-cloud-platform.yaml
@@ -17,33 +17,26 @@
       failed_when: false
       register: probe_aws
 
-    - name: "Probe for AWS 1"
-      become: true
-      become_user: root
-      ansible.builtin.command: dmidecode --string system-uuid  # | grep -iq "EC2"
-      changed_when: false
-      failed_when: false
-      register: probe_aws_1
 
-    - name: "Probe for AWS 2"
+    - name: "Probe for AWS 1"
       become: true
       become_user: root
       ansible.builtin.command: dmidecode -s bios-version  # | grep -iq "Amazon"
       changed_when: false
       failed_when: false
-      register: probe_aws_2
+      register: probe_aws_1
 
     - name: Set AWS machine type fact
       ansible.builtin.set_fact:
           aws_machine_type: true
-      when: probe_aws_2.stdout is match(".*amazon")
+      when: probe_aws_1.stdout is match(".*amazon")
 
     - name: Set AWS discovery fact
       ansible.builtin.set_fact:
         cloud_platform_is_aws: true
       when:
         - probe_aws.rc == 0
-        - probe_aws.stdout | lower == 'amazon ec2' or probe_aws_1.stdout is match("ec.*") or probe_aws_2.stdout is match(".*amazon") 
+        - probe_aws.stdout | lower == 'amazon ec2'  or probe_aws_1.stdout is match(".*amazon") 
 
 # SEE: https://stackoverflow.com/questions/30911775/how-to-know-if-a-machine-is-an-google-compute-engine-instance
 - name: "Detect GCP"


### PR DESCRIPTION
Detect-cloud-platform.yaml is implemented to have one Dmidecode of aws has been identified by azure in qesap deployment ansible code.
Removed below lines to avoid ambiguity

ansible.builtin.command: dmidecode --string system-uuid 
probe_aws_1.stdout is match("ec.*")

[TEAM-7993](https://jira.suse.com/browse/TEAM-7993)

Verification Links:

Azure saptune: http://openqaworker15.qa.suse.cz/tests/180426
Azure sapconf : http://openqaworker15.qa.suse.cz/tests/180427
GCP : http://openqaworker15.qa.suse.cz/tests/180428

AWS: http://openqaworker15.qa.suse.cz/tests/180429
http://openqaworker15.qa.suse.cz/tests/180430
http://openqaworker15.qa.suse.cz/tests/180431
http://openqaworker15.qa.suse.cz/tests/180432
http://openqaworker15.qa.suse.cz/tests/180433

