### PR TITLE
Set "allow-unhealthy-nodes=true" for HA resource

### DIFF
--- a/ansible/playbooks/tasks/azure-cluster-bootstrap.yaml
+++ b/ansible/playbooks/tasks/azure-cluster-bootstrap.yaml
@@ -231,7 +231,7 @@
     - not use_sbd | bool and azure_identity_management == 'spn'
 
 - name: Add Azure scheduled events to cluster
-  ansible.builtin.command: crm configure primitive rsc_azure-events ocf:heartbeat:azure-events op monitor interval=10s
+  ansible.builtin.command: crm configure primitive rsc_azure-events ocf:heartbeat:azure-events op monitor interval=10s allow-unhealthy-nodes=true
   when:
     - is_primary
     - rsc_azure_events | length == 0


### PR DESCRIPTION
Set "allow-unhealthy-nodes=true" for HA resource ocf:heartbeat:azure-events

Related ticket: [TEAM-8854](https://jira.suse.com/browse/TEAM-8854)
[PC][15sp3][timebox] "SAPHanaSR-ScaleUp-PerfOpt" sporadically timed out on "wait_for_ssh" after/during doing "stop_hana()"

VRs (passed): 
http://openqa.suse.de/tests/13199331
http://openqa.suse.de/tests/13199368
http://openqa.suse.de/tests/13199370