### PR TITLE
Extend the test coverage for the ansible log file feature

### DIFF
--- a/scripts/qesap/test/conftest.py
+++ b/scripts/qesap/test/conftest.py
@@ -6,6 +6,7 @@ import pytest
 
 # pylint: disable=redefined-outer-name
 
+
 @pytest.fixture()
 def config_data_sample():
     """
@@ -14,15 +15,21 @@ def config_data_sample():
     :return:
     dict based data structure
     """
-    def _callback(provider='pinocchio',
-                  az_region='westeurope',
-                  hana_ips=None,
-                  hana_disk_configuration=None):
+
+    def _callback(
+        provider="pinocchio",
+        az_region="westeurope",
+        hana_ips=None,
+        hana_disk_configuration=None,
+    ):
 
         # Default values
-        hana_ips = hana_ips if hana_ips else ['10.0.0.2', '10.0.0.3']
-        hana_disk_configuration = hana_disk_configuration if \
-            hana_disk_configuration else {'disk_type': 'hdd,hdd,hdd', 'disks_size': '64,64,64'}
+        hana_ips = hana_ips if hana_ips else ["10.0.0.2", "10.0.0.3"]
+        hana_disk_configuration = (
+            hana_disk_configuration
+            if hana_disk_configuration
+            else {"disk_type": "hdd,hdd,hdd", "disks_size": "64,64,64"}
+        )
 
         # Config template
         config = {
@@ -41,6 +48,7 @@ def config_data_sample():
         }
 
         return config
+
     return _callback
 
 
@@ -79,8 +87,8 @@ ansible:
     secondary_site: 'miky'
 """
 
-    def _callback(provider='pinocchio', apiver=3, template_file=None):
-        tfvar_template_setting = ''
+    def _callback(provider="pinocchio", apiver=3, template_file=None):
+        tfvar_template_setting = ""
         if template_file is not None:
             tfvar_template_setting = f"tfvar_template: {template_file}"
 
@@ -117,7 +125,7 @@ ansible:
     secondary_site: 'miky'
 """
 
-    def _callback(terraform_section, provider='pinocchio', apiver=3):
+    def _callback(terraform_section, provider="pinocchio", apiver=3):
         return config.format(apiver, provider, terraform_section)
 
     return _callback
@@ -126,7 +134,7 @@ ansible:
 @pytest.fixture
 def provider_dir(tmpdir):
     def _callback(provider):
-        provider_path = os.path.join(tmpdir, 'terraform', provider)
+        provider_path = os.path.join(tmpdir, "terraform", provider)
         if not os.path.isdir(provider_path):
             os.makedirs(provider_path)
         return provider_path
@@ -137,7 +145,7 @@ def provider_dir(tmpdir):
 @pytest.fixture
 def playbooks_dir(tmpdir):
     def _callback():
-        playbooks_path = os.path.join(tmpdir, 'ansible', 'playbooks')
+        playbooks_path = os.path.join(tmpdir, "ansible", "playbooks")
         if not os.path.isdir(playbooks_path):
             os.makedirs(playbooks_path)
         return playbooks_path
@@ -151,8 +159,8 @@ def create_playbooks(playbooks_dir):
         playbook_filename_list = []
         for playbook in playbook_list:
             ans_plybk_path = playbooks_dir()
-            playbook_filename = os.path.join(ans_plybk_path, playbook + '.yaml')
-            with open(playbook_filename, 'w', encoding='utf-8') as file:
+            playbook_filename = os.path.join(ans_plybk_path, playbook + ".yaml")
+            with open(playbook_filename, "w", encoding="utf-8") as file:
                 file.write("")
             playbook_filename_list.append(playbook_filename)
         return playbook_filename_list
@@ -169,9 +177,9 @@ provider: {provider}
 ansible:
     hana_urls: somesome"""
 
-        for seq in ['create', 'destroy']:
+        for seq in ["create", "destroy"]:
             if seq in playbooks:
-                config_content += f"\n    {seq}:"""
+                config_content += f"\n    {seq}:"
                 for play in playbooks[seq]:
                     config_content += f"\n        - {play}.yaml"
         return config_content
@@ -179,10 +187,47 @@ ansible:
     return _callback
 
 
