### PR TITLE
Task no longer installing particular version of gcc

### DIFF
--- a/ansible/playbooks/sap-hana-preconfigure.yaml
+++ b/ansible/playbooks/sap-hana-preconfigure.yaml
@@ -41,24 +41,7 @@
       delay: 60
 
       # 3018133 - Linux: Running SAP applications compiled with GCC 10.x
-    - name: Ensure minimum version of GCC10 are installed on SLE12
-      community.general.zypper:
-        name: "{{ item }}"
-        state: present
-        oldpackage: true
-      loop:
-        - 'libgcc_s1=10.2.1+git583-1.3.5'
-        - 'libstdc++6=10.2.1+git583-1.3.5'
-        - 'libatomic1=10.2.1+git583-1.3.5'
-      when:
-        - ansible_facts['distribution_version'] == '12.4' or
-          ansible_facts['distribution_version'] == '12.5'
-      register: result
-      until: result is succeeded
-      retries: 3
-      delay: 60
-
-    - name: Ensure minimum version of GCC10 are installed on SLE 15
+    - name: Ensure GCC10 is installed
       community.general.zypper:
         name: "{{ item }}"
         state: present
@@ -67,8 +50,6 @@
         - 'libgcc_s1>=10.2.1'
         - 'libstdc++6>=10.2.1'
         - 'libatomic1>=10.2.1'
-      when:
-        - ansible_distribution_major_version == '15'
       register: result
       until: result is succeeded
       retries: 3


### PR DESCRIPTION
In sap-hana-preconfigure.yaml the "Ensure minimum version of GCC10 are installed on SLE12" is improperly trying to install a particular version of gcc instead of defining a minimum version like the SLE15 task.

This removes the check for OS version as gcc>=10 is enough for all OSes

Verification Runs:
12SP5 & 15SP4 http://openqaworker15.qa.suse.cz/tests/overview?build=fake_build