### PR TITLE
Add cloud provider name in the intentory

### DIFF
--- a/ansible/playbooks/cluster_sbd_prep.yaml
+++ b/ansible/playbooks/cluster_sbd_prep.yaml
@@ -8,9 +8,7 @@
     - name: Detect cloud platform
       ansible.builtin.include_tasks:
         ./tasks/detect-cloud-platform.yaml
-    - name: Detection result
-      ansible.builtin.debug:
-        msg: "Cloud platform appears to be {{ cloud_platform_name }}"
+
     - name: Include sdb vars
       ansible.builtin.include_vars: ./vars/sbd_parameters.yaml
 

--- a/ansible/playbooks/pre-cluster.yaml
+++ b/ansible/playbooks/pre-cluster.yaml
@@ -1,14 +1,11 @@
 ---
-- hosts: all
-  name: Cluster preparation
+- name: Cluster preparation
+  hosts: all
   remote_user: cloudadmin
   pre_tasks:
     - name: Detect cloud platform
       ansible.builtin.include_tasks:
         ./tasks/detect-cloud-platform.yaml
-    - name: Detection result
-      ansible.builtin.debug:
-        msg: "Cloud platform appears to be {{ cloud_platform_name }}"
 
   tasks:
     - name: Ensure all hosts are present in all hosts /etc/hosts files
@@ -37,7 +34,7 @@
       ansible.builtin.file:
         path: "{{ ansible_env.HOME }}/.ssh"
         state: directory
-        owner: "{{ansible_user}}"
+        owner: "{{ ansible_user }}"
         group: users
         mode: '0700'
       when: inventory_hostname in groups.hana
@@ -57,7 +54,7 @@
 
     - name: Generate public/private keys for cloudadmin on hana hosts
       community.crypto.openssh_keypair:
-        owner: "{{ansible_user}}"
+        owner: "{{ ansible_user }}"
         group: users
         mode: '0600'
         path: "{{ ansible_env.HOME }}/.ssh/id_rsa"
@@ -80,7 +77,7 @@
 
     - name: Apply cloudadmin pub key to other node cloudadmin Authorised Keys
       ansible.posix.authorized_key:
-        user: "{{ansible_user}}"
+        user: "{{ ansible_user }}"
         state: present
         key: "{{ hostvars[item].ssh_user_keys.public_key }}"
       when: inventory_hostname in groups.hana and hostvars[item]['ansible_hostname'] in groups.hana and ansible_hostname != item

--- a/ansible/playbooks/sap-hana-cluster.yaml
+++ b/ansible/playbooks/sap-hana-cluster.yaml
@@ -1,5 +1,6 @@
 ---
-- hosts: hana
+- name: SAP Hana cluster
+  hosts: hana
   remote_user: cloudadmin
   become: true
   become_user: root
@@ -34,9 +35,6 @@
     - name: Detect cloud platform
       ansible.builtin.include_tasks:
         ./tasks/detect-cloud-platform.yaml
-    - name: Detection result
-      ansible.builtin.debug:
-        msg: "Cloud platform appears to be {{ cloud_platform_name }}"
 
     - name: Load SAP HANA variables
       ansible.builtin.include_vars: ./vars/hana_vars.yaml

--- a/ansible/playbooks/sap-hana-storage.yaml
+++ b/ansible/playbooks/sap-hana-storage.yaml
@@ -1,5 +1,6 @@
 ---
-- hosts: hana
+- name: SAP Hana storage
+  hosts: hana
   remote_user: cloudadmin
   become: true
   become_user: root
@@ -7,9 +8,6 @@
     - name: Detect cloud platform
       ansible.builtin.include_tasks:
         ./tasks/detect-cloud-platform.yaml
-    - name: Detection result
-      ansible.builtin.debug:
-        msg: "Cloud platform appears to be {{ cloud_platform_name }}"
 
   tasks:
     - name: Load AWS disk configuration for R4 instances
@@ -33,5 +31,5 @@
         sap_storage_cloud_type: 'generic'
         sap_storage_sap_type: 'sap_hana'
         sap_storage_action: 'prepare'
-      include_role:
+      ansible.builtin.include_role:
         name: ../roles/qe_sap_storage