+FAKE_BIN_PATH = "/paese/della/cuccagna/"
+ANSIBLE_EXE = FAKE_BIN_PATH + "ansible"
+ANSIBLEPB_EXE = FAKE_BIN_PATH + "ansible-playbook"
+
+
+@pytest.fixture()
+def ansible_exe_call():
+    def _callback(inventory):
+        return [
+            ANSIBLE_EXE,
+            "-vv",
+            "-i",
+            inventory,
+            "all",
+            "-a",
+            "true",
+            '--ssh-extra-args="-l cloudadmin -o UpdateHostKeys=yes -o StrictHostKeyChecking=accept-new"',
+        ]
+
+    return _callback
+
+
 @pytest.fixture
-def ansible_playbook_cmd():
-    def _callback(exe, inventory, playbook):
-        return [exe, '-vv', '-i', inventory, playbook]
+def mock_call_ansibleplaybook():
+    """
+    create a mock.call with some default elements
+    ```
+    mock.call(['ansible-playbook', '-i', inventory, playbook], env={'ANSIBLE_PIPELINING', 'True'})
+    ```
+    """
+
+    def _callback(inventory, playbook, verbosity="-vv", arguments=None, env=None):
+        playbook_cmd = [ANSIBLEPB_EXE, verbosity, "-i", inventory, playbook]
+        if arguments is not None:
+            playbook_cmd += arguments
+        if env is None:
+            original_env = dict(os.environ)
+            original_env["ANSIBLE_PIPELINING"] = "True"
+        else:
+            original_env = env
+        return mock.call(cmd=playbook_cmd, env=original_env)
 
     return _callback
 
@@ -192,10 +237,11 @@ def create_inventory(provider_dir):
     """
     Create an empty inventory file
     """
+
     def _callback(provider):
         provider_path = provider_dir(provider)
-        inventory_filename = os.path.join(provider_path, 'inventory.yaml')
-        with open(inventory_filename, 'w', encoding='utf-8') as file:
+        inventory_filename = os.path.join(provider_path, "inventory.yaml")
+        with open(inventory_filename, "w", encoding="utf-8") as file:
             file.write("")
         return inventory_filename
 
