### PR TITLE
Move Ansible modules dependency to Galaxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Tools needed
 
 * Python 3.9
 * terraform v1.3.6
-* ansible 6.5.0 (ansible-core 2.13.5). Please refer to the **requirements.txt** file
+* ansible-core 2.13.5 : please refer to the **requirements.txt** file
 * cloud provider cli tools (`az`, `aws`, `gcloud`)
 
 The Python requirements could be managed with a virtual environment
@@ -19,6 +19,12 @@ The Python requirements could be managed with a virtual environment
 python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
+```
+
+Ansible dependency are managed separately. After the installation of the Ansible core the following command has to be executed:
+
+```shell
+ansible-galaxy install -r requirements.yml
 ```
 
 Prepare a ssh key pair

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-ansible==6.5.0
-ansible-compat==2.2.1
 ansible-core==2.13.5
 awscli==1.29.4
 jmespath==0.10.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,8 @@
+---
+collections:
+  - name: community.crypto
+    version: 2.15.1
+  - name: ansible.posix
+    version: 1.5.4
+  - name: community.general
+    version: 6.5.0


### PR DESCRIPTION
Only keep Ansible-Core as OS dependency and move all needed Ansible modules installation to use ansible-galaxy.

It is more aligned as modern Ansible best practice 

Ticket  TEAM-8786

# Verification

## qesap regression

http://openqaworker15.qa.suse.cz/tests/267459 :green_circle: 

Galaxy installation has its own dedicated log http://openqaworker15.qa.suse.cz/tests/267459/logfile?filename=configure-galaxy_install.txt

To have an idea about the overall installation process you need to look at http://openqaworker15.qa.suse.cz/tests/267459/logfile?filename=serial_terminal.txt and look for `pip3.10 install --no-color --no-cache-dir -r` and `ansible-galaxy install -r` 

## hanasr

http://openqaworker15.qa.suse.cz/tests/267460  :green_circle: 

