### PR TITLE
Remove dbus-1-python installation from 15sp3 iscsi

### DIFF
--- a/ansible/playbooks/tasks/iscsi-server-sbd-prep.yaml
+++ b/ansible/playbooks/tasks/iscsi-server-sbd-prep.yaml
@@ -19,7 +19,6 @@
     state: present
   loop:
     - targetcli-fb
-    - dbus-1-python
   when: ansible_distribution_version == '15.3'
   register: result
   until: result is succeeded


### PR DESCRIPTION
Remove the installation of this package as it does not exist in the catalog for 15sp3

Related ticket: TEAM-8938

Verification http://openqaworker15.qa.suse.cz/tests/273693 