### PR TITLE
Replace azurerm vm with azurerm_linux

### DIFF
--- a/terraform/azure/.terraform.lock.hcl
+++ b/terraform/azure/.terraform.lock.hcl
@@ -1,0 +1,61 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "3.13.0"
+  constraints = "~> 3.13.0"
+  hashes = [
+    "h1:QDGy5z0n7Gam3iOCupFSSwF0pXUgTAdrhgcn3494kkw=",
+    "zh:18ea578ac352576617622b15fdc7e55db774c5b60fbca7d93da45d06d481023a",
+    "zh:1a7dd9ddada3d313f142a4672bd270fd6d23dfc6f5df3439b9d3a32fa4fc3e14",
+    "zh:3b461f72f11d37a5bc88a7784864b7373c1f93052abfe1436d37458c4bc7d9e4",
+    "zh:437aa69ca2d6e2a55a820b08402f01150da46e709b1cd4577b32bf1baebf0376",
+    "zh:4661e4870639c3631e91197d60c1a5c686ece0b57503ba7928e7d4185e42a71b",
+    "zh:5a7024bfd699d000b2e8f32b40e34fe55918d76898d4e8e3aff0be7d3b7831bb",
+    "zh:98848fe6b267c53dcb43e3397dc13c42bd6e03bab11a32118c92af1b95a001fc",
+    "zh:9da068415051d85790901b480816c22f0179ae05af190c74128851ec904ff4ea",
+    "zh:a65da710ff90a51072fb413fbb359abb306a40b509ef1927996ee5665e63f904",
+    "zh:ae63252294086b2e0bcc7d9a8f4e5734060d719188f21d7c66a16a5df93745aa",
+    "zh:d6444098adffd49d18714b6b3d218914213f2cf52b2d558821bd0f302453ac4d",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.2.3"
+  hashes = [
+    "h1:FvRIEgCmAezgZUqb2F+PZ9WnSSnR5zbEM2ZI+GLmbMk=",
+    "zh:04f0978bb3e052707b8e82e46780c371ac1c66b689b4a23bbc2f58865ab7d5c0",
+    "zh:6484f1b3e9e3771eb7cc8e8bab8b35f939a55d550b3f4fb2ab141a24269ee6aa",
+    "zh:78a56d59a013cb0f7eb1c92815d6eb5cf07f8b5f0ae20b96d049e73db915b238",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8aa9950f4c4db37239bcb62e19910c49e47043f6c8587e5b0396619923657797",
+    "zh:996beea85f9084a725ff0e6473a4594deb5266727c5f56e9c1c7c62ded6addbb",
+    "zh:9a7ef7a21f48fabfd145b2e2a4240ca57517ad155017e86a30860d7c0c109de3",
+    "zh:a63e70ac052aa25120113bcddd50c1f3cfe61f681a93a50cea5595a4b2cc3e1c",
+    "zh:a6e8d46f94108e049ad85dbed60354236dc0b9b5ec8eabe01c4580280a43d3b8",
+    "zh:bb112ce7efbfcfa0e65ed97fa245ef348e0fd5bfa5a7e4ab2091a9bd469f0a9e",
+    "zh:d7bec0da5c094c6955efed100f3fe22fca8866859f87c025be1760feb174d6d9",
+    "zh:fb9f271b72094d07cef8154cd3d50e9aa818a0ea39130bc193132ad7b23076fd",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.1.1"
+  constraints = "~> 3.1.0"
+  hashes = [
+    "h1:YvH6gTaQzGdNv+SKTZujU1O0bO+Pw6vJHOPhqgN8XNs=",
+    "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
+    "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",
+    "zh:73ce6dff935150d6ddc6ac4a10071e02647d10175c173cfe5dca81f3d13d8afe",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8fdd792a626413502e68c195f2097352bdc6a0df694f7df350ed784741eb587e",
+    "zh:976bbaf268cb497400fd5b3c774d218f3933271864345f18deebe4dcbfcd6afa",
+    "zh:b21b78ca581f98f4cdb7a366b03ae9db23a73dfa7df12c533d7c19b68e9e72e5",
+    "zh:b7fc0c1615dbdb1d6fd4abb9c7dc7da286631f7ca2299fb9cd4664258ccfbff4",
+    "zh:d1efc942b2c44345e0c29bc976594cb7278c38cfb8897b344669eafbc3cddf46",
+    "zh:e356c245b3cd9d4789bab010893566acace682d7db877e52d40fc4ca34a50924",
+    "zh:ea98802ba92fcfa8cf12cbce2e9e7ebe999afbf8ed47fa45fc847a098d89468b",
+    "zh:eff8872458806499889f6927b5d954560f3d74bf20b6043409edf94d26cd906f",
+  ]
+}

--- a/terraform/azure/modules/drbd_node/outputs.tf
+++ b/terraform/azure/modules/drbd_node/outputs.tf
@@ -1,17 +1,17 @@
 data "azurerm_public_ip" "drbd" {
   count               = var.drbd_count
   name                = element(azurerm_public_ip.drbd.*.name, count.index)
-  resource_group_name = element(azurerm_virtual_machine.drbd.*.resource_group_name, count.index)
+  resource_group_name = element(azurerm_linux_virtual_machine.drbd.*.resource_group_name, count.index)
   # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476
-  depends_on = [azurerm_virtual_machine.drbd]
+  depends_on = [azurerm_linux_virtual_machine.drbd]
 }
 
 data "azurerm_network_interface" "drbd" {
   count               = var.drbd_count
   name                = element(azurerm_network_interface.drbd.*.name, count.index)
-  resource_group_name = element(azurerm_virtual_machine.drbd.*.resource_group_name, count.index)
+  resource_group_name = element(azurerm_linux_virtual_machine.drbd.*.resource_group_name, count.index)
   # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476
-  depends_on = [azurerm_virtual_machine.drbd]
+  depends_on = [azurerm_linux_virtual_machine.drbd]
 }
 
 output "drbd_ip" {
@@ -23,7 +23,7 @@ output "drbd_public_ip" {
 }
 
 output "drbd_name" {
-  value = azurerm_virtual_machine.drbd.*.name
+  value = azurerm_linux_virtual_machine.drbd.*.name
 }
 
 output "drbd_public_name" {

--- a/terraform/azure/modules/hana_node/outputs.tf
+++ b/terraform/azure/modules/hana_node/outputs.tf
@@ -1,17 +1,17 @@
 data "azurerm_public_ip" "hana" {
   count               = var.hana_count
   name                = element(azurerm_public_ip.hana.*.name, count.index)
-  resource_group_name = element(azurerm_virtual_machine.hana.*.resource_group_name, count.index)
+  resource_group_name = element(azurerm_linux_virtual_machine.hana.*.resource_group_name, count.index)
   # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476
-  depends_on = [azurerm_virtual_machine.hana]
+  depends_on = [azurerm_linux_virtual_machine.hana]
 }
 
 data "azurerm_network_interface" "hana" {
   count               = var.hana_count
   name                = element(azurerm_network_interface.hana.*.name, count.index)
-  resource_group_name = element(azurerm_virtual_machine.hana.*.resource_group_name, count.index)
+  resource_group_name = element(azurerm_linux_virtual_machine.hana.*.resource_group_name, count.index)
   # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476
-  depends_on = [azurerm_virtual_machine.hana]
+  depends_on = [azurerm_linux_virtual_machine.hana]
 }
 
 output "hana_ip" {
@@ -23,7 +23,7 @@ output "hana_public_ip" {
 }
 
 output "hana_name" {
-  value = azurerm_virtual_machine.hana.*.name
+  value = azurerm_linux_virtual_machine.hana.*.name
 }
 
 output "hana_public_name" {

--- a/terraform/azure/modules/iscsi_server/main.tf
+++ b/terraform/azure/modules/iscsi_server/main.tf
@@ -64,57 +64,60 @@ module "os_image_reference" {
   os_image_srv_uri = var.iscsi_srv_uri != ""
 }
 
-resource "azurerm_virtual_machine" "iscsisrv" {
-  count                            = var.iscsi_count
-  name                             = "${var.name}${format("%02d", count.index + 1)}"
-  location                         = var.az_region
-  resource_group_name              = var.resource_group_name
-  network_interface_ids            = [element(azurerm_network_interface.iscsisrv.*.id, count.index)]
-  vm_size                          = var.vm_size
-  delete_os_disk_on_termination    = true
-  delete_data_disks_on_termination = true
+resource "azurerm_managed_disk" "iscsisrv_data" {
+  count                = var.iscsi_count
+  name                 = "disk-iscsisrv${format("%02d", count.index + 1)}-Data01"
+  location             = var.az_region
+  resource_group_name  = var.resource_group_name
+  storage_account_type = "StandardSSD_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = var.iscsi_disk_size
+}
 
-  storage_os_disk {
-    name              = "disk-iscsisrv${format("%02d", count.index + 1)}-Os"
-    caching           = "ReadWrite"
-    create_option     = "FromImage"
-    managed_disk_type = "Premium_LRS"
+resource "azurerm_virtual_machine_data_disk_attachment" "iscsisrv_data" {
+  count              = var.iscsi_count
+  managed_disk_id    = azurerm_managed_disk.iscsisrv_data[count.index].id
+  virtual_machine_id = azurerm_linux_virtual_machine.iscsisrv[count.index].id
+  lun                = 0
+  caching            = "ReadWrite"
+}
+
+resource "azurerm_linux_virtual_machine" "iscsisrv" {
+  count                 = var.iscsi_count
+  name                  = "${var.name}${format("%02d", count.index + 1)}"
+  location              = var.az_region
+  network_interface_ids = [element(azurerm_network_interface.iscsisrv.*.id, count.index)]
+  resource_group_name   = var.resource_group_name
+  size                  = var.vm_size
+
+  # os_profile replaced with top level arguments in azurerm_linux_virtual_machine
+  admin_username                  = var.common_variables["authorized_user"]
+  disable_password_authentication = true
+  admin_ssh_key {
+    username   = var.common_variables["authorized_user"]
+    public_key = var.common_variables["public_key"]
   }
 
-  storage_image_reference {
-    id        = var.iscsi_srv_uri != "" ? join(",", azurerm_image.iscsi_srv.*.id) : ""
-    publisher = var.iscsi_srv_uri != "" ? "" : module.os_image_reference.publisher
-    offer     = var.iscsi_srv_uri != "" ? "" : module.os_image_reference.offer
-    sku       = var.iscsi_srv_uri != "" ? "" : module.os_image_reference.sku
-    version   = var.iscsi_srv_uri != "" ? "" : module.os_image_reference.version
+  os_disk {
+    name                 = "disk-iscsisrv${format("%02d", count.index + 1)}-Os"
+    caching              = "ReadWrite"
+    storage_account_type = "Premium_LRS"
   }
 
-  storage_data_disk {
-    name              = "disk-iscsisrv${format("%02d", count.index + 1)}-Data01"
-    caching           = "ReadWrite"
-    create_option     = "Empty"
-    disk_size_gb      = var.iscsi_disk_size
-    lun               = "0"
-    managed_disk_type = "StandardSSD_LRS"
-  }
-
-  os_profile {
-    computer_name  = "${local.hostname}${format("%02d", count.index + 1)}"
-    admin_username = var.common_variables["authorized_user"]
-  }
-
-  os_profile_linux_config {
-    disable_password_authentication = true
-
-    ssh_keys {
-      path     = "/home/${var.common_variables["authorized_user"]}/.ssh/authorized_keys"
-      key_data = var.common_variables["public_key"]
+  dynamic "source_image_reference" {
+    for_each = var.iscsi_srv_uri != "" ? [] : [1]
+    content {
+      publisher = module.os_image_reference.publisher
+      offer     = module.os_image_reference.offer
+      sku       = module.os_image_reference.sku
+      version   = module.os_image_reference.version
     }
   }
 
+  source_image_id = var.iscsi_srv_uri != "" ? join(",", azurerm_image.iscsi_srv.*.id) : null
+
   boot_diagnostics {
-    enabled     = "true"
-    storage_uri = var.storage_account
+    storage_account_uri = var.storage_account
   }
 
   tags = {

--- a/terraform/azure/modules/iscsi_server/outputs.tf
+++ b/terraform/azure/modules/iscsi_server/outputs.tf
@@ -1,17 +1,17 @@
 data "azurerm_public_ip" "iscsisrv" {
   count               = var.iscsi_count
   name                = element(azurerm_public_ip.iscsisrv.*.name, count.index)
-  resource_group_name = element(azurerm_virtual_machine.iscsisrv.*.resource_group_name, count.index)
+  resource_group_name = element(azurerm_linux_virtual_machine.iscsisrv.*.resource_group_name, count.index)
   # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476
-  depends_on = [azurerm_virtual_machine.iscsisrv]
+  depends_on = [azurerm_linux_virtual_machine.iscsisrv]
 }
 
 data "azurerm_network_interface" "iscsisrv" {
   count               = var.iscsi_count
   name                = element(azurerm_network_interface.iscsisrv.*.name, count.index)
-  resource_group_name = element(azurerm_virtual_machine.iscsisrv.*.resource_group_name, count.index)
+  resource_group_name = element(azurerm_linux_virtual_machine.iscsisrv.*.resource_group_name, count.index)
   # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476
-  depends_on = [azurerm_virtual_machine.iscsisrv]
+  depends_on = [azurerm_linux_virtual_machine.iscsisrv]
 }
 
 output "iscsisrv_ip" {
@@ -23,7 +23,7 @@ output "iscsisrv_public_ip" {
 }
 
 output "iscsisrv_name" {
-  value = azurerm_virtual_machine.iscsisrv.*.name
+  value = azurerm_linux_virtual_machine.iscsisrv.*.name
 }
 
 output "iscsisrv_public_name" {

--- a/terraform/azure/modules/majority_maker_node/outputs.tf
+++ b/terraform/azure/modules/majority_maker_node/outputs.tf
@@ -1,17 +1,17 @@
 data "azurerm_public_ip" "majority_maker" {
   count               = var.node_count
   name                = element(azurerm_public_ip.majority_maker.*.name, count.index)
-  resource_group_name = element(azurerm_virtual_machine.majority_maker.*.resource_group_name, count.index)
+  resource_group_name = element(azurerm_linux_virtual_machine.majority_maker.*.resource_group_name, count.index)
   # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476
-  depends_on = [azurerm_virtual_machine.majority_maker]
+  depends_on = [azurerm_linux_virtual_machine.majority_maker]
 }
 
 data "azurerm_network_interface" "majority_maker" {
   count               = var.node_count
   name                = element(azurerm_network_interface.majority_maker.*.name, count.index)
-  resource_group_name = element(azurerm_virtual_machine.majority_maker.*.resource_group_name, count.index)
+  resource_group_name = element(azurerm_linux_virtual_machine.majority_maker.*.resource_group_name, count.index)
   # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476
-  depends_on = [azurerm_virtual_machine.majority_maker]
+  depends_on = [azurerm_linux_virtual_machine.majority_maker]
 }
 
 output "hana_ip" {
@@ -23,7 +23,7 @@ output "hana_public_ip" {
 }
 
 output "hana_name" {
-  value = [azurerm_virtual_machine.majority_maker.*.name]
+  value = [azurerm_linux_virtual_machine.majority_maker.*.name]
 }
 
 output "hana_public_name" {

--- a/terraform/azure/modules/monitoring/main.tf
+++ b/terraform/azure/modules/monitoring/main.tf
@@ -64,57 +64,59 @@ module "os_image_reference" {
   os_image_srv_uri = var.monitoring_uri != ""
 }
 
-resource "azurerm_virtual_machine" "monitoring" {
-  name                             = var.name
-  count                            = var.monitoring_enabled == true ? 1 : 0
-  location                         = var.az_region
-  resource_group_name              = var.resource_group_name
-  network_interface_ids            = [azurerm_network_interface.monitoring.0.id]
-  vm_size                          = var.vm_size
-  delete_os_disk_on_termination    = true
-  delete_data_disks_on_termination = true
+resource "azurerm_managed_disk" "monitoring_data" {
+  count                = var.monitoring_enabled == true ? 1 : 0
+  name                 = "disk-monitoring-Data01"
+  location             = var.az_region
+  resource_group_name  = var.resource_group_name
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = 10
+}
 
-  storage_os_disk {
-    name              = "disk-monitoring-Os"
-    caching           = "ReadWrite"
-    create_option     = "FromImage"
-    managed_disk_type = "Premium_LRS"
+resource "azurerm_virtual_machine_data_disk_attachment" "monitoring_data" {
+  count              = var.monitoring_enabled == true ? 1 : 0
+  managed_disk_id    = azurerm_managed_disk.monitoring_data[count.index].id
+  virtual_machine_id = azurerm_linux_virtual_machine.monitoring[count.index].id
+  lun                = 0
+  caching            = "ReadWrite"
+}
+
+resource "azurerm_linux_virtual_machine" "monitoring" {
+  name                  = var.name
+  count                 = var.monitoring_enabled == true ? 1 : 0
+  location              = var.az_region
+  network_interface_ids = [azurerm_network_interface.monitoring[0].id]
+  resource_group_name   = var.resource_group_name
+  size                  = var.vm_size
+  # os_profile replaced with top level arguments in azurerm_linux_virtual_machine
+  admin_username                  = var.common_variables["authorized_user"]
+  disable_password_authentication = true
+  admin_ssh_key {
+    username   = var.common_variables["authorized_user"]
+    public_key = var.common_variables["public_key"]
   }
 
-  storage_image_reference {
-    id        = var.monitoring_uri != "" ? azurerm_image.monitoring.0.id : ""
-    publisher = var.monitoring_uri != "" ? "" : module.os_image_reference.publisher
-    offer     = var.monitoring_uri != "" ? "" : module.os_image_reference.offer
-    sku       = var.monitoring_uri != "" ? "" : module.os_image_reference.sku
-    version   = var.monitoring_uri != "" ? "" : module.os_image_reference.version
+  os_disk {
+    name                 = "disk-monitoring-Os"
+    caching              = "ReadWrite"
+    storage_account_type = "Premium_LRS"
   }
 
-  storage_data_disk {
-    name              = "disk-monitoring-Data01"
-    caching           = "ReadWrite"
-    create_option     = "Empty"
-    disk_size_gb      = "10"
-    lun               = "0"
-    managed_disk_type = "Standard_LRS"
-  }
-
-  os_profile {
-    computer_name  = local.hostname
-    admin_username = var.common_variables["authorized_user"]
-  }
-
-  os_profile_linux_config {
-    disable_password_authentication = true
-
-    ssh_keys {
-      path     = "/home/${var.common_variables["authorized_user"]}/.ssh/authorized_keys"
-      key_data = var.common_variables["public_key"]
+  dynamic "source_image_reference" {
+    for_each = var.monitoring_uri != "" ? [] : [1]
+    content {
+      publisher = module.os_image_reference.publisher
+      offer     = module.os_image_reference.offer
+      sku       = module.os_image_reference.sku
+      version   = module.os_image_reference.version
     }
   }
 
+  source_image_id = var.monitoring_uri != "" ? azurerm_image.monitoring.0.id : null
+
   boot_diagnostics {
-    enabled     = "true"
-    storage_uri = var.storage_account
+    storage_account_uri = var.storage_account
   }
 
   tags = {

--- a/terraform/azure/modules/monitoring/outputs.tf
+++ b/terraform/azure/modules/monitoring/outputs.tf
@@ -1,17 +1,17 @@
 data "azurerm_public_ip" "monitoring" {
   count               = var.monitoring_enabled == true ? 1 : 0
   name                = azurerm_public_ip.monitoring.0.name
-  resource_group_name = azurerm_virtual_machine.monitoring.0.resource_group_name
+  resource_group_name = azurerm_linux_virtual_machine.monitoring.0.resource_group_name
   # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476
-  depends_on = [azurerm_virtual_machine.monitoring]
+  depends_on = [azurerm_linux_virtual_machine.monitoring]
 }
 
 data "azurerm_network_interface" "monitoring" {
   count               = var.monitoring_enabled == true ? 1 : 0
   name                = azurerm_network_interface.monitoring.0.name
-  resource_group_name = azurerm_virtual_machine.monitoring.0.resource_group_name
+  resource_group_name = azurerm_linux_virtual_machine.monitoring.0.resource_group_name
   # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476
-  depends_on = [azurerm_virtual_machine.monitoring]
+  depends_on = [azurerm_linux_virtual_machine.monitoring]
 }
 
 output "monitoring_ip" {
@@ -23,7 +23,7 @@ output "monitoring_public_ip" {
 }
 
 output "monitoring_name" {
-  value = join("", azurerm_virtual_machine.monitoring.*.name)
+  value = join("", azurerm_linux_virtual_machine.monitoring.*.name)
 }
 
 output "monitoring_public_name" {

--- a/terraform/azure/modules/netweaver_node/outputs.tf
+++ b/terraform/azure/modules/netweaver_node/outputs.tf
@@ -1,17 +1,17 @@
 data "azurerm_public_ip" "netweaver" {
   count               = local.vm_count
   name                = element(azurerm_public_ip.netweaver.*.name, count.index)
-  resource_group_name = element(azurerm_virtual_machine.netweaver.*.resource_group_name, count.index)
+  resource_group_name = element(azurerm_linux_virtual_machine.netweaver.*.resource_group_name, count.index)
   # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476
-  depends_on = [azurerm_virtual_machine.netweaver]
+  depends_on = [azurerm_linux_virtual_machine.netweaver]
 }
 
 data "azurerm_network_interface" "netweaver" {
   count               = local.vm_count
   name                = element(azurerm_network_interface.netweaver.*.name, count.index)
-  resource_group_name = element(azurerm_virtual_machine.netweaver.*.resource_group_name, count.index)
+  resource_group_name = element(azurerm_linux_virtual_machine.netweaver.*.resource_group_name, count.index)
   # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476
-  depends_on = [azurerm_virtual_machine.netweaver]
+  depends_on = [azurerm_linux_virtual_machine.netweaver]
 }
 
 output "netweaver_ip" {
@@ -23,7 +23,7 @@ output "netweaver_public_ip" {
 }
 
 output "netweaver_name" {
-  value = azurerm_virtual_machine.netweaver.*.name
+  value = azurerm_linux_virtual_machine.netweaver.*.name
 }
 
 output "netweaver_public_name" {

--- a/terraform/azure/version.tf
+++ b/terraform/azure/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Configure the Azure Provider
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.74.0"
+      version = "~> 3.13.0"
     }
     null = {
       source  = "hashicorp/null"
@@ -15,5 +15,9 @@ terraform {
 
 # Configure the Azure Provider
 provider "azurerm" {
-  features {}
+  features {
+    virtual_machine {
+      delete_os_disk_on_deletion = true
+    }
+  }
 }


### PR DESCRIPTION
This pr replaces all cases of `azurerm_virtual_machine`, which is deprecated, with `azurerm_linux_virtual_machine`. The conversion demanded a LOT of other changes as well, as the 2 resources have a lot of differences in the way they define and use their components.

**Some of the differences (they are too many to list all of them) are:**

- Data disks that were defined inside the `azurerm_virtual_machine` resource, now need to be defined as a separate resource together with an attachment resource that binds them to the respective VMs.
- That also lead to changes in the way the names of the disks are calculated, since some of them used VM specific counts. I did the changes with the goal of ending up with the same exact names in the end.
- `vm_size` renamed to `size`
- The `os_profile` and `os_profile_linux_config` blocks are replaced with top-level arguments in `azurerm_linux_virtual_machine`
- `delete_os_disk_on_termination` and `delete_data_disks_on_termination` attributes are removed from the `azurerm_linux_virtual_machine` resource. The first is now moved to provider level and renamed (`provider->features->delete_os_disk_on_deletion`), while the second has disappeared completely (!!) and is no longer doable in terraform. Ricardo said thet pcw takes care of that cleanup
- `boot_diagnostics` changes: `enabled` attribute no longer supported, while `storage_uri` is renamed to `storage_account_uri`
- ... and more.

**LINKS:**
- Related ticket: https://jira.suse.com/browse/TEAM-8424
- Verification Runs: 

**HanaSr-Azure-(BYOS|PAYG):**
15sp3 BYOS:
https://openqaworker15.qa.suse.cz/tests/236441 :green_circle: 

**Qesap-Azure-(BYOS|PAYG)** (failure after deployment expected):
15sp5:
https://openqaworker15.qa.suse.cz/tests/236437 red is later after the deployment and quite like due to TEAM-8442
15sp4:
https://openqaworker15.qa.suse.cz/tests/236439 red is later after the deployment and quite like due to TEAM-8442
12sp5:
https://openqaworker15.qa.suse.cz/tests/237155 :green_circle: 
http://openqaworker15.qa.suse.cz/tests/237156 red is later after the deployment and quite like due to TEAM-8442

**qesap-azure-saptune-uri:**
https://openqa.suse.de/tests/12325535 red is later after the deployment and quite like due to TEAM-8442