### PR TITLE
Update ansible-core used in qe-sap-deployment

### DIFF
--- a/.github/workflows/gluescript.yml
+++ b/.github/workflows/gluescript.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         platform: [ubuntu-20.04]
         # all available versions are in https://github.com/actions/python-versions/blob/main/versions-manifest.json
-        python-version: ['3.9.19', '3.10.14', '3.11.9', '3.12.3']
+        python-version: ['3.10.14', '3.11.9', '3.12.3']
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This project is in a very early stage of development.
 
 Tools needed
 
-* Python >= 3.9
+* Python >= 3.10
 * terraform v1.5.7
-* ansible-core 2.13.5 : please refer to the **requirements.txt** file
+* ansible-core 2.16.8 : please refer to the **requirements.txt** file
 * cloud provider cli tools (`az`, `aws`, `gcloud`)
 
 The Python requirements could be managed with a virtual environment

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ansible-core==2.13.5
+ansible-core==2.16.8
 awscli==1.29.4
 jmespath==0.10.0

--- a/scripts/qesap/lib/cmds.py
+++ b/scripts/qesap/lib/cmds.py
@@ -296,9 +296,12 @@ def ansible_command_sequence(configure_data_ansible, base_project, sequence, ver
     ansible_cmd_seq = []
     ssh_share = ansible_common.copy()
     ssh_share[0] = ansible_bin_paths['ansible']
+    # Don't set '--ssh-extra-args="..."' but 'ssh-extra-args=...'
+    # for avoiding the ansible ssh connection failure introduced by
+    # https://github.com/ansible/ansible/pull/78826 in "ansible-core 2.15.0"
     ssh_share.extend([
         'all', '-a', 'true',
-        '--ssh-extra-args="-l cloudadmin -o UpdateHostKeys=yes -o StrictHostKeyChecking=accept-new"'])
+        '--ssh-extra-args=-l cloudadmin -o UpdateHostKeys=yes -o StrictHostKeyChecking=accept-new'])
     ansible_cmd_seq.append({'cmd': ssh_share})
     original_env = dict(os.environ)
     original_env['ANSIBLE_PIPELINING'] = 'True'

--- a/scripts/qesap/test/conftest.py
+++ b/scripts/qesap/test/conftest.py
@@ -203,7 +203,7 @@ def ansible_exe_call():
             "all",
             "-a",
             "true",
-            '--ssh-extra-args="-l cloudadmin -o UpdateHostKeys=yes -o StrictHostKeyChecking=accept-new"',
+            '--ssh-extra-args=-l cloudadmin -o UpdateHostKeys=yes -o StrictHostKeyChecking=accept-new',
         ]
 
     return _callback

--- a/scripts/qesap/test/unit/test_qesap_ansible.py
+++ b/scripts/qesap/test/unit/test_qesap_ansible.py
@@ -543,7 +543,7 @@ def test_ansible_ssh(
     ssh-add -v "${ssh_key}"
 
     # Accept new ssh keys for ansible-controlled hosts
-    ansible ${AnsFlgs} all -a true --ssh-extra-args="-l cloudadmin -o UpdateHostKeys=yes -o StrictHostKeyChecking=accept-new"
+    ansible ${AnsFlgs} all -a true --ssh-extra-args=-l cloudadmin -o UpdateHostKeys=yes -o StrictHostKeyChecking=accept-new
     """
     provider = "grilloparlante"
     playbooks = {"create": ["get_cherry_wood", "made_pinocchio_head"]}


### PR DESCRIPTION
Update ansible-core used in qe-sap-deployment

Related ticket: [TEAM-9473](https://jira.suse.com/browse/TEAM-9473) - Update ansible-core used in qe-sap-deployment

VRs:
- 15-SP5 Azure qesap_azure_saptune_test: https://openqaworker15.qa.suse.cz/tests/287532 (passed)
- 15-SP5 AWS   qesap_aws_saptune_test:   https://openqaworker15.qa.suse.cz/tests/287533
  The ansible cmd succeeded. The failure on "zypper returned 7 ...System management is locked by the application ..." is known issue.
- 15-SP4 Aws   hanasr_aws_test_saptune_fencing_native: https://openqaworker15.qa.suse.cz/tests/287642
  The ansible deploy passed. The failure on "Crash_site_a-primary" is known issue.
- 15-SP3 GCP   qesap_gcp_sapconf_test:   http://openqaworker15.qa.suse.cz/tests/287645
  The ansible cmd succeeded. The failure of "crm resource" is known issue.
- 15-SP2 Azure hanasr_azure_test_msi:    http://openqaworker15.qa.suse.cz/tests/287643
  The ansible deploy passed. The failure on "Crash_site_a-primary" is known issue.
- 12-SP5 Azure hanasr_azure_test_msi:    https://openqaworker15.qa.suse.cz/tests/287531 (passed)

Also verified if the code changes of [scripts/qesap/lib/cmds.py](https://github.com/SUSE/qe-sap-deployment/pull/250/files#diff-ff1328cce63191a9de7b776642c1200f36c2b0107f5eb0259347f10cb3b8e754) can compatible with old **ansible-core==2.13.5**. Yes the code changes in cmds.py support 2.13.5, see:
- 15-SP5 AWS   qesap_aws_saptune_test ansible: https://openqaworker15.qa.suse.cz/tests/287601 (passed)
- 12-SP5 Azure hanasr_azure_test_msi ansible:  https://openqaworker15.qa.suse.cz/tests/287600 (passed)
