### PR TITLE
Add --junit argument

### DIFF
--- a/scripts/qesap/qesap.py
+++ b/scripts/qesap/qesap.py
@@ -18,7 +18,7 @@ logging.basicConfig(format="%(levelname)-8s %(message)s")
 log = logging.getLogger('QESAP')
 
 
-VERSION = '0.4'
+VERSION = '0.5'
 
 DESCRIBE = '''qe-sap-deployment helper script'''
 
@@ -124,6 +124,9 @@ def cli(command_line=None):
                                 action='store_true',
                                 help='Run Ansible with ansible.posix.profile_tasks')
 
+    parser_ansible.add_argument('--junit',
+                                help='Enable Ansible junit report and store it in provided folder')
+
     parsed_args = parser.parse_args(command_line)
     return parsed_args
 
@@ -190,7 +193,8 @@ def main(command_line=None):  # pylint: disable=too-many-return-statements
             parsed_args.dryrun,
             parsed_args.verbose,
             destroy=parsed_args.destroy,
-            profile=parsed_args.profile
+            profile=parsed_args.profile,
+            junit=parsed_args.junit
         )
     else:
         res = Status(f"Unknown command: {parsed_args.command}")

--- a/scripts/qesap/test/unit/test_qesap_cli.py
+++ b/scripts/qesap/test/unit/test_qesap_cli.py
@@ -187,3 +187,14 @@ def test_cli_ansible_profile(base_args):
     args.append('ansible')
     args.append('--profile')
     cli(args)
+
+
+def test_cli_ansible_junit(base_args):
+    '''
+    Test ansible with --junit mode
+    '''
+    args = base_args()
+    args.append('ansible')
+    args.append('--junit')
+    args.append('/somefolder/')
+    cli(args)


### PR DESCRIPTION
Add --junit in the ansible subcommand of the gluescript. It's mind to activate generation of junit report.

WIP openQA part of it is https://github.com/os-autoinst/os-autoinst-distri-opensuse/compare/master...mpagot:os-autoinst-distri-opensuse:qesap_ansible_junit

Ticket : TEAM-6844

https://openqaworker15.qa.suse.cz/tests/283139
https://openqaworker15.qa.suse.cz/tests/283140