### PR TITLE
Change name in azure resources to avoid clash

### DIFF
--- a/terraform/azure/modules/majority_maker_node/main.tf
+++ b/terraform/azure/modules/majority_maker_node/main.tf
@@ -42,7 +42,7 @@ resource "azurerm_public_ip" "majority_maker" {
 
 resource "azurerm_image" "sles4sap" {
   count               = var.sles4sap_uri != "" ? 1 : 0
-  name                = "BVSles4SapImg"
+  name                = "MmSrvImg"
   location            = var.az_region
   resource_group_name = var.resource_group_name
 


### PR DESCRIPTION
This changes the name of the created azure majority maker image, because it had the same name with the image from hana node which led to clashes.

- Related ticket: https://jira.suse.com/browse/TEAM-9016
- Verification runs: https://openqaworker15.qa.suse.cz/tests/274950#details