### PR TITLE
Remove duplicate ansible output

### DIFF
--- a/scripts/qesap/lib/cmds.py
+++ b/scripts/qesap/lib/cmds.py
@@ -352,10 +352,11 @@ def cmd_ansible(configure_data, base_project, dryrun, verbose, destroy=False, pr
             print(' '.join(command['cmd']))
         else:
             ret, out = lib.process_manager.subprocess_run(**command)
-            for out_line in out:
-                log.debug(">    %s", out_line)
             log.debug("Ansible process return ret:%d", ret)
-            if ret != 0:
+            if ret == 0:
+                for out_line in out:
+                    log.debug(">    %s", out_line)
+            else:
                 log.error("command:%s returned non zero %d", command, ret)
                 return Status(ret)
     return Status("ok")

--- a/scripts/qesap/lib/config.py
+++ b/scripts/qesap/lib/config.py
@@ -101,6 +101,11 @@ class CONF:
         if 'variables' not in self.conf['terraform']:
             log.error("Missing 'variables' key in conf['terraform'] ")
             return False
+
+        if not isinstance(self.conf['terraform']['variables'], dict):
+            log.error("'variables' in conf['terraform'] is empty")
+            return False
+
         return True
 
     def has_tfvar_template(self):


### PR DESCRIPTION
Remove double log of the Ansible output in case of error


Verification:
 - USUALLY PASS : sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_ansible_roles_test@64bit -> http://openqaworker15.qa.suse.cz/tests/280758 :green_apple:  Failure is later in the destroy test module. Test calling `qesap.py` is visiblein http://openqaworker15.qa.suse.cz/tests/280758/logfile?filename=serial_terminal.txt . Like:
 
```
(exec_venv) # python3.11 /root/qe-sap-deployment/scripts/qesap/qesap.py --verbose -c /root/qe-sap-deployment/scripts/qesap/qesap_azure_roles.yaml -b /root/qe-sap-deployment ansible --profile |& tee -a /tmp/qesap_exec_ansible__profile.log.txt; echo 7JvMC-$?-
INFO     Running Ansible...
```
  Log from ansible is in http://openqaworker15.qa.suse.cz/tests/280758/logfile?filename=deploy-qesap_exec_ansible__profile.log.txt 
 - USUALLY ANSIBLE FAIL :  sle-15-SP5-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE15_5_PAYG-qesap_gcp_sapconf_test@64bit -> http://openqaworker15.qa.suse.cz/tests/280759
