### PR TITLE
Fix ansible timed out for last boot time check 600

### DIFF
--- a/ansible/playbooks/fully-patch-system.yaml
+++ b/ansible/playbooks/fully-patch-system.yaml
@@ -19,4 +19,6 @@
   handlers:
     - name: Reboot after patch
       ansible.builtin.reboot:
+        msg: "Reboot initiated by Ansible - after full patch system"
         reboot_timeout: "{{ use_reboottimeout | int }}"
+        connect_timeout: 5

--- a/ansible/playbooks/sap-hana-preconfigure.yaml
+++ b/ansible/playbooks/sap-hana-preconfigure.yaml
@@ -75,4 +75,6 @@
   handlers:
     - name: Reboot
       ansible.builtin.reboot:
+        msg: "Reboot initiated by Ansible - after sap hana preconfigure"
         reboot_timeout: "{{ use_reboottimeout | int }}"
+        connect_timeout: 5


### PR DESCRIPTION
Fix ansible timed out for last boot time check
Related ticket: [TEAM-8893](https://jira.suse.com/browse/TEAM-8893) - Follow up to sporadic HANA reboot timeout in qe-sap-deployment Ansible

FYI: 
connect_timeout:
Maximum seconds to wait for a successful connection to the managed hosts before trying again.
If unspecified, the default setting for the underlying connection plugin is used.
(See https://docs.ansible.com/ansible/latest/collections/ansible/builtin/reboot_module.html)

VRs: tried 20+ times and this timed out issue disappears.
https://openqa.suse.de/tests/14714474#next_previous 