@@ -210,22 +256,23 @@ def base_args(tmpdir):
         base_dir (str): used for -b
         config_file (str): used for -c
     """
+
     def _callback(base_dir=None, config_file=None, verbose=True):
         args = []
         if verbose:
-            args.append('--verbose')
+            args.append("--verbose")
 
-        args.append('--base-dir')
+        args.append("--base-dir")
         if base_dir is None:
             args.append(str(tmpdir))
         else:
             args.append(str(base_dir))
 
-        args.append('--config-file')
+        args.append("--config-file")
         if config_file is None:
             # create an empty config.yaml
-            config_file_name = str(tmpdir / 'config.yaml')
-            with open(config_file_name, 'w', encoding='utf-8') as file:
+            config_file_name = str(tmpdir / "config.yaml")
+            with open(config_file_name, "w", encoding="utf-8") as file:
                 file.write("")
             args.append(config_file_name)
         else:
@@ -239,20 +286,20 @@ def base_args(tmpdir):
 def args_helper(tmpdir, base_args, provider_dir):
     def _callback(provider, conf, tfvar_template=None):
         provider_path = provider_dir(provider)
-        tfvar_path = os.path.join(provider_path, 'terraform.tfvars')
+        tfvar_path = os.path.join(provider_path, "terraform.tfvars")
 
-        ansiblevars_path = os.path.join(tmpdir, 'ansible', 'playbooks', 'vars')
+        ansiblevars_path = os.path.join(tmpdir, "ansible", "playbooks", "vars")
         if not os.path.isdir(ansiblevars_path):
             os.makedirs(ansiblevars_path)
-        hana_media = os.path.join(ansiblevars_path, 'hana_media.yaml')
-        hana_vars = os.path.join(ansiblevars_path, 'hana_vars.yaml')
+        hana_media = os.path.join(ansiblevars_path, "hana_media.yaml")
+        hana_vars = os.path.join(ansiblevars_path, "hana_vars.yaml")
 
-        config_file_name = str(tmpdir / 'config.yaml')
-        with open(config_file_name, 'w', encoding='utf-8') as file:
+        config_file_name = str(tmpdir / "config.yaml")
+        with open(config_file_name, "w", encoding="utf-8") as file:
             file.write(conf)
         if tfvar_template is not None:
-            with open(tfvar_template['file'], 'w', encoding='utf-8') as file:
-                for line in tfvar_template['data']:
+            with open(tfvar_template["file"], "w", encoding="utf-8") as file:
+                for line in tfvar_template["data"]:
                     file.write(line)
 
         args = base_args(base_dir=tmpdir, config_file=config_file_name)
@@ -264,8 +311,10 @@ def args_helper(tmpdir, base_args, provider_dir):
 @pytest.fixture
 def configure_helper(args_helper):
     def _callback(provider, conf, tfvar_template=None):
-        args, _, tfvar_path, hana_media, hana_vars = args_helper(provider, conf, tfvar_template)
-        args.append('configure')
+        args, _, tfvar_path, hana_media, hana_vars = args_helper(
+            provider, conf, tfvar_template
+        )
+        args.append("configure")
         return args, tfvar_path, hana_media, hana_vars
 
     return _callback
@@ -273,15 +322,12 @@ def configure_helper(args_helper):
 
 @pytest.fixture
 def create_config():
-    """Create one element for the list in the configure.json related to trento_deploy.py -s
-    """
+    """Create one element for the list in the configure.json related to trento_deploy.py -s"""
+
     def _callback(typ, reg, ver):
-        config = {
-            'type': typ,
-            'registry': reg
-        }
+        config = {"type": typ, "registry": reg}
         if ver:
-            config['version'] = ver
+            config["version"] = ver
         return config
 
     return _callback
@@ -292,6 +338,7 @@ def line_match():
     """
     return True if matcher string is present at least one in the string_list
     """
+
     def _callback(string_list, matcher):
         return len([s for s in string_list if matcher in s]) > 0
 
@@ -309,52 +356,57 @@ def check_duplicate():
 
         Returns:
             tuple: True/False result, if False str about the error message
-        """
+    """
+
     def _callback(lines):
         for line in lines:
             if len([s for s in lines if line.strip() in s.strip()]) != 1:
                 return (False, "Line '" + line + "' appear more than one time")
-            if '--set' in line:
-                setting = line.split(' ')[1]
-                setting_field = setting.split('=')[0]
+            if "--set" in line:
+                setting = line.split(" ")[1]
+                setting_field = setting.split("=")[0]
                 if len([s for s in lines if setting_field in s]) != 1:
-                    return (False, "Setting '" + setting_field + "' appear more than one time")
-        return (True, '')
+                    return (
+                        False,
+                        "Setting '" + setting_field + "' appear more than one time",
+                    )
+        return (True, "")
 
     return _callback
 
 
 @pytest.fixture
 def check_manadatory_args(capsys, tmpdir):
-    '''
+    """
     Given a cli to test and a subcommand string,
     check that both -c and -b are mandatory
