### PR TITLE
Playbook to add IBS mirror

### DIFF
--- a/ansible/playbooks/ibsm.yaml
+++ b/ansible/playbooks/ibsm.yaml
@@ -1,0 +1,41 @@
+---
+- hosts: all
+  remote_user: cloudadmin
+  become: true
+  become_user: root
+
+  tasks:
+
+    - name: Assert that required variables are defined
+      ansible.builtin.assert:
+        that: "{{ item }} is defined"
+        fail_msg: >-
+          The required variable '{{ item }}' is not defined. This variable must be
+          defined when using this playbook.
+        success_msg: >-
+          The variable '{{ item }}' is defined.
+      loop:
+        - 'ibsm_ip'
+        - 'download_hostname'
+        - 'repos'
+
+    - name: Add mirror to hosts
+      ansible.builtin.lineinfile:
+        path: "/etc/hosts"
+        line: "{{ ibsm_ip }}  {{ download_hostname }}"
+        state: present
+
+    - name: Zypper add repo
+      community.general.zypper_repository:
+        repo: "{{ item }}"
+        name: "TEST_{{ repo_id }}"
+        disable_gpg_check: true
+        autorefresh: true
+      loop: "{{ repos.split(',') }}"
+      loop_control:
+        index_var: repo_id
+
+    - name: Refresh all repos
+      community.general.zypper_repository:
+        repo: '*'
+        runrefresh: true


### PR DESCRIPTION
Playbooks needs 3 arguments:
- ibsm_ip: the IP of the mirror in the cloud
- download_hostname: the hostname that zypper will use
- repos: comma separated list of repos urls


The idea is to match what implemented in:
- https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/tests/sles4sap/publiccloud/add_server_to_hosts.pm
- https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/tests/sles4sap/publiccloud/cluster_add_repos.pm

Ticket: TEAM-9092

VR: done manually
