### PR TITLE
Avoid python Azure package collision in SLES15

### DIFF
--- a/ansible/playbooks/tasks/azure-cluster-bootstrap.yaml
+++ b/ansible/playbooks/tasks/azure-cluster-bootstrap.yaml
@@ -44,16 +44,47 @@
     - ansible_distribution_major_version == '15'
     - public_cloud_module != 'Registered'
 
-# TODO: Version Control
-- name: Ensure Azure Python SDK and Azure Identity python modules are installed
+# For SLES 12 a we need to force a downgrade of python-azure-core see https://www.suse.com/support/kb/doc/?id=000020716
+- name: Ensure Azure Python SDK and Azure Identity python modules are installed [12sp5]
   community.general.zypper:
-    name: "{{ item.package }}"
+    name: "{{ item }}"
     state: present
   loop:
-    # For SLES 12 a we need to force a downgrade of python-azure-core see https://www.suse.com/support/kb/doc/?id=000020716
-    - {'sles': '12', 'package': ['python-azure-mgmt-compute', 'python-azure-identity', 'python-azure-core==1.9.0-2.3.4']}
-    - {'sles': '15', 'package': ['python3-azure-mgmt-compute', 'python3-azure-identity']}
-  when: item.sles == ansible_distribution_major_version
+    - 'python-azure-mgmt-compute'
+    - 'python-azure-identity'
+    - 'python-azure-core==1.9.0-2.3.4'
+  when:
+    - ansible_distribution_version is version('12.5', '==')
+  register: result
+  until: result is succeeded
+  retries: 3
+  delay: 60
+
+- name: Ensure Azure Python SDK and Azure Identity python modules are installed [15 sp<4]
+  community.general.zypper:
+    name: "{{ item }}"
+    state: present
+  loop:
+    - 'python3-azure-mgmt-compute'
+    - 'python3-azure-identity'
+  when:
+    - ansible_distribution_version is version('15.4', '<')
+    - ansible_distribution_version is version('12.5', '!=')
+  register: result
+  until: result is succeeded
+  retries: 3
+  delay: 60
+
+# https://www.suse.com/c/incompatible-changes-ahead-for-public-cloud-sdks/
+- name: Ensure Azure Python SDK and Azure Identity python modules are installed [15 sp>=4]
+  community.general.zypper:
+    name: "{{ item }}"
+    state: present
+  loop:
+    - 'python311-azure-mgmt-compute'
+    - 'python311-azure-identity'
+  when:
+    - ansible_distribution_version is version('15.4', '>=')
   register: result
   until: result is succeeded
   retries: 3


### PR DESCRIPTION
Ticket TEAM-9307

Verification: 

# 15SP5

## BYOS

 - sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_sapconf_test@64bit -> http://openqaworker15.qa.suse.cz/tests/283207 :green_circle: 
Test is using Azure image `suse:sles-sap-15-sp5-byos:gen2:2024.05.08`
 From http://openqaworker15.qa.suse.cz/tests/283207/logfile?filename=deploy-qesap_exec_ansible__profile.log.txt
the deployment executes `zypper patch` as part of playbook `ansible/playbooks/fully-patch-system.yaml`

Zypper finds:
```
<solvable 
    type=\\"package\\" 
    name=\\"python311-azure-mgmt-compute\\"
    edition=\\"30.5.0-150400.14.3.1\\"
    arch=\\"noarch\\"
    repository=\\"Public_Cloud_Module_x86_64:SLE-Module-Public-Cloud15-SP5-Updates\\"
    summary=\\"Microsoft Azure Compute Management Client Library\\">
<description>
...
This package has been tested with Python 2.7, 3.5, 3.6 and 3.7.
</description>
</solvable>

...

 CHANGELOG.md file provided with this package
- Remove temporary version override
- Update Requires from setup.py
 
Changes in python-azure-mgmt-compute:
- Switch package to modern Python Stack on SLE-15
  + Use Python 3.11 on SLE-15 by default
  + Add Obsoletes for old python3 package on SLE-15
  + Drop support for older Python versions


<solvable type=\\"package\\" name=\\"python3-azure-mgmt-compute\\" edition=\\"26.1.0-150200.9.3.2\\" arch=\\"noarch\\" repository=\\"@System\\" summary=\\"Microsoft Azure Compute Management Client Library\\">\\n<description>This is the Microsoft Azure Compute Management Client Library.\\n\\nAzure Resource Manager (ARM) is the next generation of management APIs that\\nreplace the old Azure Service Management (ASM).\\n\\nThis package has been tested with Python 2.7, 3.5, 3.6 and 3.7.</description></solvable>

...

<download url=\\"[https://smt-azure.susecloud.net/repo/SUSE/Updates/SLE-Module-Public-Cloud/15-SP5/x86_64/update/noarch/python311-azure-mgmt-compute-30.5.0-150400.14.3.1.noarch.rpm?credentials=Public_Cloud_Module_x86_64\\"](https://smt-azure.susecloud.net/repo/SUSE/Updates/SLE-Module-Public-Cloud/15-SP5/x86_64/update/noarch/python311-azure-mgmt-compute-30.5.0-150400.14.3.1.noarch.rpm?credentials=Public_Cloud_Module_x86_64\\%22) percent=\\"-1\\" rate=\\"-1\\"/>
```
and
```
<solvable type=\"package\" name=\"python311-azure-identity\" edition=\"1.15.0-150400.11.3.1\" arch=\"noarch\" repository=\"Public_Cloud_Module_x86_64:SLE-Module-Public-Cloud15-SP5-Updates\" summary=\"Azure Identity client library for Python\">
```

