### PR TITLE
Fix sporadic reboot timeout in qe-sap-deployment

### DIFF
--- a/ansible/playbooks/fully-patch-system.yaml
+++ b/ansible/playbooks/fully-patch-system.yaml
@@ -5,7 +5,10 @@
   become: true
   become_user: root
   vars:
-    use_reboottimeout: 600
+    # Set use_reboottimeout default value to 1200,
+    # as for AWS 'r5b.metal' instance type the reboot elapses at least 800 seconds
+    use_reboottimeout: 1200
+    use_connecttimeout: 10
 
   tasks:
     # Fully patch system
@@ -21,4 +24,4 @@
       ansible.builtin.reboot:
         msg: "Reboot initiated by Ansible - after full patch system"
         reboot_timeout: "{{ use_reboottimeout | int }}"
-        connect_timeout: 5
+        connect_timeout: "{{ use_connecttimeout | int }}"

--- a/ansible/playbooks/sap-hana-preconfigure.yaml
+++ b/ansible/playbooks/sap-hana-preconfigure.yaml
@@ -6,7 +6,10 @@
   vars:
     scale_out: false
     use_sapconf: false
-    use_reboottimeout: 600
+    # Set use_reboottimeout default value to 1200,
+    # as for AWS 'r5b.metal' instance type the reboot elapses at least 800 seconds
+    use_reboottimeout: 1200
+    use_connecttimeout: 10
     saptune_solution: HANA
     platform: azure
     cluster_node: true
@@ -77,4 +80,4 @@
       ansible.builtin.reboot:
         msg: "Reboot initiated by Ansible - after sap hana preconfigure"
         reboot_timeout: "{{ use_reboottimeout | int }}"
-        connect_timeout: 5
+        connect_timeout: "{{ use_connecttimeout | int }}"


### PR DESCRIPTION
Fix sporadic HANA reboot timeout in qe-sap-deployment Ansible 

Related ticket:
 [TEAM-8893](https://jira.suse.com/browse/TEAM-8893) - Follow up to sporadic HANA reboot timeout in qe-sap-deployment Ansible

VRs:

- AWS r5b.metal: https://openqaworker15.qa.suse.cz/tests/287141#next_previous (10 latest "Build=Lily-VR-TEAM-8893" cases passed)
- Azure: https://openqaworker15.qa.suse.cz/tests/287163#next_previous (10 latest "Build=Lily-VR-TEAM-8893" cases passed on reboot related playbooks)
- GCP: no this issue found so far