--- a/ansible/playbooks/tasks/detect-cloud-platform.yaml
+++ b/ansible/playbooks/tasks/detect-cloud-platform.yaml
@@ -16,7 +16,7 @@
       changed_when: false
       failed_when: false
       register: probe_aws
-
+      when: cloud_platform_name is undefined or cloud_platform_name | length == 0
 
     - name: "Probe for AWS 1"
       become: true
@@ -25,18 +25,27 @@
       changed_when: false
       failed_when: false
       register: probe_aws_1
+      when: cloud_platform_name is undefined or cloud_platform_name | length == 0 or cloud_platform_name == "aws"
 
     - name: Set AWS machine type fact
       ansible.builtin.set_fact:
         aws_machine_type: true
-      when: probe_aws_1.stdout is match(".*amazon")
+      when:
+        - cloud_platform_name is undefined or cloud_platform_name | length == 0 or cloud_platform_name == "aws"
+        - probe_aws_1.stdout is match(".*amazon")
 
     - name: Set AWS discovery fact
       ansible.builtin.set_fact:
         cloud_platform_is_aws: true
       when:
+        - cloud_platform_name is undefined or cloud_platform_name | length == 0
         - probe_aws.rc == 0
-        - probe_aws.stdout | lower == 'amazon ec2'  or probe_aws_1.stdout is match(".*amazon")
+        - probe_aws.stdout | lower == 'amazon ec2' or probe_aws_1.stdout is match(".*amazon")
+
+    - name: Set AWS  from var
+      ansible.builtin.set_fact:
+        cloud_platform_is_aws: true
+      when: cloud_platform_name is defined and cloud_platform_name == "aws"
 
 # SEE: https://stackoverflow.com/questions/30911775/how-to-know-if-a-machine-is-an-google-compute-engine-instance
 - name: "Detect GCP"
@@ -49,13 +58,21 @@
       changed_when: false
       failed_when: false
       register: probe_gcp
+      when: cloud_platform_name is undefined or cloud_platform_name | length == 0
 
     - name: Set GCP discovery fact
       ansible.builtin.set_fact:
         cloud_platform_is_gcp: true
       when:
+        - cloud_platform_name is undefined or cloud_platform_name | length == 0
         - probe_gcp.rc == 0
         - probe_gcp.stdout | lower == 'google'
+
+    - name: Set GCP from var
+      ansible.builtin.set_fact:
+        cloud_platform_is_gcp: true
+      when:
+        - cloud_platform_name is defined and cloud_platform_name == 'gcp'
 
 # SEE: https://stackoverflow.com/questions/11570965/how-to-detect-azure-amazon-vm
 - name: "Detect Azure"
@@ -68,6 +85,7 @@
       changed_when: false
       failed_when: false
       register: probe_azure_1
+      when: cloud_platform_name is undefined or cloud_platform_name | length == 0
 
     - name: "Probe for Azure 2/2"
       become: true
@@ -76,12 +94,26 @@
       changed_when: false
       failed_when: false
       register: probe_azure_2
+      when: cloud_platform_name is undefined or cloud_platform_name | length == 0
 
     - name: Set Azure Discovery Fact
       ansible.builtin.set_fact:
         cloud_platform_is_azure: true
-      when: probe_azure_1.rc == 0 and probe_azure_1.stdout | lower == 'microsoft corporation' or probe_azure_2.rc == 0 and probe_azure_2.stdout | lower == 'virtual machine'
+      when:
+        - cloud_platform_name is undefined or cloud_platform_name | length == 0
+        - probe_azure_1.rc == 0 and probe_azure_1.stdout | lower == 'microsoft corporation' or probe_azure_2.rc == 0 and probe_azure_2.stdout | lower == 'virtual machine'
+
+    - name: Set Azure from var
+      ansible.builtin.set_fact:
+        cloud_platform_is_azure: true
+      when:
+        - cloud_platform_name is defined and cloud_platform_name == 'azure'
 
 - name: "Set Cloud Platform"
-  set_fact:
+  ansible.builtin.set_fact:
     cloud_platform_name: "{% if cloud_platform_is_azure %}azure{% elif cloud_platform_is_aws %}aws{% elif cloud_platform_is_gcp %}gcp{% else %}unknown{% endif %}"
