### PR TITLE
WIP: Fix failing registration task

### DIFF
--- a/ansible/playbooks/registration.yaml
+++ b/ansible/playbooks/registration.yaml
@@ -43,6 +43,7 @@
       until: result is succeeded
       retries: 10
       delay: 60
+      failed_when: result.rc != 0 or result.stderr != ""
       when:
         - not_registered_found
         - rcg.rc == 0


### PR DESCRIPTION
The registration task (with registercloudguest) sometimes fails without returning a non-zero return code. I can't replicate this by providing a wrong code, but it may be happening if the command and code are correct, and the problem lies elsewhere (i.e. server connection problems or similar). This is just a hypothesis, but the effect has been seen (for example: https://openqaworker15.qa.suse.cz/tests/225386, look at the registration task in the ansible log for vmhana02 and vmiscsi).

This pr adds an additional check, so that if the rc is 0 but there's output in stderr, the test still fails in registration, instead of moving on to next tasks.

- Related Ticket: https://jira.suse.com/browse/TEAM-8533
- Verification Runs:
-- Wrong code (it fails due to `rc` correctly being `!= 1`, but should also fail in the case `rc==0 && stderr!=""`): http://openqaworker15.qa.suse.cz/tests/229032
- Correct code (job executes as expected): http://openqaworker15.qa.suse.cz/tests/229032