### PR TITLE
Terraform pass more data to Ansible for AWS native fencing

### DIFF
--- a/ansible/playbooks/sap-hana-cluster.yaml
+++ b/ansible/playbooks/sap-hana-cluster.yaml
@@ -39,10 +39,6 @@
 
 
   tasks:
-    - name: Include AWS variables
-      ansible.builtin.include_vars: ../../terraform/aws/aws_cluster_data.yaml
-      when: cloud_platform_is_aws
-
     - name: Base Cluster Configuration [azure]
       ansible.builtin.include_tasks: ./tasks/azure-cluster-bootstrap.yaml
       when: cloud_platform_is_azure

--- a/terraform/aws/aws_cluster_data.tftpl
+++ b/terraform/aws/aws_cluster_data.tftpl
@@ -1,3 +1,0 @@
-aws_route_table: ${routetable_id}
-aws_cluster_ip: ${virtual_ip}
-

--- a/terraform/aws/inventory.tmpl
+++ b/terraform/aws/inventory.tmpl
@@ -1,6 +1,9 @@
 all:
   vars:
     use_sbd: ${use_sbd}
+    aws_route_table: ${routetable_id}
+    aws_cluster_ip: ${virtual_ip}
+    aws_stonith_tag: ${stonith_tag}
   children:
     hana:
       hosts:

--- a/terraform/aws/modules/hana_node/main.tf
+++ b/terraform/aws/modules/hana_node/main.tf
@@ -3,6 +3,7 @@ locals {
   create_scale_out = var.hana_count > 1 && var.common_variables["hana"]["scale_out_enabled"] ? 1 : 0
   create_ha_infra  = var.hana_count > 1 && var.common_variables["hana"]["ha_enabled"] ? 1 : 0
   hostname         = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
+  hana_stonith_tag = "${var.common_variables["deployment_name"]}-cluster"
 }
 
 # Network resources: subnets, routes, etc
@@ -84,8 +85,8 @@ resource "aws_instance" "hana" {
   #}
 
   tags = {
-    Name                                                 = "${var.common_variables["deployment_name"]}-${var.name}${format("%02d", count.index + 1)}"
-    Workspace                                            = var.common_variables["deployment_name"]
-    "${var.common_variables["deployment_name"]}-cluster" = "${var.name}${format("%02d", count.index + 1)}"
+    Name                        = "${var.common_variables["deployment_name"]}-${var.name}${format("%02d", count.index + 1)}"
+    Workspace                   = var.common_variables["deployment_name"]
+    "${local.hana_stonith_tag}" = "${var.name}${format("%02d", count.index + 1)}"
   }
 }

--- a/terraform/aws/modules/hana_node/outputs.tf
+++ b/terraform/aws/modules/hana_node/outputs.tf
@@ -19,3 +19,7 @@ output "hana_public_name" {
   value = data.aws_instance.hana.*.public_dns
 }
 
+output "stonith_tag" {
+  value = local.hana_stonith_tag
+}
+

--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -105,17 +105,11 @@ resource "local_file" "ansible_inventory" {
       iscsi_pip           = module.iscsi_server.iscsisrv_public_ip,
       iscsi_enabled       = local.iscsi_enabled,
       iscsi_remote_python = var.iscsi_remote_python,
-      use_sbd             = local.use_sbd
+      use_sbd             = local.use_sbd,
+      routetable_id       = aws_route_table.route-table.id,
+      virtual_ip          = local.hana_cluster_vip,
+      stonith_tag         = module.hana_node.stonith_tag
   })
   filename = "inventory.yaml"
 }
 
-# Additional cluster information
-resource "local_file" "cluster_data" {
-  content = templatefile("aws_cluster_data.tftpl",
-    {
-      routetable_id = aws_route_table.route-table.id,
-      virtual_ip    = local.hana_cluster_vip
-  })
-  filename = "aws_cluster_data.yaml"
-}


### PR DESCRIPTION
Deprecate aws_cluster_data.yaml and move everything to the inventory. Add variable to pass the name of the tag applied to the hana machines.

Ticket [TEAM-8702](https://jira.suse.com/browse/TEAM-8702)


# Verification 

## Azure qesap regression
 http://openqaworker15.qa.suse.cz/tests/274106 inventory.yaml for Azure is not influenced as expected. Jobs fails for two consecutive `"Timed out waiting for last boot time check (timeout=600)"`

http://openqaworker15.qa.suse.cz/tests/274115

## Azure qesap regression role registration
 http://openqaworker15.qa.suse.cz/tests/274107 :green_circle: 

## AWS qesap regression
 http://openqaworker15.qa.suse.cz/tests/274108 :green_circle: 
the inventory has the new variables http://openqaworker15.qa.suse.cz/tests/274108/file/deploy-inventory.yaml 
no more generated `aws_cluster_data.yaml` seems not a problem for the `ansible/playbooks/sap-hana-cluster.yaml` and `ansible/playbooks/tasks/cluster-bootstrap.yaml` that now reads variables from the inventory. Look for Task named `Configure cluster IP [aws]` in http://openqaworker15.qa.suse.cz/tests/274108/logfile?filename=deploy-qesap_exec_ansible__profile.log.txt

```
DEBUG    OUTPUT:     "cmd": [
DEBUG    OUTPUT:         "crm",
DEBUG    OUTPUT:         "configure",
DEBUG    OUTPUT:         "primitive",
DEBUG    OUTPUT:         "rsc_ip_HDB_HDB00",
DEBUG    OUTPUT:         "ocf:suse:aws-vpc-move-ip",
DEBUG    OUTPUT:         "params",
DEBUG    OUTPUT:         "ip=192.168.1.10",
DEBUG    OUTPUT:         "routing_table=rtb-0ee1bc73858853cde",
```

http://openqaworker15.qa.suse.cz/tests/274116


## AWS qesap regression forcing sbd
 http://openqaworker15.qa.suse.cz/tests/274109 :green_circle: 

Inventory is ok with new variables
Test fails but exactly like the test used to clone this VR, failure is in `TASK [Configure cluster IP [aws]]`

## HanaSR aws
 http://openqaworker15.qa.suse.cz/tests/274110
inventory content is ok. It is visible in http://openqaworker15.qa.suse.cz/tests/274110/logfile?filename=serial_terminal.txt at `> cat /root/qe-sap-deployment/terraform/ec2/inventory.yaml` 

Test fails as usual at `TASK [Configure cluster IP [aws]]`

## HanaSR azure
 http://openqaworker15.qa.suse.cz/tests/274112 :green_circle: 