### PR TITLE
Add additional assert task in configure_hsr

### DIFF
--- a/ansible/roles/sap_ha_install_hana_hsr/tasks/configure_hsr.yml
+++ b/ansible/roles/sap_ha_install_hana_hsr/tasks/configure_hsr.yml
@@ -12,6 +12,15 @@
   changed_when: false
   failed_when: false
 
+# assert that the previous task produced a meaningful result
+# specifically, ensure that the result has an 'stdout' attribute
+- name: "Assert stdout is defined for System Replication Status"
+  assert:
+    that:
+      - __sap_ha_install_hana_hsr_srstate.stdout is defined
+    fail_msg: "'stdout' is not defined in '__sap_ha_install_hana_hsr_srstate'. Check the previous task execution."
+    success_msg: "'stdout' is defined in '__sap_ha_install_hana_hsr_srstate'."
+
 # looping through cluster definition to run on defined primary
 # and apply the respective 'site' value
 - name: "SAP HSR - Enable HANA System Replication on primary node"


### PR DESCRIPTION
This pr adds an additional task in the `configure_hsr` playbook, to assert that the "SAP HSR - Check System Replication Status" task has returned meaningful output, or fail otherwise.

- Related ticket: https://jira.suse.com/browse/TEAM-9208
- Verrification runs: https://openqa.suse.de/tests/13986182 (passed the ansible part - fail unrelated)
https://openqa.suse.de/tests/13990311 (passed)