### PR TITLE
Fix flake8 version requirement

### DIFF
--- a/scripts/qesap/requirements-dev.txt
+++ b/scripts/qesap/requirements-dev.txt
@@ -1,4 +1,4 @@
-flake8>=6.0.*
+flake8==6.*
 flake8-bugbear==23.5.*
 hypothesis==6.*
 pylint==3.1.*


### PR DESCRIPTION
Old version format is no more supported by the latest pip 24.1.1