### PR TITLE
Add new test strategy for qesap.py

### DIFF
--- a/.github/workflows/gluescript.yml
+++ b/.github/workflows/gluescript.yml
@@ -38,11 +38,19 @@ jobs:
       run: tox -e flake8
       env:
         PLATFORM: ${{ matrix.platform }}
-    - name: Test with tox
+    - name: UT tox
       working-directory: scripts/qesap/
       run: tox
       env:
         PLATFORM: ${{ matrix.platform }}
+    - name: Test UT variants
+      working-directory: scripts/qesap/
+      run: |
+        tox -e pytest_verbose
+        tox -e pytest_hypo
+        tox -e pytest_finddep
+      env:
+        PLATFORM: '3.11.9'
     - name: Test e2e
       run: |
         python -m pip install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,9 @@ static-ansible: static-ansible-yaml static-ansible-syntax
 
 test: test-ut test-e2e
 
-beyond: all static-flake8-test static-ansible-kics static-terraform-kics static-ansible-lint
+test-all: test-ut test-ut-fuzzy test-ut-verbose test-ut-dep  test-e2e
+
+beyond: all static-flake8-test static-ansible-kics static-terraform-kics static-ansible-lint test-ut-fuzzy test-ut-verbose test-ut-dep
 
 static-pylint:
 	@cd scripts/qesap/ ; tox -e pylint
@@ -57,7 +59,16 @@ static-ansible-lint:
 	@ansible-lint ansible/ --exclude ansible/playbooks/registration_role.yaml --exclude ansible/playbooks/vars/hana_media.yaml --exclude ansible/playbooks/vars/hana_vars.yaml
 
 test-ut:
-	@cd scripts/qesap/ ; tox -e pytest
+	@cd scripts/qesap/ ; tox -e py311
+
+test-ut-fuzzy:
+	@cd scripts/qesap/ ; tox -e pytest_hypo
+
+test-ut-verbose:
+	@cd scripts/qesap/ ; tox -e pytest_verbose
+
+test-ut-dep:
+	@cd scripts/qesap/ ; tox -e pytest_finddep
 
 test-e2e:
 	@cd scripts/qesap/test/e2e ; ./test.sh

--- a/scripts/qesap/requirements-dev.txt
+++ b/scripts/qesap/requirements-dev.txt
@@ -1,9 +1,10 @@
-flake8==6.0.0
-flake8-bugbear==23.5.9
+flake8==6.0.*
+flake8-bugbear==23.5.*
 hypothesis==6.*
-pylint==3.1.0
-pyparsing==3.0.9
-pytest==8.2.0
+pylint==3.1.*
+pytest==8.2.*
 pytest-subprocess
-yamllint==1.35.1
+pytest-find-dependencies
+detect-test-pollution
+yamllint==1.35.*
 ansible-lint

--- a/scripts/qesap/test/unit/test_hy_conf.py
+++ b/scripts/qesap/test/unit/test_hy_conf.py
@@ -1,0 +1,33 @@
+import os
+import pytest
+from hypothesis import given
+from hypothesis.strategies import dictionaries, text
+from lib.config import CONF
+
+
+@pytest.mark.skipif("FUZZYTEST" not in os.environ, reason="Fuzzy test disabled by default")
+@given(dictionaries(text(), text()))
+def test_conf_has_not_ansible(conf_dict):
+    conf = CONF(conf_dict)
+    assert conf.has_ansible() is False
+
+
+@pytest.mark.skipif("FUZZYTEST" not in os.environ, reason="Fuzzy test disabled by default")
+@given(dictionaries(text(), text()), dictionaries(text(), text()))
+def test_conf_has_ansible(conf_dict, conf_ansible):
+    data = conf_dict
+    data['ansible'] = conf_ansible
+    conf = CONF(data)
+    assert conf.has_ansible() is True
+
+
+@pytest.mark.skipif("FUZZYTEST" not in os.environ, reason="Fuzzy test disabled by default")
+@given(dictionaries(text(), text()))
+def test_yaml_to_tfvars(conf_dict_date):
+    conf_dict = dict()
+    conf_dict['terraform'] = dict()
+    conf_dict['terraform']['variables'] = conf_dict_date
+    conf = CONF(conf_dict)
+    if conf.terraform_yml():
+        tfvars = conf.yaml_to_tfvars()
+        assert isinstance(tfvars, str)

--- a/scripts/qesap/tox.ini
+++ b/scripts/qesap/tox.ini
@@ -1,12 +1,13 @@
 [tox]
-envlist = flake8,pylint,py38
+envlist = py39,py310,py311,flake8,pylint
 skipsdist = True
 
 [gh-actions]
 python =
-    3.8: py38
+    3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [testenv:flake8]
 deps = -r{toxinidir}/requirements-dev.txt
@@ -19,6 +20,25 @@ commands = flake8 test/
 [testenv:pylint]
 deps = -r{toxinidir}/requirements-dev.txt
 commands = pylint --rcfile=pylint.rc qesap.py lib/
+
+[testenv:pytest_verbose]
+deps = -r{toxinidir}/requirements-dev.txt
+setenv =
+    PYTHONPATH = {toxinidir}:{toxinidir}
+commands = pytest -vv -o log_cli=true -o log_cli_level=10 {posargs:test/unit}
+
+[testenv:pytest_finddep]
+deps = -r{toxinidir}/requirements-dev.txt
+setenv =
+    PYTHONPATH = {toxinidir}:{toxinidir}
+commands = pytest --find-dependencies {posargs:test/unit}
+
+[testenv:pytest_hypo]
+deps = -r{toxinidir}/requirements-dev.txt
+setenv =
+    PYTHONPATH = {toxinidir}:{toxinidir}
+    FUZZYTEST = 1
+commands = pytest {posargs:test/unit}
 
 [testenv]
 deps = -r{toxinidir}/requirements-dev.txt


### PR DESCRIPTION
Add Hypotesys that is a UT framework for Boundary defined tests (to keep it simpl ea sort of fuzzer).
Add pytest plugin `pytest-find-dependencies` and create a tox env and a Makefile target  to run it.
Add tox and Makefile target to run pytest in verbose mode.