-    '''
+    """
+
     def _callback(cli_to_test, subcmd):
         try:
             cli_to_test([subcmd])
         except SystemExit:
             pass
         captured = capsys.readouterr()
-        if 'error:' not in captured.err:
+        if "error:" not in captured.err:
             return False
 
         # Try with b but without c
         try:
-            cli_to_test(['-b', str(tmpdir), subcmd])
+            cli_to_test(["-b", str(tmpdir), subcmd])
         except SystemExit:
             pass
         captured = capsys.readouterr()
-        if 'error:' not in captured.err:
+        if "error:" not in captured.err:
             return False
 
         # Try with c but without b
         try:
-            cli_to_test(['-c', str(tmpdir), subcmd])
+            cli_to_test(["-c", str(tmpdir), subcmd])
         except SystemExit:
             pass
         captured = capsys.readouterr()
-        if 'error:' not in captured.err:
+        if "error:" not in captured.err:
             return False
         return True
 
@@ -362,24 +414,8 @@ def check_manadatory_args(capsys, tmpdir):
 
 
 @pytest.fixture
-def mock_call_ansibleplaybook():
-    '''
-    create a mock.call with some default elements
-    ```
-    mock.call(['ansible-playbook', '-i', inventory, playbook], env={'ANSIBLE_PIPELINING', 'True'})
-    ```
-    '''
-    def _callback(playbook_cmd):
-        original_env = dict(os.environ)
-        original_env['ANSIBLE_PIPELINING'] = 'True'
-        return mock.call(cmd=playbook_cmd, env=original_env)
-
-    return _callback
-
-
-@pytest.fixture
 def validate_hana_media():
-    '''
+    """
     Validate hana_media.yaml file needed by Ansible
 
     ```
@@ -391,34 +427,67 @@ def validate_hana_media():
       - <IMDB_SERVER_SAR>
       - <IMDB_CLIENT_SAR>
     ```
-    '''
-    def _callback(hana_media_file, account='ACCOUNT', container='CONTAINER', token=None, sapcar='SAPCAR_EXE', imdb_srv='IMDB_SERVER_SAR', imdb_cln='IMDB_CLIENT_SAR'):
-        with open(hana_media_file, 'r', encoding='utf-8') as file:
+    """
+
+    def _callback(
+        hana_media_file,
+        account="ACCOUNT",
+        container="CONTAINER",
+        token=None,
+        sapcar="SAPCAR_EXE",
+        imdb_srv="IMDB_SERVER_SAR",
+        imdb_cln="IMDB_CLIENT_SAR",
+    ):
+        with open(hana_media_file, "r", encoding="utf-8") as file:
             data = yaml.load(file, Loader=yaml.FullLoader)
 
-            if 'az_storage_account_name' not in data:
-                return False, 'az_storage_account_name missing in the generated hana_media.yaml'
-            if account != data['az_storage_account_name']:
-                return False, f"az_storage_account_name value is {data['az_storage_account_name']} and not expected {account}"
+            if "az_storage_account_name" not in data:
+                return (
+                    False,
+                    "az_storage_account_name missing in the generated hana_media.yaml",
+                )
+            if account != data["az_storage_account_name"]:
+                return (
+                    False,
+                    f"az_storage_account_name value is {data['az_storage_account_name']} and not expected {account}",
+                )
 
-            if 'az_container_name' not in data:
-                return False, 'az_container_name missing in the generated hana_media.yaml'
-            if container != data['az_container_name']:
-                return False, f"az_container_name value is {data['az_container_name']} and not expected {container}"
+            if "az_container_name" not in data:
+                return (
+                    False,
+                    "az_container_name missing in the generated hana_media.yaml",
+                )
+            if container != data["az_container_name"]:
+                return (
+                    False,
+                    f"az_container_name value is {data['az_container_name']} and not expected {container}",
+                )
 
             # az_sas_token is optional, test it only if requested
             if token:
-                if 'az_sas_token' not in data:
-                    return False, 'az_sas_token missing in the generated hana_media.yaml'
-                if token != data['az_sas_token']:
-                    return False, f"az_sas_token value is {data['az_sas_token']} and not expected {token}"
+                if "az_sas_token" not in data:
+                    return (
+                        False,
+                        "az_sas_token missing in the generated hana_media.yaml",
+                    )
+                if token != data["az_sas_token"]:
+                    return (
+                        False,
+                        f"az_sas_token value is {data['az_sas_token']} and not expected {token}",
+                    )
 
-            blob_key = 'az_blobs'
+            blob_key = "az_blobs"
             if blob_key not in data:
-                return False, f"{blob_key} section missing in the generated hana_media.yaml"
+                return (
+                    False,
+                    f"{blob_key} section missing in the generated hana_media.yaml",
+                )
             urls_num = len(data[blob_key])
             if urls_num != 3:
-                return False, f"Number of elements in {blob_key} is {urls_num} and not 3"
+                return (
+                    False,
+                    f"Number of elements in {blob_key} is {urls_num} and not 3",
+                )
             if sapcar not in data[blob_key]:
                 return False, f"{sapcar} missing in {blob_key}: {data[blob_key]}"
             if imdb_srv not in data[blob_key]:
@@ -426,6 +495,6 @@ def validate_hana_media():
             if imdb_cln not in data[blob_key]:
                 return False, f"{imdb_cln} missing in {blob_key}: {data[blob_key]}"
 