This first Ansible deployment attempt fails on `"Timed out waiting for last boot time check (timeout=900)"` but it is not related to any python3 ansible packages.

Second attempt is logged in http://openqaworker15.qa.suse.cz/tests/283207/logfile?filename=deploy-qesap_ansible_retry.log.txt. The part about `zypper patch` is the same. It also has the part related to the ansible code changed in this PR in 
```
DEBUG    >    ok: [vmhana02] => (item={'sles': '15', 'package': ['python311-azure-mgmt-compute', 'python311-azure-identity']}) => {
DEBUG    >        "ansible_loop_var": "item",
DEBUG    >        "attempts": 1,
DEBUG    >        "changed": false,
DEBUG    >        "invocation": {
DEBUG    >            "module_args": {
DEBUG    >                "allow_vendor_change": false,
DEBUG    >                "clean_deps": false,
DEBUG    >                "disable_gpg_check": false,
DEBUG    >                "disable_recommends": true,
DEBUG    >                "extra_args": null,
DEBUG    >                "extra_args_precommand": null,
DEBUG    >                "force": false,
DEBUG    >                "force_resolution": false,
DEBUG    >                "name": [
DEBUG    >                    "python311-azure-mgmt-compute",
DEBUG    >                    "python311-azure-identity"
DEBUG    >                ],
DEBUG    >                "oldpackage": false,
DEBUG    >                "replacefiles": false,
DEBUG    >                "state": "present",
DEBUG    >                "type": "package",
DEBUG    >                "update_cache": false
DEBUG    >            }
DEBUG    >        },
DEBUG    >        "item": {
DEBUG    >            "package": [
DEBUG    >                "python311-azure-mgmt-compute",
DEBUG    >                "python311-azure-identity"
DEBUG    >            ],
DEBUG    >            "sles": "15"
DEBUG    >        },
DEBUG    >        "name": [
DEBUG    >            "python311-azure-mgmt-compute",
DEBUG    >            "python311-azure-identity"
DEBUG    >        ],
DEBUG    >        "rc": 0,
DEBUG    >        "state": "present",
DEBUG    >        "update_cache": false
DEBUG    >    }
```

 - http://openqaworker15.qa.suse.cz/tests/283468 :green_circle:  Ansible http://openqaworker15.qa.suse.cz/tests/283468/logfile?filename=deploy-qesap_exec_ansible__profile.log.txt 

In SLES4SAP 15SP5, facts collected by Ansible are:
- "ansible_distribution_release": "5",
- "ansible_distribution_version": "15.5",
- "ansible_distribution_major_version": "15"

`TASK [Ensure Azure Python SDK and Azure Identity python modules are installed [12sp5]]` is skipped
`TASK [Ensure Azure Python SDK and Azure Identity python modules are installed [15 sp<4]]` is skipped 
`TASK [Ensure Azure Python SDK and Azure Identity python modules are installed [15 sp>=4]]` is executed and pass
 
## PAYG

### MSI

sle-15-SP5-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-qesap_azure_saptune_test_msi@64bit 

- http://openqaworker15.qa.suse.cz/tests/283208 :red_circle: the Ansible part of the deployment is fine but there's a failure later in `  * rsc_stonith_azure	(stonith:fence_azure_arm):	 Stopped` 

- http://openqaworker15.qa.suse.cz/tests/283469 :red_circle: the Ansible part of the deployment is fine but there's a failure later in `  * rsc_stonith_azure	(stonith:fence_azure_arm):	 Stopped` 

Ansible log http://openqaworker15.qa.suse.cz/tests/283469/logfile?filename=deploy-qesap_exec_ansible__profile.log.txt has:

`TASK [Ensure Azure Python SDK and Azure Identity python modules are installed [15 sp>=4]]` is executed and pass

Later in Ansible

```
DEBUG    OUTPUT:             "_raw_params": "crm configure primitive rsc_stonith_azure stonith:fence_azure_arm params msi=true subscriptionId=\"**************\" resourceGroup=\"rg-ha-sap-qesapval12345\" tenantId=\"**************\" pcmk_monitor_retries=4 pcmk_action_limit=3 power_timeout=240 pcmk_reboot_timeout=900 pcmk_delay_max=15 op monitor interval=3600 timeout=120",

...

DEBUG    OUTPUT:     "rc": 0,

DEBUG    OUTPUT:     "stderr": "\u001b[33mWARNING\u001b[0m: (unpack_config) \twarning: Blind faith: not fencing unseen nodes",

DEBUG    OUTPUT:     "stdout": "",
```
Checking the cluster, after that Ansible deployment concluded successfully, result in : 
http://openqaworker15.qa.suse.cz/tests/283469#step/test_cluster/184

