### PR TITLE
Fix non-fatal registration failure

### DIFF
--- a/ansible/playbooks/registration.yaml
+++ b/ansible/playbooks/registration.yaml
@@ -40,6 +40,7 @@
     - name: registercloudguest registration
       ansible.builtin.command: registercloudguest --force-new -r "{{ reg_code }}" -e "{{ email_address }}"
       register: result
+      failed_when: result.rc != 0
       until: result is succeeded
       retries: 10
       delay: 60


### PR DESCRIPTION
The task `registercloudguest registration` does not fail if the return code is not 0, but we would like it to do so. So this pr adds a failure condition, when the return code is not 0.

- Related ticket: https://jira.suse.com/browse/TEAM-7349
- Verification run: 
-- without this pr: http://openqaworker15.qa.suse.cz/tests/201961
-- with this pr: http://openqaworker15.qa.suse.cz/tests/201960