-        return (True, '')
+        return (True, "")
 
     return _callback

--- a/scripts/qesap/test/unit/test_qesap_lib_cmd_terraform.py
+++ b/scripts/qesap/test/unit/test_qesap_lib_cmd_terraform.py
@@ -10,16 +10,16 @@ log = logging.getLogger(__name__)
 
 
 def test_create_tfvars_string():
-    '''
+    """
     Try .tfvars generation for string terraform variables format in config.yaml
-    '''
+    """
 
     # This test overlap a little bit with test_tfvars_yaml
-    conf_yaml = '''---
+    conf_yaml = """---
 terraform:
   variables:
     az_region: "westeurope"
-'''
+"""
     data = yaml.load(conf_yaml, Loader=yaml.FullLoader)
     config = CONF(data)
     tfvar_content, err = create_tfvars(config, None)
@@ -29,14 +29,14 @@ terraform:
 
 
 def test_create_tfvars_int():
-    '''
+    """
     Try .tfvars generation for int terraform variables format in config.yaml
-    '''
-    conf_yaml = '''---
+    """
+    conf_yaml = """---
 terraform:
   variables:
     sandwiches: 5
-'''
+"""
     data = yaml.load(conf_yaml, Loader=yaml.FullLoader)
     config = CONF(data)
     tfvar_content, err = create_tfvars(config, None)
@@ -46,16 +46,16 @@ terraform:
 
 
 def test_create_tfvars_list():
-    '''
+    """
     Try .tfvars generation for list terraform variables format in config.yaml
-    '''
-    conf_yaml = '''---
+    """
+    conf_yaml = """---
 terraform:
   variables:
     sandwiches:
       - tuna
       - club
-'''
+"""
     data = yaml.load(conf_yaml, Loader=yaml.FullLoader)
     config = CONF(data)
     tfvar_content, err = create_tfvars(config, None)
@@ -65,14 +65,14 @@ terraform:
 
 
 def test_create_tfvars_unsupported_format():
-    '''
+    """
     Try .tfvars generation for float in conf.yaml result in an error
-    '''
-    conf_yaml = '''---
+    """
+    conf_yaml = """---
 terraform:
   variables:
     sandwiches: 3.14
-'''
+"""
     data = yaml.load(conf_yaml, Loader=yaml.FullLoader)
     config = CONF(data)
     tfvar_content, err = create_tfvars(config, None)
@@ -81,41 +81,41 @@ terraform:
 
 
 def test_create_tfvars_string_with_template(tmpdir):
-    '''
+    """
     Try .tfvars generation from .tfvar.template and conf.yaml without overlapping variables
-    '''
-    conf_yaml = '''---
+    """
+    conf_yaml = """---
 terraform:
   variables:
     sandwiches: "club"
-'''
+"""
     data = yaml.load(conf_yaml, Loader=yaml.FullLoader)
     config = CONF(data)
-    tfvar_template_file = str(tmpdir / 'gnocchi.txt')
-    with open(tfvar_template_file, 'w', encoding='utf-8') as file:
-        file.write('# This is a comment')
+    tfvar_template_file = str(tmpdir / "gnocchi.txt")
+    with open(tfvar_template_file, "w", encoding="utf-8") as file:
+        file.write("# This is a comment")
 
     tfvar_content, err = create_tfvars(config, tfvar_template_file)
 
     log.error(tfvar_content)
     assert err is None, "Unexpected err from create_tfvars:" + str(err)
-    assert '# This is a comment\n' in tfvar_content
+    assert "# This is a comment\n" in tfvar_content
     assert 'sandwiches = "club"\n' in tfvar_content
 
 
 def test_create_tfvars_string_with_template_and_substitution(tmpdir):