```
$ crm status

Full List of Resources:
  * rsc_stonith_azure	(stonith:fence_azure_arm):	 Stopped
 
```

and from the `pacemaker.log`

```
May 20 22:26:57.138 vmhana01 pacemaker-fenced    [19063] (log_op_output) 	info: fence_azure_arm_monitor_1of4[21110] error output [ 2024-05-20 22:26:57,110 ERROR: Azure Resource Manager Python SDK not found or not accessible ]
```


### SPN

sle-15-SP5-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-qesap_azure_saptune_test_spn@64bit
 
- http://openqaworker15.qa.suse.cz/tests/283209  :red_circle: the Ansible part of the deployment is fine

Updated module is

```
<solvable 
    type=\\"package\\"
    name=\\"python311-azure-identity\\"
    edition=\\"1.15.0-150400.11.3.1\\"
    arch=\\"noarch\\" 
    repository=\\"Public_Cloud_Module_x86_64:SLE-Module-Public-Cloud15-SP5-Updates\\" 
    summary=\\"Azure Identity client library for Python\\">
```

 but there's a failure later in `  * rsc_stonith_azure	(stonith:fence_azure_arm):	 Stopped` 

- http://openqaworker15.qa.suse.cz/tests/283470 :red_circle: 

same error of `MSI` http://openqaworker15.qa.suse.cz/tests/283470#step/test_cluster/127
`  * rsc_stonith_azure	(stonith:fence_azure_arm):	 Stopped` 


# 15SP4 
## PAYG

### SBD fencing
 - sle-15-SP4-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_4_PAYG-qesap_azure_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/283210  :green_circle: 

 -   http://openqaworker15.qa.suse.cz/tests/283471 :green_circle: 

`TASK [Ensure Azure Python SDK and Azure Identity python modules are installed [12sp5]]` is skipped
`TASK [Ensure Azure Python SDK and Azure Identity python modules are installed [15 sp<4]]` is skipped 
`TASK [Ensure Azure Python SDK and Azure Identity python modules are installed [15 sp>=4]]` is executed and pass

### Native fencing SPN
 - sle-15-SP4-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_4_PAYG-qesap_azure_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/283534 :red_circle:  deployment is fine but later the cluster resource is not started http://openqaworker15.qa.suse.cz/tests/283534#step/test_cluster/182 `* rsc_stonith_azure	(stonith:fence_azure_arm):	 Stopped`

# 15SP3 
## PAYG

### SBD fencing
 sle-15-SP3-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_3_PAYG-qesap_azure_sapconf_test@64bit
-  http://openqaworker15.qa.suse.cz/tests/283472 :green_circle: 

`TASK [Ensure Azure Python SDK and Azure Identity python modules are installed [12sp5]]` is skipped
`TASK [Ensure Azure Python SDK and Azure Identity python modules are installed [15 sp<4]]` is executed and pass
`TASK [Ensure Azure Python SDK and Azure Identity python modules are installed [15 sp>=4]]` is skipped 

Cluster is healthy after the deployment `stonith-sbd	(stonith:external/sbd):	 Started vmhana01` 

### Native fencing SPN
 sle-15-SP3-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_3_PAYG-qesap_azure_sapconf_test@64bit
 - http://openqaworker15.qa.suse.cz/tests/283535 :green_circle: 
`  * rsc_stonith_azure	(stonith:fence_azure_arm):	 Started vmhana01`
 
# 12SP5
## PAYG

### sle-12-SP5-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE12_5_PAYG-qesap_azure_saptune_test@64bit

- http://openqaworker15.qa.suse.cz/tests/283473 :green_circle: 

From http://openqaworker15.qa.suse.cz/tests/283473/logfile?filename=deploy-qesap_exec_ansible__profile.log.txt


`TASK [Ensure Azure Python SDK and Azure Identity python modules are installed [12sp5]]` is executed and pass
`TASK [Ensure Azure Python SDK and Azure Identity python modules are installed [15 sp<4]]`  is skipped 
`TASK [Ensure Azure Python SDK and Azure Identity python modules are installed [15 sp>=4]]` is skipped 


 
## BYOS
 - sle-12-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE12_5_BYOS-qesap_azure_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/283213 :green_circle: 

# 15SP6
 
## BYOS

### SBD
 sle-15-SP6-Qesap-Azure-Byos-Ibs-x86_64-BuildLATEST_AZURE_SLE15_6_BYOS_IBS-qesap_azure_uri@az_Standard_E8s_v3
- http://openqaworker15.qa.suse.cz/tests/283543 :red_circle: as nothing provide `python311-azure*` packages

### Native fencing
- http://openqaworker15.qa.suse.cz/tests/283544 :red_circle: as nothing provide `python311-azure*` packages