+  when: cloud_platform_name is undefined or cloud_platform_name | length == 0
+
+- name: "Cloud Platform detection result"
+  ansible.builtin.debug:
+    msg: "Cloud platform appears to be {{ cloud_platform_name }}"

--- a/terraform/aws/inventory.tmpl
+++ b/terraform/aws/inventory.tmpl
@@ -1,5 +1,6 @@
 all:
   vars:
+    cloud_platform_name: aws
     use_sbd: ${use_sbd}
     aws_route_table_id: ${routetable_id}
     aws_cluster_ip: ${virtual_ip}

--- a/terraform/azure/inventory.tmpl
+++ b/terraform/azure/inventory.tmpl
@@ -1,5 +1,6 @@
 all:
   vars:
+    cloud_platform_name: azure
     use_sbd: ${use_sbd}
     resource_group_name: ${resource_group_name}
     subscription_id: ${subscription_id}

--- a/terraform/gcp/inventory.tmpl
+++ b/terraform/gcp/inventory.tmpl
@@ -1,5 +1,6 @@
 all:
   vars:
+    cloud_platform_name: gcp
     use_sbd: ${use_sbd}
     gcp_cluster_ip: ${hana-vip}
     prefix: ${name_prefix}


### PR DESCRIPTION
On the Terraform side: add the name of the cloud provider to the inventory. On the Ansible side: make the platform detection optional only in case the variable is not configured from the external (aka the inventory) This change allow to save time in many ansible playbooks.

Ticket: https://jira.suse.com/browse/TEAM-9474

# Verification

## HanaSR

 sle-15-SP5-HanaSr-Azure-Byos-x86_64-Build15-SP5_2024-06-13T02:03:18Z-hanasr_azure_test_sbd@64bit 
 - http://openqaworker15.qa.suse.cz/tests/287220
 - http://openqaworker15.qa.suse.cz/tests/287221
 
##  qesap regression

### Azure

#### sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_ibsmirror_peering_test@64bit 
 -  http://openqaworker15.qa.suse.cz/tests/287130
 -  http://openqaworker15.qa.suse.cz/tests/287222 :green_circle: http://openqaworker15.qa.suse.cz/tests/287222/logfile?filename=deploy-ansible.pre-cluster.log.txt shows:
    -- all the tasks in the `detect-cloud-platform.yaml` skipped. All out of `TASK [Set Azure from var]` and `TASK [Cloud Platform detection result]` that show `azure`

### AWS

#### sle-15-SP5-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_5_BYOS-qesap_aws_fencing_native_test@64bit 
 -  http://openqaworker15.qa.suse.cz/tests/287122 . Inventory file http://openqaworker15.qa.suse.cz/tests/287122/file/deploy-inventory.yaml has `cloud_platform_name: aws`
 - http://openqaworker15.qa.suse.cz/tests/287223 :green_circle: from http://openqaworker15.qa.suse.cz/tests/287223/logfile?filename=deploy-ansible.pre-cluster.log.txt shows:
     -- shows all the detect task skipped, all out of `TASK [Probe for AWS 1]` (that is needed to calculate `aws_machine_type`) and `TASK [Set AWS  from var]`

#### sle-15-SP5-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_5_BYOS-qesap_aws_r48xlarge_test@64bit
- http://openqaworker15.qa.suse.cz/tests/287224 :green_circle: in this example `"aws_machine_type": true`

 #### sle-15-SP5-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_5_BYOS-qesap_aws_r5bmetal_test@64bit
 -  http://openqaworker15.qa.suse.cz/tests/287226

### GCP

sle-15-SP5-Qesap-Gcp-Byos-x86_64-BuildLATEST_GCE_SLE15_5_BYOS-qesap_gcp_sapconf_test@64bit
 - http://openqaworker15.qa.suse.cz/tests/287227

sle-15-SP5-Qesap-Gcp-Byos-x86_64-BuildLATEST_GCE_SLE15_5_BYOS-qesap_gcp_sapconf_test@64bit 
 - http://openqaworker15.qa.suse.cz/tests/287228

 #### sle-15-SP5-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE15_5_PAYG-qesap_gcp_sapconf_test@64bit 
 -  http://openqaworker15.qa.suse.cz/tests/287126
 -  http://openqaworker15.qa.suse.cz/tests/287129