### PR TITLE
Fix resource ip not starting

### DIFF
--- a/ansible/playbooks/tasks/azure-cluster-hana.yaml
+++ b/ansible/playbooks/tasks/azure-cluster-hana.yaml
@@ -60,7 +60,7 @@
 
 - name: Create IP resource
   # TODO - IP address is hardcoded here, that's not good and will only work when the VIP perfectly matches.
-  ansible.builtin.command: "crm configure primitive rsc_ip_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }} ocf:heartbeat:IPaddr2 meta target-role=\"Started\" operations $id=\"rsc_ip_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}-operations\" op monitor interval=\"10s\" timeout=\"20s\" params ip=\"10.10.1.12\""
+  ansible.builtin.command: "crm configure primitive rsc_ip_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }} ocf:heartbeat:IPaddr2 meta target-role=\"Started\" operations $id=\"rsc_ip_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}-operations\" op monitor interval=\"10s\" timeout=\"20s\" params ip=\"{{ cluster_ip }}\""
   when: ip_resource | length == 0
 
 - name: Create socat resource

--- a/terraform/azure/inventory.tmpl
+++ b/terraform/azure/inventory.tmpl
@@ -1,4 +1,6 @@
 all:
+  vars:
+    cluster_ip: ${cluster_ip}
   children:
     hana:
       hosts:

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -26,6 +26,7 @@ locals {
   hana_majority_maker_ip     = var.hana_majority_maker_ip != "" ? var.hana_majority_maker_ip : cidrhost(local.subnet_address_range, local.hana_ip_start - 1)
   hana_cluster_vip           = var.hana_cluster_vip != "" ? var.hana_cluster_vip : cidrhost(local.subnet_address_range, var.hana_count + local.hana_ip_start)
   hana_cluster_vip_secondary = var.hana_cluster_vip_secondary != "" ? var.hana_cluster_vip_secondary : cidrhost(local.subnet_address_range, var.hana_count + local.hana_ip_start + 1)
+  cluster_ip                 = var.cluster_ip != "" ? var.cluster_ip : cidrhost(local.subnet_address_range, var.hana_count + local.hana_ip_start + 2)
 
   drbd_ip_start    = 6
   drbd_ips         = length(var.drbd_ips) != 0 ? var.drbd_ips : [for ip_index in range(local.drbd_ip_start, local.drbd_ip_start + 2) : cidrhost(local.subnet_address_range, ip_index)]

--- a/terraform/azure/outputs.tf
+++ b/terraform/azure/outputs.tf
@@ -100,6 +100,7 @@ resource "local_file" "ansible_inventory" {
     {
       hana-name           = module.hana_node.hana_name,
       hana-pip            = module.hana_node.hana_public_ip,
+      cluster_ip          = local.cluster_ip,
       hana-remote-python  = var.hana_remote_python,
       iscsi-name          = module.iscsi_server.iscsisrv_name,
       iscsi-pip           = module.iscsi_server.iscsisrv_public_ip,

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -273,6 +273,18 @@ variable "hana_ips" {
   }
 }
 
+variable "cluster_ip" {
+  description = "Cluster alias ip. If it's not set the address will be auto generated from the provided vnet address range"
+  type        = string
+  default     = ""
+  validation {
+    condition = (
+      var.cluster_ip == "" || can(regex("^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$", var.cluster_ip))
+    )
+    error_message = "Invalid IP address format."
+  }
+}
+
 variable "hana_majority_maker_ip" {
   description = "ip address to set to the HANA Majority Maker node. If it's not set the addresses will be auto generated from the provided vnet address range"
   type        = string


### PR DESCRIPTION
This pr makes sure `rsc_ip` is created dynamically together with the hana ips. 
In case the user provides custom ips manually, they should make sure to provide a suitable `rsc_ip` as well.

- Related ticket: https://jira.suse.com/browse/TEAM-8069
- Verification Run: http://openqaworker15.qa.suse.cz/tests/195928#step/deploy_qesap_ansible/85