### PR TITLE
WIP: Change timeout handling

### DIFF
--- a/ansible/playbooks/tasks/cluster-bootstrap.yaml
+++ b/ansible/playbooks/tasks/cluster-bootstrap.yaml
@@ -204,7 +204,7 @@
 
 - name: Get op_defaults cluster configuration
   ansible.builtin.command:
-    cmd: crm configure show op-options
+    cmd: crm configure show op_defaults
   register: crm_op_options_show
   changed_when: false
   failed_when: false
@@ -310,12 +310,9 @@
     - is_primary
     - cloud_platform_is_aws or cloud_platform_is_gcp
 
-- name: Set op_defaults timeout [aws/gcp]
+- name: Set op_defaults timeout
   ansible.builtin.command:
-    cmd: >-
-      crm configure rsc_defaults
-      $id="op-options"
-      timeout=600
+    cmd: crm configure op_defaults timeout=600
   when:
     - op_default_timeout != '600'
     - is_primary


### PR DESCRIPTION
The way the timeout was set until now is not valid per the latest versions (see ticket). This pr fixes the relevant task and gets rid of the associated error.

- Related ticket: https://jira.suse.com/browse/TEAM-9247
- Verification run: https://openqa.suse.de/tests/14117896
https://openqa.suse.de/tests/14116288