### PR TITLE
Deploy valid images past their deprecation time

### DIFF
--- a/terraform/aws/modules/get_os_image/main.tf
+++ b/terraform/aws/modules/get_os_image/main.tf
@@ -1,7 +1,8 @@
 # Data used to get the correct AMI image
 data "aws_ami" "image" {
-  most_recent = true
-  owners      = [var.os_owner]
+  most_recent        = true
+  owners             = [var.os_owner]
+  include_deprecated = true
 
   filter {
     name   = "name"
@@ -21,5 +22,10 @@ data "aws_ami" "image" {
   filter {
     name   = "virtualization-type"
     values = ["hvm"]
+  }
+
+  filter {
+    name   = "state"
+    values = ["available"]
   }
 }

--- a/terraform/aws/version.tf
+++ b/terraform/aws/version.tf
@@ -4,11 +4,11 @@ terraform {
     # Configure the Azure Provider
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0.0"
+      version = "~> 5.14.0"
     }
     null = {
       source  = "hashicorp/null"
-      version = "~> 3.1.0"
+      version = "~> 3.2.1"
     }
   }
 }


### PR DESCRIPTION
Deploy valid images past their deprecation time.

Related ticket:
  [TEAM-8177](https://jira.suse.com/browse/TEAM-8177) - [AWS][Terraform] qe-sap-deployment cannot deploy valid images past their DeprecationTime

**VRs (all as expected):**

1. VRs of 15sp3:
1.1 VRs of "mr_test" using **os_image = "suse-sles-sap-15-sp3-byos-*"**:   
1.1.1 **Inactive** image
        https://openqaworker15.qa.suse.cz/tests/217667 (passed on qesap_terraform)    
1.1.2  **Deprecated** image 
        https://openqaworker15.qa.suse.cz/tests/217946 (passed on qesap_terraform)  
1.1.3 **Deprecated** image  
        https://openqaworker15.qa.suse.cz/tests/217947#step/qesap_terraform/142 (passed on qesap_terraform) 
1.2 VRs of "SAPHanaSR-ScaleUp-PerfOpt" using **os_image = "ami-*"** accordingly:
      1.2.1 https://openqaworker15.qa.suse.cz/tests/217668 (passed on qesap_terraform) 
      1.2.2 https://openqaworker15.qa.suse.cz/tests/217945 (passed on qesap_terraform) 
      1.2.3 https://openqaworker15.qa.suse.cz/tests/217950# (passed on qesap_terraform)
2. VRs of 15sp2 (by default Settings, **inactive** images, all passed on qesap_terraform):
  https://openqaworker15.qa.suse.cz/tests/217954
  https://openqaworker15.qa.suse.cz/tests/217955
3. VRs of 15sp1 (by default Settings, **inactive** images, all passed on qesap_terraform):
    https://openqaworker15.qa.suse.cz/tests/217960
    https://openqaworker15.qa.suse.cz/tests/217961

**FYI, the 15sp3 images info used in the test VRs:**
[ 
$ aws ec2 describe-images --region eu-central-1  --filters '[{"Name": "state", "Values": ["available"]}, {"Name": "name", "Values": ["suse-sles-sap-15-sp3-byos-*"]}, {"Name": "image-id", "Values": ["*"]}]' --include-deprecated --owners aws-marketplac
e | grep -E -i "imageid|location|depre|state"     
                                                                                             
    "ImageId": "ami-0331c808bb33c6595",  
    "ImageLocation": "aws-marketplace/suse-sles-sap-15-sp3-byos-v20220418-hvm-ssd-x86_64-*",   
    "State": "available",  
    "DeprecationTime": "2022-09-30T08:40:00.000Z"  
  
    "ImageId": "ami-00cc4c1ada575a1d0",  
    "ImageLocation": "aws-marketplace/suse-sles-sap-15-sp3-byos-v20220719-hvm-ssd-x86_64-*",  
    "State": "available",  
    "DeprecationTime": "2022-12-16T13:14:00.000Z"  
  
    "ImageId": "ami-0140b01979a357b11",  
    "ImageLocation": "aws-marketplace/suse-sles-sap-15-sp3-byos-v20221108-hvm-ssd-x86_64-*",  
    "State": "available",  
    "DeprecationTime": "2023-06-21T18:37:00.000Z"  
]