### PR TITLE
Remove hardcoded HANA installer parameters

### DIFF
--- a/ansible/playbooks/sap-hana-system-replication-hooks.yaml
+++ b/ansible/playbooks/sap-hana-system-replication-hooks.yaml
@@ -11,8 +11,6 @@
   vars:
     is_primary: "{{ ansible_play_hosts[0] == inventory_hostname }}"
     hooks_dir: myHooks
-    sap_hana_install_sid: HDB
-    sap_hana_install_instance_number: 00
     hana_status: unknown
 
   handlers:
@@ -28,6 +26,19 @@
       when: not is_primary
 
   tasks:
+
+    - name: Assert that required variables are defined
+      ansible.builtin.assert:
+        that: "{{ item }} is defined"
+        fail_msg: >-
+          The required variable '{{ item }}' is not defined. This variable must be
+          defined when using this role.
+        success_msg: >-
+          The variable '{{ item }}' is defined.
+      loop:
+        - 'sap_hana_install_sid'
+        - 'sap_hana_install_instance_number'
+
     - name: Ensure hooks directory exists
       ansible.builtin.file:
         path: "/hana/shared/{{ hooks_dir }}"
@@ -53,7 +64,7 @@
       block:
         - name: Ensure ha_dr_provider_SAPHanaSR section exists in global.ini
           community.general.ini_file:
-            path: /usr/sap/HDB/SYS/global/hdb/custom/config/global.ini
+            path: /usr/sap/{{ sap_hana_install_sid }}/SYS/global/hdb/custom/config/global.ini
             section: "{{ item.section }}"
             option: "{{ item.key }}"
             value: "{{ item.value }}"


### PR DESCRIPTION
Remove hardcoded parameters from sap-hana-system-replication-hooks

Ticket: [TEAM-8674](https://jira.suse.com/browse/TEAM-8674)

# Verifications:

## HanaSR
### sle-15-SP4-HanaSr-Azure-Byos-x86_64-Build15-SP4_2023-12-19T05:03:09Z-hanasr_azure_test_sapconf_msi@64bit
http://openqaworker15.qa.suse.cz/tests/273299 :green_circle: failure is later after the end of the `qe-sap-deployment` deploy

 http://openqaworker15.qa.suse.cz/tests/273370 after [pr_fix](https://github.com/SUSE/qe-sap-deployment/compare/670b462a378e9c66e16bb0f2cd8a21d77543ce2b..0f212872ff8dbd833f8b28f1efdf48d59f49ac67)

###  - sle-15-SP4-HanaSr-Aws-Byos-x86_64-Build15-SP4_2023-12-19T05:03:09Z-hanasr_aws_test_saptune@64bit
 - http://openqaworker15.qa.suse.cz/tests/273300   :red_circle: Fails exactly in the same way as without this PR. It is a combination also failing in regression 

```
ERROR    OUTPUT:              "stderr": "\u001b[31mERROR\u001b[0m: (unpack_resources) \terror: Resource start-up disabled since no STONITH resources have been defined\n\u001b[31mERROR\u001b[0m: (unpack_resources) \terror: Either configure some or disable STONITH with the stonith-enabled option\n\u001b[31mERROR\u001b[0m: (unpack_resources) \terror: NOTE: Clusters with shared data need STONITH to ensure data integrity\n\u001b[31mERROR\u001b[0m: crm_verify: Errors found during check: config not valid",
ERROR    OUTPUT:              "stderr_lines": [
ERROR    OUTPUT:                  "\u001b[31mERROR\u001b[0m: (unpack_resources) \terror: Resource start-up disabled since no STONITH resources have been defined",
ERROR    OUTPUT:                  "\u001b[31mERROR\u001b[0m: (unpack_resources) \terror: Either configure some or disable STONITH with the stonith-enabled option",
ERROR    OUTPUT:                  "\u001b[31mERROR\u001b[0m: (unpack_resources) \terror: NOTE: Clusters with shared data need STONITH to ensure data integrity",
ERROR    OUTPUT:                  "\u001b[31mERROR\u001b[0m: crm_verify: Errors found during check: config not valid"
ERROR    OUTPUT:              ],
ERROR    OUTPUT:              "stdout": "\u001b[33mWARNING\u001b[0m: (cluster_status) \twarning: Fencing and resource management disabled due to lack of quorum",
```

###  - sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_sapconf_test@64bit 
- http://openqaworker15.qa.suse.cz/tests/273301 :green_circle:  to be considered as PASS as deploy and test_cluster are ok
-  http://openqaworker15.qa.suse.cz/tests/273371 after [pr_fix](https://github.com/SUSE/qe-sap-deployment/compare/670b462a378e9c66e16bb0f2cd8a21d77543ce2b..0f212872ff8dbd833f8b28f1efdf48d59f49ac67) :red_circle: but not significant as failure is known issue `"msg": "Timed out waiting for last boot time check (timeout=900)",`
-  http://openqaworker15.qa.suse.cz/tests/273373  after [pr_fix](https://github.com/SUSE/qe-sap-deployment/compare/670b462a378e9c66e16bb0f2cd8a21d77543ce2b..0f212872ff8dbd833f8b28f1efdf48d59f49ac67)



## qesap regression
### sle-15-SP5-Qesap-Gcp-Byos-x86_64-BuildLATEST_GCE_SLE15_5_BYOS-qesap_gcp_sbd@64bit
- http://openqaworker15.qa.suse.cz/tests/273298 :red_circle: fails in Ansible but failure is due to bug fixed in another PR https://github.com/SUSE/qe-sap-deployment/pull/196
-  http://openqaworker15.qa.suse.cz/tests/273307 :red_circle: fails in Ansible but failure is due to bug fixed in another PR https://github.com/SUSE/qe-sap-deployment/pull/196

### sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_saptune_test@64bit 
- http://openqaworker15.qa.suse.cz/tests/273308 :green_circle: 
- http://openqaworker15.qa.suse.cz/tests/273372 after [pr_fix](https://github.com/SUSE/qe-sap-deployment/compare/670b462a378e9c66e16bb0f2cd8a21d77543ce2b..0f212872ff8dbd833f8b28f1efdf48d59f49ac67)

###  sle-15-SP5-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_5_BYOS-qesap_aws_sbd@64bit
- http://openqaworker15.qa.suse.cz/tests/273309 :green_circle: 

###  sle-15-SP5-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_5_BYOS-qesap_aws_saptune_test@64bit 
- http://openqaworker15.qa.suse.cz/tests/273310 :red_circle: Fails exactly in the same way as without this PR. It is a combination also failing in regression 
```
ERROR    OUTPUT:                  "\u001b[33mWARNING\u001b[0m: (cluster_status) \twarning: Fencing and resource management disabled due to lack of quorum",
ERROR    OUTPUT:                  "\u001b[31mERROR\u001b[0m: (unpack_resources) \terror: Resource start-up disabled since no STONITH resources have been defined",
ERROR    OUTPUT:                  "\u001b[31mERROR\u001b[0m: (unpack_resources) \terror: Either configure some or disable STONITH with the stonith-enabled option",
ERROR    OUTPUT:                  "\u001b[31mERROR\u001b[0m: (unpack_resources) \terror: NOTE: Clusters with shared data need STONITH to ensure data integrity",
ERROR    OUTPUT:                  "\u001b[31mERROR\u001b[0m: crm_verify: Errors found during check: config not valid"
```


