### PR TITLE
Relax gcc package version requirements

### DIFF
--- a/ansible/playbooks/sap-hana-preconfigure.yaml
+++ b/ansible/playbooks/sap-hana-preconfigure.yaml
@@ -58,35 +58,17 @@
       retries: 3
       delay: 60
 
-    - name: Ensure minimum version of GCC10 are installed on SLE 15-SP[123]
+    - name: Ensure minimum version of GCC10 are installed on SLE 15
       community.general.zypper:
         name: "{{ item }}"
         state: present
         oldpackage: true
       loop:
-        - 'libgcc_s1=10.2.1+git583-1.3.4'
-        - 'libstdc++6=10.2.1+git583-1.3.4'
-        - 'libatomic1=10.2.1+git583-1.3.4'
+        - 'libgcc_s1>=10.2.1'
+        - 'libstdc++6>=10.2.1'
+        - 'libatomic1>=10.2.1'
       when:
-        - ansible_facts['distribution_version'] == '15.1' or
-          ansible_facts['distribution_version'] == '15.2' or
-          ansible_facts['distribution_version'] == '15.3'
-      register: result
-      until: result is succeeded
-      retries: 3
-      delay: 60
-
-    - name: Ensure minimum version of GCC10 are installed on SLE 15-SP4
-      community.general.zypper:
-        name: "{{ item }}"
-        state: present
-        oldpackage: true
-      loop:
-        - 'libgcc_s1=11.2.1+git610-150000.1.6.6'
-        - 'libstdc++6=11.2.1+git610-150000.1.6.6'
-        - 'libatomic1=11.2.1+git610-150000.1.6.6'
-      when:
-        - ansible_facts['distribution_version'] == '15.4'
+        - ansible_distribution_major_version == '15'
       register: result
       until: result is succeeded
       retries: 3


### PR DESCRIPTION
SAP HANA needs some gcc packages. Relax the requirement for all sp in SLES15.

Ticket [TEAM-8051](https://jira.suse.com/browse/TEAM-8051)

# Verification:

## Azure
- SLES 12sp5 http://openqaworker15.qa.suse.cz/tests/187306 :heavy_check_mark:
- SLES 15sp4 http://openqaworker15.qa.suse.cz/tests/187305 :heavy_check_mark:
- SLES 15sp5 http://openqaworker15.qa.suse.cz/tests/187307 :heavy_check_mark:

## AWS:
- SLES 12sp5 http://openqaworker15.qa.suse.cz/tests/187308 :heavy_check_mark:
- SLES 15sp4 http://openqaworker15.qa.suse.cz/tests/187303 :heavy_check_mark:
- SLES 15sp5 http://openqaworker15.qa.suse.cz/tests/187311 :heavy_check_mark:

## GCP:
- SLES 12sp5 http://openqaworker15.qa.suse.cz/tests/187310  https://openqaworker15.qa.suse.cz/tests/187767 https://openqaworker15.qa.suse.cz/tests/187770
- SLES 15sp4 http://openqaworker15.qa.suse.cz/tests/187309  https://openqaworker15.qa.suse.cz/tests/187768 http://openqaworker15.qa.suse.cz/tests/187771

