### PR TITLE
Add environment variable driven failure trigger

### DIFF
--- a/scripts/qesap/qesap.py
+++ b/scripts/qesap/qesap.py
@@ -141,6 +141,14 @@ def main(command_line=None):  # pylint: disable=too-many-return-statements
         log.debug("No command")
         return 0
 
+    sim_message = os.getenv('QESAP_SIM_MSG')
+    if sim_message:
+        log.error("This is a -- %s -- simulation.", sim_message)
+    sim_rc = os.getenv('QESAP_SIM_RC')
+    if sim_rc:
+        res = Status(int(sim_rc))
+        return res
+
     if parsed_args.command == "configure":
         log.info("Configuring...")
         res = cmd_configure(


### PR DESCRIPTION
Add code in qesap.py to trigger a simulated failure. 
- QESAP_SIM_RC force the script to immediately exit with a specific exit code
- QESAP_SIM_MSG print a message on log.error

Setting only `QESAP_SIM_MSG`  it is possible to obtain a normal execution but injecting a specific message at the log beginning
```
% QESAP_SIM_MSG="CIAO" qesap.py --verbose  -b ${QESAPROOT} -c config.yaml configure
ERROR    This is a -- CIAO -- simulation.
INFO     Configuring...
DEBUG    Configure data:{'provider': 'azure', 'apiver': 3, 'terraform': {'variables': {'az_region': 'westeurope', 
... 
% echo $?
0
```

Setting only `QESAP_SIM_MSG`  it is possible to obtain a not 0 exit code. Script exit immediately
```
% QESAP_SIM_RC=42  qesap.py --verbose  -b ${QESAPROOT} -c config.yaml configure

% echo $?
42
```

Using both
```
% QESAP_SIM_RC=42 QESAP_SIM_MSG="CIAO" qesap.py --verbose  -b ${QESAPROOT} -c config.yaml configure
ERROR    This is a -- CIAO -- simulation.

% echo $?
42
```


Verification:
http://openqaworker15.qa.suse.cz/tests/248634 QESAP_SIM_RC=42 configured after qesap.py ...configure and before qesap.py ... terraform. Job just die, as expected no retry is attempted. 🟢

http://openqaworker15.qa.suse.cz/tests/248638 QESAP_SIM_RC=42 configured after qesap.py ... terraform and before qesap.py ... ansible :green_circle: 