### PR TITLE
Fix fully-patch-system not do reboot after patch

### DIFF
--- a/ansible/playbooks/fully-patch-system.yaml
+++ b/ansible/playbooks/fully-patch-system.yaml
@@ -13,8 +13,9 @@
         name: '*'
         state: latest
         type: patch
+      notify: Reboot after patch
 
   handlers:
-    - name: Reboot
+    - name: Reboot after patch
       ansible.builtin.reboot:
         reboot_timeout: "{{ use_reboottimeout | int }}"


### PR DESCRIPTION
Fix playbook fully-patch-system.yaml not do reboot after patch

VR passed and `NOTIFIED HANDLER Reboot after patch` can be found in ansible log file:
    https://openqa.suse.de/tests/12854819 