### PR TITLE
Pass use_sbd from Terraform to Ansible

### DIFF
--- a/terraform/aws/inventory.tmpl
+++ b/terraform/aws/inventory.tmpl
@@ -1,4 +1,6 @@
 all:
+  vars:
+    use_sbd: ${use_sbd}
   children:
     hana:
       hosts:

--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -105,6 +105,7 @@ resource "local_file" "ansible_inventory" {
       iscsi-pip           = module.iscsi_server.iscsisrv_public_ip,
       iscsi-enabled       = local.iscsi_enabled,
       iscsi-remote-python = var.iscsi_remote_python
+      use_sbd             = local.use_sbd
   })
   filename = "inventory.yaml"
 }

--- a/terraform/azure/inventory.tmpl
+++ b/terraform/azure/inventory.tmpl
@@ -1,6 +1,7 @@
 all:
   vars:
     cluster_ip: ${cluster_ip}
+    use_sbd: ${use_sbd}
   children:
     hana:
       hosts:

--- a/terraform/azure/outputs.tf
+++ b/terraform/azure/outputs.tf
@@ -106,6 +106,7 @@ resource "local_file" "ansible_inventory" {
       iscsi-pip           = module.iscsi_server.iscsisrv_public_ip,
       iscsi-enabled       = local.iscsi_enabled,
       iscsi-remote-python = var.iscsi_remote_python
+      use_sbd             = local.use_sbd
   })
   filename = "inventory.yaml"
 }

--- a/terraform/gcp/inventory.tmpl
+++ b/terraform/gcp/inventory.tmpl
@@ -1,4 +1,6 @@
 all:
+  vars:
+    use_sbd: ${use_sbd}
   children:
     hana:
       hosts:

--- a/terraform/gcp/outputs.tf
+++ b/terraform/gcp/outputs.tf
@@ -107,6 +107,7 @@ resource "local_file" "ansible_inventory" {
       iscsi-pip           = module.iscsi_server.iscsisrv_public_ip,
       iscsi-enabled       = local.iscsi_enabled,
       iscsi-remote-python = var.iscsi_remote_python
+      use_sbd             = local.use_sbd
   })
   filename = "inventory.yaml"
 }


### PR DESCRIPTION
Record calculated Terraform local value `use_sbd` as variable in the Ansible inventory.
Try to apply more consistent naming convention in inventory variables names.

It can helps [TEAM-8672](https://jira.suse.com/browse/TEAM-8672) and Azure fencing PR https://github.com/SUSE/qe-sap-deployment/pull/180

## Azure configured for sbd
 - sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_sapconf_test@64bit -> http://openqaworker15.qa.suse.cz/tests/246058

The generated [inventory.yaml](http://openqaworker15.qa.suse.cz/tests/246058/file/deploy-inventory.yaml) has `use_sbd: true`. In the [Ansible log](http://openqaworker15.qa.suse.cz/tests/246058/file/deploy-qesap_exec_ansible__profile.log.txt) ...

## AWS configured for native fencing
- sle-15-SP5-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_5_BYOS-qesap_aws_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/246059

The generated [inventory.yaml](http://openqaworker15.qa.suse.cz/tests/246059/file/deploy-inventory.yaml) has `use_sbd: false`. In the [Ansible log](http://openqaworker15.qa.suse.cz/tests/246059/file/deploy-qesap_exec_ansible__profile.log.txt)  ...

After the deployment, [crm status](http://openqaworker15.qa.suse.cz/tests/246059/logfile?filename=serial_terminal.txt)

```
Status of pacemakerd: 'Pacemaker is running' (last updated 2023-10-12 23:19:14Z)
Cluster Summary:
...
Full List of Resources:
  * rsc_iscsi_sbd	(stonith:external/sbd):	 Stopped
...
Failed Resource Actions:
  * rsc_iscsi_sbd_start_0 on vmhana02 'error' (1): call=10, status='complete', last-rc-change='Thu Oct 12 23:16:58 2023', queued=0ms, exec=3261ms
  * rsc_iscsi_sbd_start_0 on vmhana01 'error' (1): call=10, status='complete', last-rc-change='Thu Oct 12 23:16:50 2023', queued=0ms, exec=3226ms
...
SCRIPT_FINISHEDRAtxa-0-
```
so this PR is ok in the sense that write the right `use_sbd` in the `inventory.yaml` but it is not enough to magically fix the original issue about having iscsi resource

## GCP configured for native fencing
 - sle-15-SP5-Qesap-Gcp-Byos-x86_64-BuildLATEST_GCE_SLE15_5_BYOS-qesap_gcp_sapconf_test@64bit -> http://openqaworker15.qa.suse.cz/tests/246060

The generated [inventory.yaml](http://openqaworker15.qa.suse.cz/tests/246060/file/deploy-inventory.yaml) has `use_sbd: false`. In the Ansible log ...

