### PR TITLE
Validate Terraform 1.5.7 and add tool validation pipeline

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -1,4 +1,5 @@
 name: Ansible
+
 on: [push, pull_request]
 
 jobs:

--- a/.github/workflows/gluescript.yml
+++ b/.github/workflows/gluescript.yml
@@ -2,6 +2,8 @@ name: Glue Script
 
 on:
   push:
+    branches:
+      - "main"
     paths:
       - scripts/qesap/**
       - .github/workflows/gluescript.yml

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v2
       with:
-        terraform_version: 1.3.6
+        terraform_version: 1.5.7
     # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init
       run: terraform init

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -1,0 +1,51 @@
+name: Tools environment
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - Dockerfile
+      - requirements.txt
+      - requirements.yml
+      - .github/workflows/tools.yml
+  pull_request:
+    paths:
+      - Dockerfile
+      - requirements.txt
+      - requirements.yml
+      - .github/workflows/tools.yml
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v5
+        with:
+          push: false
+          load: true # Export to Docker Engine rather than pushing to a registry
+          tags: ${{ github.run_id }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Test
+        run: |
+          cre=docker ./tools/image_test.sh ${{ github.run_id }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM opensuse/tumbleweed:latest
 ## AZURE
 # way suggested on https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=zypper
 RUN zypper ref && zypper up -y && \
-    zypper install -y tar gzip unzip curl python310-pip openssh && \
+    zypper install -y tar gzip unzip curl python311-pip openssh && \
     rpm --import https://packages.microsoft.com/keys/microsoft.asc && \
     zypper addrepo --name 'Azure CLI' --check https://packages.microsoft.com/yumrepos/azure-cli azure-cli && \
     zypper install --from azure-cli -y azure-cli && \
@@ -21,13 +21,20 @@ RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud
     echo 'source ~/google-cloud-sdk/path.bash.inc' >> ~/.bashrc
 
 ## Terraform
-RUN curl https://releases.hashicorp.com/terraform/1.3.6/terraform_1.3.6_linux_amd64.zip -o terraform.zip && \
+RUN curl https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_amd64.zip -o terraform.zip && \
     unzip terraform.zip -d /usr/local/bin && \
     terraform -install-autocomplete && \
     rm terraform.zip
 
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3.11 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install --upgrade pip && \
+    pip install -r requirements.txt
+
+COPY requirements.yml .
+RUN  ansible-galaxy install -r requirements.yml
 
 RUN mkdir /src
 WORKDIR /src

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This project is in a very early stage of development.
 
 Tools needed
 
-* Python 3.9
-* terraform v1.3.6
+* Python >= 3.9
+* terraform v1.5.7
 * ansible-core 2.13.5 : please refer to the **requirements.txt** file
 * cloud provider cli tools (`az`, `aws`, `gcloud`)
 

--- a/tools/image_test.sh
+++ b/tools/image_test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+img_name=$1
+cre="${cre:-"podman"}"
+
+#$cre build -f Dockerfile -t "${img_name}"
+
+$cre run "${img_name}" terraform --version | grep 1.5.7 || ( echo "ERROR[$?] wrong or not usable Terraform" ; exit 1 )
+$cre run -v $(pwd):/src "${img_name}" terraform -chdir=/src/terraform/azure init || ( echo "ERROR[$?] terraform init does not work for azure" ; exit 1 )
+$cre run -v $(pwd):/src "${img_name}" terraform -chdir=/src/terraform/aws init || ( echo "ERROR[$?] terraform init does not work for aws" ; exit 1 )
+$cre run  -v $(pwd):/src "${img_name}" terraform -chdir=/src/terraform/gcp init || ( echo "ERROR[$?] terraform init does not work for google" ; exit 1 )
+
+$cre run "${img_name}" python3.11 --version | grep 3.11 || ( echo "ERROR[$?] wrong or not usable Python" ; exit 1 )
+$cre run "${img_name}" pip3.11 --version || ( echo "ERROR[$?] wrong or not usable pip" ; exit 1 )
+$cre run "${img_name}" pip3.11 freeze | grep ansible-core || ( echo "ERROR[$?] ansible-core not installed" ; exit 1 )
+$cre run "${img_name}" ansible --version || ( echo "ERROR[$?] wrong or not usable Terraform" ; exit 1 )
+$cre run "${img_name}" ansible-galaxy --version || ( echo "ERROR[$?] wrong or not usable Terraform" ; exit 1 )
+
+$cre run "${img_name}" pip3.11 freeze | grep aws || ( echo "ERROR[$?] aws cli not installed" ; exit 1 )
+$cre run "${img_name}" aws --version || ( echo "ERROR[$?] wrong or not usable aws" ; exit 1 )
+$cre run "${img_name}" az --version || ( echo "ERROR[$?] wrong or not usable az" ; exit 1 )
+#$cre run "${img_name}" cat /root/.bashrc
+# $cre run "${img_name}" gcloud --version
+
+


### PR DESCRIPTION
# Commit description

Improve the Dockerfile to use Terraform 1.5.7 and Python 3.11.
Add virtual env in the Dockerfile to fix a bug that prevented pip installation of python packages.
Add bash script to validate the docker image.
Add githubaction to build the container image and run the validation
test.

# Context

These project needs some tools to be pre-installed on the JumpHost to perform the deployment. Two of them are Python and Terraform. There's no way for the project to have control over what is installed, so tools version for these two are only suggested in the project main readme.

Dockerfile is not the main way this deployment is used, openQA is not running the `qe-sap-deployment` code from within a container.

# PR purpose

This PR is about:
 - creating a test bench to validate external dependency not directly under control of this project (Terraform and Python)
 - test created in this PR are not enough to say that a new version of Python or Terraform are good to be used with `qe-sap-deployment` ...
 - ... but it is a good starting point :1st_place_medal: 

# Pro n Cons
- What I do not like about this PR is that version of Terraform and Python are spread in many places:
    - In the main readme
    - Dockerfile
    - In some YAML to define the GH pipeline

If something fails during the execution of the new pipeline is not so easy to understand what was wrong

The new pipeline could fails due to external issues, the Dockerfile are installing stuff from the web


# Ticket
 TEAM-9050

# Verification
VR is the PR pipeline, took to the one named `tools` https://github.com/SUSE/qe-sap-deployment/actions/runs/7822845007/job/21342714076?pr=208