### PR TITLE
Move prefix and gcp_cluster_ip

### DIFF
--- a/terraform/gcp/inventory.tmpl
+++ b/terraform/gcp/inventory.tmpl
@@ -1,6 +1,8 @@
 all:
   vars:
     use_sbd: ${use_sbd}
+    gcp_cluster_ip: ${hana-vip}
+    prefix: ${name_prefix}
   children:
     hana:
       hosts:
@@ -18,7 +20,4 @@ all:
           ansible_python_interpreter: ${iscsi_remote_python}
 %{ endfor ~}
 %{ endif }
-      vars:
-        gcp_cluster_ip: ${hana-vip}
-        prefix: ${name_prefix}
   hosts: null


### PR DESCRIPTION
Move inventory vars to be available to all groups of nodes

Ticket TEAM-8887

# Verification

## qesap regression
### sle-15-SP5-Qesap-Gcp-Byos-x86_64-BuildLATEST_GCE_SLE15_5_BYOS-qesap_gcp_sbd@64bit 
-  http://openqaworker15.qa.suse.cz/tests/273292 :green_circle: 

### sle-15-SP5-Qesap-Gcp-Byos-x86_64-BuildLATEST_GCE_SLE15_5_BYOS-qesap_gcp_sbd@64bit 
- http://openqaworker15.qa.suse.cz/tests/273294 :green_circle: 

###  sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_sapconf_test@64bit
- http://openqaworker15.qa.suse.cz/tests/273295 :green_circle: 

### sle-15-SP4-HanaSr-Azure-Byos-x86_64-Build15-SP4_2023-12-19T05:03:09Z-hanasr_azure_test_sapconf_msi@64bit
 - http://openqaworker15.qa.suse.cz/tests/273296 :red_circle:  fails in Terraform, even before the PR code is used
- https://openqaworker15.qa.suse.cz/tests/273302


