### PR TITLE
Add workaround for bsc1224249

### DIFF
--- a/ansible/playbooks/fully-patch-system.yaml
+++ b/ansible/playbooks/fully-patch-system.yaml
@@ -8,6 +8,12 @@
     use_reboottimeout: 600
 
   tasks:
+    # Workaround for bsc#1224249
+    - name: Install python3-argcomplete
+      community.general.zypper:
+        name: 'python3-argcomplete'
+        state: latest
+
     # Fully patch system
     - name: Apply all available patches
       community.general.zypper:


### PR DESCRIPTION
S:M:33974:python3 breaks installation of `python3` in 15-SP5 images in CSP's catalogs. Seems issue comes from the `python3-argcomplete` package shipped in the OS image, which breaks a post installation script during the installation of `python3`. This workaround will only be required if S:M:33974 gets released, and until 15-SP5 images are refreshed in the CSPs later in 2024.

**IMPORTANT**: only merge if the MU is released and it starts impacting all tests in the cloud.