### PR TITLE
Manage roles path from the conf.yaml

### DIFF
--- a/scripts/qesap/lib/cmds.py
+++ b/scripts/qesap/lib/cmds.py
@@ -291,6 +291,8 @@ def ansible_command_sequence(configure_data_ansible, base_project, sequence, ver
     original_env['ANSIBLE_PIPELINING'] = 'True'
     if profile:
         original_env['ANSIBLE_CALLBACK_WHITELIST'] = 'ansible.posix.profile_tasks'
+    if 'roles_path' in configure_data_ansible:
+        original_env['ANSIBLE_ROLES_PATH'] = configure_data_ansible['roles_path']
 
     for playbook in configure_data_ansible[sequence]:
         ansible_cmd = ansible_common.copy()

--- a/scripts/qesap/pylint.rc
+++ b/scripts/qesap/pylint.rc
@@ -214,8 +214,8 @@ min-public-methods=2
 [EXCEPTIONS]
 
 # Exceptions that will emit a warning when caught.
-overgeneral-exceptions=BaseException,
-                       Exception
+#overgeneral-exceptions=BaseException,
+#                       Exception
 
 
 [FORMAT]


### PR DESCRIPTION
It is about a new conf.yaml feature to be able to specify an external roles path.

Ticket: [TEAM-8142](https://jira.suse.com/browse/TEAM-8142)

Verified locally with `conf.yaml` like

```
provider: azure
apiver: 3
terraform:
...
ansible:
...
  roles_path: 'community.sles-for-sap/roles'
  create:
    - registration_role.yaml -e reg_code=${REG_CODE} -e email_address=${EMAIL}
```