### PR TITLE
Enable SPN and MSI based native fencing for azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ ansible:
     - deregister.yaml
 ```
 
+* In case of Azure deployment using native fencing, there are additional parameters to be added for `sap-hana-cluster.yaml` playbook.
+* For details please check ./docs/playbooks/README.md
+
 #### Deploy
 
 Terraform and Ansible deployment steps can be executed like:

--- a/ansible/playbooks/sap-hana-cluster.yaml
+++ b/ansible/playbooks/sap-hana-cluster.yaml
@@ -7,13 +7,11 @@
     # is_primary is selected so that tasks that need to be issued one are honoured correctly
     is_primary: "{{ ansible_play_hosts[0] == inventory_hostname }}"
     primary_hostname: "{{ ansible_play_hosts[0] }}"
-    use_sbd: yes
     # Azure fencing specific vars
-    subscription_id:
-    resource_group:
-    tenant_id:
-    application_id:
-    app_password:
+    azure_identity_management:  # use 'spi' (service principal) or 'msi' (managed identity)
+    # Azure fencing - SPN related variables
+    spn_application_id:
+    spn_application_password:
     # corosync variables
     crypto_hash: sha1
     crypto_cipher: aes256

--- a/ansible/playbooks/tasks/azure-cluster-bootstrap.yaml
+++ b/ansible/playbooks/tasks/azure-cluster-bootstrap.yaml
@@ -216,12 +216,19 @@
     - is_primary
     - crm_maintenance_mode is false or crm_maintenance_mode == 'unknown'
 
-- name: Configure azure fencing
-  ansible.builtin.command: "crm configure primitive rsc_stonith_azure stonith:fence_azure_arm params subscriptionId=\"{{ subscription_id }}\" resourceGroup=\"{{ resource_group }}\" tenantId=\"{{ tenant_id }}\" login=\"{{ application_id }}\" passwd=\"{{ app_password }}\" pcmk_monitor_retries=4 pcmk_action_limit=3 power_timeout=240 pcmk_reboot_timeout=900 op monitor interval=3600 timeout=120"
+- name: Configure azure fencing [MSI (Managed identity)]
+  ansible.builtin.command: "crm configure primitive rsc_stonith_azure stonith:fence_azure_arm params msi=true subscriptionId=\"{{ subscription_id }}\" resourceGroup=\"{{ resource_group_name }}\" tenantId=\"{{ tenant_id }}\" pcmk_monitor_retries=4 pcmk_action_limit=3 power_timeout=240 pcmk_reboot_timeout=900 pcmk_delay_max=15 op monitor interval=3600 timeout=120"
   when:
     - is_primary
     - rsc_st_azure | length == 0
-    - not use_sbd | bool
+    - not use_sbd | bool and azure_identity_management == 'msi'
+
+- name: Configure azure fencing [SPN (Service principal)]
+  ansible.builtin.command: "crm configure primitive rsc_stonith_azure stonith:fence_azure_arm params subscriptionId=\"{{ subscription_id }}\" resourceGroup=\"{{ resource_group_name }}\" tenantId=\"{{ tenant_id }}\" login=\"{{ spn_application_id }}\" passwd=\"{{ spn_application_password }}\" pcmk_monitor_retries=4 pcmk_action_limit=3 power_timeout=240 pcmk_reboot_timeout=900 op monitor interval=3600 timeout=120"
+  when:
+    - is_primary
+    - rsc_st_azure | length == 0
+    - not use_sbd | bool and azure_identity_management == 'spn'
 
 - name: Add Azure scheduled events to cluster
   ansible.builtin.command: crm configure primitive rsc_azure-events ocf:heartbeat:azure-events op monitor interval=10s

--- a/docs/playbooks/README.md
+++ b/docs/playbooks/README.md
@@ -335,13 +335,15 @@ an SBD based cluster will be created.
 To use Azure native fencing you must:
 
 * Be using the azure provider in terraform
-* Set the variable `use_sbd` to 'no'
-* Provide the following variables:
-  * subscription_id:
-  * resource_group:
-  * tenant_id:
-  * application_id:
-  * app_password:
+* **Provide the following variables:**
+  * identity_management - 'msi' or 'spn'
+  * spn_application_id - SPN fencing app id
+  * spn_application_password - Password used for SPN based fencing
+* **Variables below are provided by terraform output:**
+  * use_sbd - has to be set to 'no'
+  * subscription_id
+  * resource_group
+  * tenant_id
 
 The five additional variables all relate to the SAP fencing application
 that needs to be created. At this point, the creation of the fencing

--- a/terraform/azure/fence_data.tmpl
+++ b/terraform/azure/fence_data.tmpl
@@ -1,5 +1,0 @@
-{
-  "resource_group_name" : "${resource_group_name}",
-  "subscription_id" : "${subscription_id}",
-  "tenant_id": "${tenant_id}"
-}

--- a/terraform/azure/inventory.tmpl
+++ b/terraform/azure/inventory.tmpl
@@ -1,7 +1,10 @@
 all:
   vars:
-    cluster_ip: ${cluster_ip}
     use_sbd: ${use_sbd}
+    resource_group_name: ${resource_group_name}
+    subscription_id: ${subscription_id}
+    tenant_id: ${tenant_id}
+    cluster_ip: ${cluster_ip}
   children:
     hana:
       hosts:

--- a/terraform/azure/outputs.tf
+++ b/terraform/azure/outputs.tf
@@ -107,16 +107,9 @@ resource "local_file" "ansible_inventory" {
       iscsi_enabled       = local.iscsi_enabled,
       iscsi_remote_python = var.iscsi_remote_python
       use_sbd             = local.use_sbd
-  })
-  filename = "inventory.yaml"
-}
-
-resource "local_file" "fence_data" {
-  content = templatefile("fence_data.tmpl",
-    {
       resource_group_name = local.resource_group_name
       subscription_id     = data.azurerm_subscription.current.subscription_id
       tenant_id           = data.azurerm_subscription.current.tenant_id
   })
-  filename = "fence_data.json"
+  filename = "inventory.yaml"
 }


### PR DESCRIPTION
This PR enables usage of native fencing for azure using both SPN and MSI based 
setup. Setup type is defined by parameter 'identity_management' with MSI being 
default option. There are still manual steps required for native fencing to be 
working, like enabling managed indetity and assigning roles. For details check: 
https://learn.microsoft.com/en-us/azure/sap/workloads/high-availability-guide-
suse-pacemaker#use-an-azure-fence-agent-1 

Tickets:
https://jira.suse.com/browse/TEAM-8632
https://jira.suse.com/browse/TEAM-8631

VR: 
SPN setup:
https://openqaworker15.qa.suse.cz/tests/248629#step/Verify_azure_fence_agent_(SPN)/48

MSI setup:
https://openqaworker15.qa.suse.cz/tests/248626#step/Verify_azure_fence_agent_(MSI)/40

SBD setup:
https://openqaworker15.qa.suse.cz/tests/248623#step/Stop_site_a-primary/8

QESAP-regression - SBD based:
* Test failed because other issue. On the link below you can see that the deployment took the correct road and created SBD related resources
https://openqaworker15.qa.suse.cz/tests/248630#step/test_cluster/122