### PR TITLE
Add playbook for ptf installation

### DIFF
--- a/ansible/playbooks/additional_fence_agent_tasks.yaml
+++ b/ansible/playbooks/additional_fence_agent_tasks.yaml
@@ -1,0 +1,28 @@
+---
+- name: PTF Installation
+  hosts: hana
+  remote_user: cloudadmin
+  become: true
+  become_user: root
+
+  tasks:
+    - name: Verify installation
+      command: "rpm -qf $(which fence_azure_arm)"
+      args:
+        _uses_shell: true
+      register: verify_installation
+
+    - name: Display verification result
+      debug:
+        var: verify_installation.stdout_lines
+
+    - name: Install additional Python packages
+      zypper:
+        name:
+          - python311-pexpect
+          - python311-pycurl
+        state: present
+        update_cache: true
+
+    - name: Modify fence_azure_arm script to use Python 3.11
+      command: "sed -i s/python3/python3.11/ /usr/sbin/fence_azure_arm"

--- a/ansible/playbooks/ptf_installation.yaml
+++ b/ansible/playbooks/ptf_installation.yaml
@@ -1,0 +1,60 @@
+---
+- name: PTF Installation
+  hosts: hana
+  remote_user: cloudadmin
+  become: true
+  become_user: root
+  vars:
+    ptf_url: "your_ptf_url"
+    ptf_user: "your_username_here"
+    ptf_password: "your_pass_here"
+    ptf_dir: "/tmp/ptf_dir"
+  tasks:
+    - name: Create directory for PTF installation
+      file:
+        path: "{{ ptf_dir }}"
+        state: directory
+        mode: '0755'
+
+    - name: Download PTF files recursively with wget
+      command: "wget --no-directories --recursive --reject 'index.html*' --user={{ ptf_user }} --password={{ ptf_password }} --no-parent {{ ptf_url }}"
+      args:
+        chdir: "{{ ptf_dir }}"
+
+    - name: List downloaded files
+      command: "ls -la"
+      args:
+        chdir: "{{ ptf_dir }}"
+      register: download_list
+
+    - name: Display downloaded files
+      debug:
+        var: download_list.stdout_lines
+
+    - name: Find downloaded RPM files
+      find:
+        paths: "{{ ptf_dir }}"
+        patterns: "*.rpm"
+      register: rpm_files
+
+    - name: Display found RPM files
+      debug:
+        var: rpm_files.files
+
+    - name: Filter out src.rpm files
+      set_fact:
+        filtered_rpm_files: "{{ rpm_files.files | selectattr('path', 'search', '^(?!.*src\\.rpm$).*') | list }}"
+
+    - name: Display filtered RPM files
+      debug:
+        var: filtered_rpm_files
+
+    - name: Install PTF RPM packages
+      zypper:
+        name: "{{ item.path }}"
+        state: present
+        disable_gpg_check: true
+        update_cache: true
+      loop: "{{ filtered_rpm_files }}"
+      loop_control:
+        label: "{{ item.path }}"


### PR DESCRIPTION
This is the first step for the related ticket (it enables manual deployment).

This commit adds a playbook to automate download and installation of ptf packages for **manual** deployment (since you need to add username/pass in the playbook vars for this to work, and you don't want them in openqa for all to see).

It also has some specific commands about a specific ptf(fence agents for azure) in a separate playbook, but the first playbook can be used with any ptf (probably).

**Instructions**:
- go to `ansible/playbooks/ptf_installation.yaml`
- in the `vars` section, add the PTF url, your SUSE dev username and your SUSE dev pass
- add the playbooks in your custom `config.yaml`, with the ptf one first and the fence agents one second, for example after the `fully_patch_system` playbook

That's it! Just run the deployment as normal, and the playbook will automatically download the ptf, install all non-src rpms (up to here it's generic for any ptf), and then install additional python311 deps and change the `fence_azure_arm` shebang.

- Related ticket: https://jira.suse.com/browse/TEAM-9453