### PR TITLE
Remove private_key GCP Terraform variable

### DIFF
--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -85,7 +85,6 @@ module "common_variables" {
   reg_additional_modules      = var.reg_additional_modules
   additional_packages         = var.additional_packages
   public_key                  = var.public_key
-  private_key                 = var.private_key
   authorized_keys             = var.authorized_keys
   authorized_user             = var.admin_user
 

--- a/terraform/gcp/terraform.tfvars.example
+++ b/terraform/gcp/terraform.tfvars.example
@@ -63,20 +63,13 @@ region = "europe-west1"
 # The project requires a pair of SSH keys (public and private) to provision the machines
 # The private key is only used to create the SSH connection, it is not uploaded to the machines
 # Besides the provisioning, the SSH connection for this keys will be authorized in the created machines
-# These keys are provided using the next two variables in 2 different ways
+# The public keys is provided using the next variable in 2 different ways
 # Path to already existing keys
 public_key  = "/home/myuser/.ssh/id_rsa.pub"
-private_key = "/home/myuser/.ssh/id_rsa"
 
 # Or provide the content of SSH keys
 #public_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCt06V...."
-#private_key = <<EOF
-#-----BEGIN OPENSSH PRIVATE KEY-----
-#b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABFwAAAAdzc2gtcn
-#...
-#P9eYliTYFxhv/0E7AAAAEnhhcmJ1bHVAbGludXgtYWZqOQ==
-#-----END OPENSSH PRIVATE KEY-----
-#EOF
+
 
 # Authorize additional keys optionally (in this case, the private key is not required)
 # Path to local files or keys content

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -50,11 +50,6 @@ variable "public_key" {
   type        = string
 }
 
-variable "private_key" {
-  description = "Content of a SSH private key or path to an already existing SSH private key. The key is only used to provision the machines. It is not uploaded to the machines in any case"
-  type        = string
-}
-
 variable "authorized_keys" {
   description = "List of additional authorized SSH public keys content or path to already existing SSH public keys to access the created machines with the used admin user (root in this case)"
   type        = list(string)


### PR DESCRIPTION
Ticket: https://jira.suse.com/browse/TEAM-9123

# Verification

# qesap regression

Without `os-autoinst-distri-opensuse:sles4sap_ssh_keys_qesapdeployment_followup`
 - sle-15-SP5-Qesap-Gcp-Byos-x86_64-BuildLATEST_GCE_SLE15_5_BYOS-qesap_gcp_sapconf_test@64bit -> http://openqaworker15.qa.suse.cz/tests/277982 :green_circle:  Terraform is ok, with expected warning like
 ```
DEBUG    OUTPUT: Warning: Value for undeclared variable
DEBUG    OUTPUT: 
DEBUG    OUTPUT: The root module does not declare a variable named "private_key" but a value
DEBUG    OUTPUT: was found in file "terraform.tfvars". If you meant to use this value, add a
DEBUG    OUTPUT: "variable" block to the configuration.
```
due to the fact that qe-sap-deployment no more have the `private_key` variable, but openQA code try to set it.

With `os-autoinst-distri-opensuse:sles4sap_ssh_keys_qesapdeployment_followup`
 - sle-15-SP5-Qesap-Gcp-Byos-x86_64-BuildLATEST_GCE_SLE15_5_BYOS-qesap_gcp_sapconf_test@64bit -> http://openqaworker15.qa.suse.cz/tests/277987 :green_circle: 

The Terraform warning is gone http://openqaworker15.qa.suse.cz/tests/277987/logfile?filename=deploy-qesap_exec_terraform.log.txt . It is expected as this VR also have openQA side code to remove `private_key` from the conf.yaml



# mr_test

:green_circle: in both VR Terraform is fine. both jobs fails later for registration error.

Without `os-autoinst-distri-opensuse:sles4sap_ssh_keys_qesapdeployment_followup`
 - sle-15-SP6-GCE-SAP-BYOS-x86_64-Build0467-sles4sap_gnome_saptune_delete_rename@gce_n1_highmem_8 -> http://openqaworker15.qa.suse.cz/tests/277985

With `os-autoinst-distri-opensuse:sles4sap_ssh_keys_qesapdeployment_followup`
 - sle-15-SP6-GCE-SAP-BYOS-x86_64-Build0467-sles4sap_gnome_saptune_delete_rename@gce_n1_highmem_8 -> http://openqaworker15.qa.suse.cz/tests/277986
