### PR TITLE
Add fully patch system ansible playbook module

### DIFF
--- a/ansible/playbooks/fully-patch-system.yaml
+++ b/ansible/playbooks/fully-patch-system.yaml
@@ -1,0 +1,20 @@
+---
+- hosts: all
+  remote_user: cloudadmin
+  become: true
+  become_user: root
+  vars:
+    use_reboottimeout: 600
+
+  tasks:
+    # Fully patch system
+    - name: Apply all available patches
+      community.general.zypper:
+        name: '*'
+        state: latest
+        type: patch
+
+  handlers:
+    - name: Reboot
+      ansible.builtin.reboot:
+        reboot_timeout: "{{ use_reboottimeout | int }}"


### PR DESCRIPTION
Add fully patch system before test start on public cloud qe-sap-deployment

Related ticket:  
  TEAM-8437 - [qesap-deployment] Fully patch system before test start  

VRs:   (see deploy_qesap_ansible-qesap_exec_ansible.log.txt file for the execution of this new added playbook)
1. sle-15-SP2-HanaSr-Azure-Byos: hanasr_azure_test
    https://openqaworker15.qa.suse.cz/tests/229811 (passed, (02:02 hours))
2. sle-15-SP4-HanaSr-Aws-Byos: hanasr_aws_test_saptune
    http://openqaworker15.qa.suse.cz/t229807 (Command "sudo SAPHanaSR-showAttr" passed)
    (The "Fenced database 'vmhana01' is not offline" failure is a known issue)
3. sle-15-SP4-Azure-SAP-BYOS: SAPHanaSR-ScaleUp-PerfOpt
    https://openqaworker15.qa.suse.cz/tests/229815 (passed)