-    '''
+    """
     Try .tfvars generation from .tfvar.template and conf.yaml with overlapping string variables
-    '''
-    conf_yaml = '''---
+    """
+    conf_yaml = """---
 terraform:
   variables:
     sandwiches: "club"
-'''
+"""
     data = yaml.load(conf_yaml, Loader=yaml.FullLoader)
     config = CONF(data)
-    tfvar_template_file = str(tmpdir / 'gnocchi.txt')
-    with open(tfvar_template_file, 'w', encoding='utf-8') as file:
+    tfvar_template_file = str(tmpdir / "gnocchi.txt")
+    with open(tfvar_template_file, "w", encoding="utf-8") as file:
         file.write('sandwiches = "cheese"')
 
     tfvar_content, err = create_tfvars(config, tfvar_template_file)
@@ -126,20 +126,20 @@ terraform:
 
 
 def test_create_tfvars_list_with_template_and_substitution(tmpdir):
-    '''
+    """
     Try .tfvars generation from .tfvar.template and conf.yaml with overlapping list variables
-    '''
-    conf_yaml = '''---
+    """
+    conf_yaml = """---
 terraform:
   variables:
     sandwiches:
       - club
       - cheese
-'''
+"""
     data = yaml.load(conf_yaml, Loader=yaml.FullLoader)
     config = CONF(data)
-    tfvar_template_file = str(tmpdir / 'gnocchi.txt')
-    with open(tfvar_template_file, 'w', encoding='utf-8') as file:
+    tfvar_template_file = str(tmpdir / "gnocchi.txt")
+    with open(tfvar_template_file, "w", encoding="utf-8") as file:
         file.write('sandwiches = ["tuna", "vegan"]')
 
     tfvar_content, err = create_tfvars(config, tfvar_template_file)
@@ -151,15 +151,15 @@ terraform:
 
 @mock.patch("lib.process_manager.subprocess_run")
 def test_cmd_terraform(subprocess_run, tmpdir):
-    '''
+    """
     This test coverage overlap with tests from
     scripts/qesap/test/unit/test_qesap_terraform.py
 
     this one is calling lower API than the other
-    '''
+    """
 
     # Set env and input
-    conf_yaml = '''---
+    conf_yaml = """---
 apiver: 3
 provider: "lolo"
 terraform:
@@ -167,20 +167,21 @@ terraform:
     sandwiches:
       - club
       - cheese
-'''
+"""
     data = yaml.load(conf_yaml, Loader=yaml.FullLoader)
-    provider_folder = tmpdir / 'terraform' / 'lolo'
+    provider_folder = tmpdir / "terraform" / "lolo"
     os.makedirs(provider_folder)
-    subprocess_run.return_value = (0, ['This is the terraform output', 'Two lines of that'])
+    subprocess_run.return_value = (
+        0,
+        ["This is the terraform output", "Two lines of that"],
+    )
 
     # Set expectation
     calls = []
-    terraform_cmd = [
-        'terraform',
-        f"-chdir={provider_folder}"]
+    terraform_cmd = ["terraform", f"-chdir={provider_folder}"]
     # Just test one of them
-    terraform_cmd.append('init')
-    terraform_cmd.append('-no-color')
+    terraform_cmd.append("init")
+    terraform_cmd.append("-no-color")
     calls.append(mock.call(terraform_cmd))
 
     ret = cmd_terraform(data, tmpdir, False)


### PR DESCRIPTION
Ticket: https://jira.suse.com/browse/TEAM-6844

- Remove double log from Terraform in case of PASS in verbose mode
- export_ansible_output
    - Rename `export_ansible_output` to aligne it to all other ansible related function
    - Change API of export_ansible_output to accept `cmd` in a more direct way
    - Add docstring
- lib/cmd to always print exit code of the executed command
- Run static analysis on the test code too at each PR
- reorganixe UT and fixture

# Verification
 - sle-15-SP5-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_5_PAYG-qesap_azure_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/286219
 - sle-15-SP5-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_5_BYOS-qesap_aws_r5bmetal_test@64bit -> http://openqaworker15.qa.suse.cz/tests/286220
 - sle-15-SP6-Qesap-Azure-Byos-Ibs-x86_64-BuildLATEST_AZURE_SLE15_6_BYOS_IBS-qesap_azure_uri@az_Standard_E8s_v3 -> http://openqaworker15.qa.suse.cz/tests/286221
 - sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2024-06-13T02:03:18Z-hanasr_azure_test_sbd@64bit -> http://openqaworker15.qa.suse.cz/tests/286222
 - sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2024-06-13T02:03:18Z-hanasr_azure_test_sbd@64bit -> http://openqaworker15.qa.suse.cz/tests/286482