### PR TITLE
Add validation for Python 3.11

### DIFF
--- a/.github/workflows/gluescript.yml
+++ b/.github/workflows/gluescript.yml
@@ -16,7 +16,8 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-20.04]
-        python-version: ['3.8.16', '3.9.15', '3.10.10']
+        # all available versions are in https://github.com/actions/python-versions/blob/main/versions-manifest.json
+        python-version: ['3.8.16', '3.9.15', '3.10.10', '3.11.5']
 
     steps:
     - uses: actions/checkout@v3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 PyYAML==6.0.1
-pytest==7.1.2
-pytest-datafiles==2.0.1
-pylint==2.14.5
-yamllint==1.28.0
-ansible-lint==6.10.0
+pytest==8.0.0
+pytest-datafiles==3.0.0
+pylint==3.0.3
+yamllint==1.34.0
+ansible-lint==6.22.2

--- a/scripts/qesap/tox.ini
+++ b/scripts/qesap/tox.ini
@@ -6,6 +6,7 @@ skipsdist = True
 python =
     3.8: py38
     3.10: py310
+    3.11: py311
 
 [testenv:flake8]
 deps = -r{toxinidir}/requirements-dev.txt


### PR DESCRIPTION
Related ticket https://jira.suse.com/browse/TEAM-9047

VR: 

https://github.com/SUSE/qe-sap-deployment/actions/runs/7807760558/job/21296766173?pr=207

I also tested it locally by :

```
% python3.11 -m venv .venv_dev

% source .venv_dev/bin/activate

% pip install -r requirements-dev.txt

%  pip freeze| grep pytest
pytest==8.0.0
pytest-datafiles==3.0.0

% cd qe-sap-deployment/scripts/qesap

% PYTHONPATH=$(pwd)  python -m  pytest -o log_cli=true -o log_cli_level=10 -v test/unit/test_qesap_configure_ansible.py

...

============================================================================================== 11 passed in 0.29s ==============================================================================================

```