### PR TITLE
Add ansible playbook syntax check

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -12,7 +12,12 @@ jobs:
       - name: Install all requirements
         run: |
           python3 -m pip install --upgrade -r requirements.txt
+          ansible-galaxy install -r requirements.yml
 
       - name: Run ansible-yaml-lint
         run: |
            make static-ansible-yaml
+
+      - name: Run ansible-playbooks syntax-check
+        run: |
+           make static-ansible-syntax

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ venv/
 **/.venv/
 **/__pycache__/
 secret/
-inventory.yaml
+terraform/**/inventory.yaml
 terraform/**/.terraform
 terraform/**/terraform.tfstate*
 terraform/**/terraform.tfvars

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ static-ansible-yaml:
 
 static-ansible-syntax: export ANSIBLE_ROLES_PATH=tools/dummy_roles
 static-ansible-syntax:
-	@find ansible/playbooks/ -type f -iname "*.yaml" -maxdepth 1  -exec ansible-playbook -l all -i tools/inventory.yaml --syntax-check  {} +
+	@python3 tools/ansible_playbook_syntax_check.py
 
 static-ansible-lint:
 	@ansible-lint ansible/

--- a/tools/ansible_playbook_syntax_check.py
+++ b/tools/ansible_playbook_syntax_check.py
@@ -1,0 +1,45 @@
+import subprocess
+import re
+import sys
+import os
+
+def syntax_check_playbook(path):
+    cmd = ['ansible-playbook', '-i', 'tools/inventory.yaml', '-l', 'all', '--syntax-check', path]
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False)
+    output = proc.stdout.decode('utf-8')
+    if proc.returncode == 0:
+        return output, []
+
+    errors = []
+    match = re.search(r".*ERROR!(.*)\n+The error.*in '(.*)'.*line (\d+)", output, re.MULTILINE)
+    if match:
+        errors.append({
+                'file': match.group(2),
+                'line': int(match.group(3)),
+                'message': match.group(1).strip()
+            })
+    return output, errors
+
+if __name__ == '__main__':
+    playbooks_folder = 'ansible/playbooks'
+    # Iterate directory
+    has_error = False
+    for path in os.listdir(playbooks_folder):
+        playbook = os.path.join(playbooks_folder, path)
+        # check if current path is a file
+        if not os.path.isfile(playbook):
+            continue
+        output, errors = syntax_check_playbook(playbook)
+        if len(errors) > 0:
+            if "GITHUB_ACTIONS" in os.environ:
+                for error in errors:
+                    print('::error file={},line={},endLine={},title=ERROR::{}'.format(
+                        error['file'], error['line'], error['line'], error['message']
+                    ))
+            else:
+                print(output)
+            has_error = True
+
+    if has_error:
+        sys.exit(1)
+

--- a/tools/inventory.yaml
+++ b/tools/inventory.yaml
@@ -1,0 +1,24 @@
+all:
+  vars:
+    use_sbd: true
+    resource_group_name: rg-name
+    subscription_id: AAAAA-BBBBB-CCCCC-DDDDD
+    tenant_id: EEEEE-FFFFF-GGGGG-HHHHH
+    cluster_ip: 1.2.3.4
+  children:
+    hana:
+      hosts:
+        vmhana01:
+          ansible_host: 1.2.3.4
+          ansible_python_interpreter: /usr/bin/python3
+        vmhana02:
+          ansible_host: 5.6.7.8
+          ansible_python_interpreter: /usr/bin/python3
+
+    iscsi:
+      hosts:
+        vmiscsi01:
+          ansible_host: 9.9.9.9
+          ansible_python_interpreter: /usr/bin/python3
+
+  hosts: null


### PR DESCRIPTION
Call ansible-playbook for each playbook using --syntax-check. 
Dummy roles and inventory is provided to avoid false error detection. 
The python script also format the error output to be compliant to github pipeline standard.
Add Github pipeline to run this test.


Ticket : TEAM-7184

Verification: is the pipeline execution in this PR


Here how an error will looks like
![image](https://github.com/SUSE/qe-sap-deployment/assets/101880010/581cb9cf-a13b-4557-bc25-c89a99549b99)

