### PR TITLE
Fix issue with ansible log in case of failure

### DIFF
--- a/scripts/qesap/lib/process_manager.py
+++ b/scripts/qesap/lib/process_manager.py
@@ -24,13 +24,13 @@ def subprocess_run(cmd, env=None):
         log.info("with env %s", env)
 
     proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False, env=env)
+
+    ret_stdout = list(proc.stdout.decode('UTF-8').splitlines())
     if proc.returncode != 0:
         log.error("ERROR %d in %s", proc.returncode, ' '.join(cmd[0:1]))
-        for line in proc.stdout.decode('UTF-8').splitlines():
-            log.error("OUTPUT:          %s", line)
-        return (proc.returncode, [])
-    stdout = [line.decode("utf-8") for line in proc.stdout.splitlines()]
-
-    for line in stdout:
-        log.debug('OUTPUT: %s', line)
-    return (0, stdout)
+    for line in ret_stdout:
+        if proc.returncode != 0:
+            log.error("OUTPUT: %s", line)
+        else:
+            log.debug('OUTPUT: %s', line)
+    return (proc.returncode, ret_stdout)

--- a/scripts/qesap/test/e2e/marasca.yaml
+++ b/scripts/qesap/test/e2e/marasca.yaml
@@ -1,0 +1,9 @@
+---
+- name: Marasca
+  hosts: all
+  tasks:
+    - name: This fails
+      ansible.builtin.assert:
+        that: "'marasca' == 'matura'"
+        fail_msg: "Non ancora matura"
+        success_msg: "Matura!! enjoy..."

--- a/scripts/qesap/test/e2e/test_7.yaml
+++ b/scripts/qesap/test/e2e/test_7.yaml
@@ -1,0 +1,18 @@
+---
+apiver: 3
+provider: fragola
+terraform:
+  variables:
+    fruit: papaya
+ansible:
+  hana_media:
+    - mora
+    - corniolo
+  hana_urls: mirtillo
+  az_storage_account_name: ribes
+  az_container_name: uvaspina
+  az_sas_token: '***'
+  create:
+    - sambuconero.yaml
+    - marasca.yaml
+    - sambuconero.yaml

--- a/scripts/qesap/test/unit/test_subprocess_run.py
+++ b/scripts/qesap/test/unit/test_subprocess_run.py
@@ -42,7 +42,7 @@ def test_stderr():
     test_text = '"Banana"'
     exit_code, stdout_list = subprocess_run(['logger', '-s', test_text])
     assert exit_code == 0
-    assert stdout_list != []
+    assert len(stdout_list) > 0
 
 
 def test_err():
@@ -53,7 +53,7 @@ def test_err():
 
     exit_code, stdout_list = subprocess_run(['cat', not_existing_file])
     assert exit_code == 1
-    assert stdout_list == []
+    assert len(stdout_list) > 0
 
 
 def test_env():


### PR DESCRIPTION
Fix the issue. 
Added two 2e2 tests that are currently failing showing an issue with the glue script behavior.
The `.log.txt` generated in case of failures are empty. 

Ticket: https://jira.suse.com/browse/TEAM-9490

# Verification
 - sle-15-SP6-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_6_BYOS-qesap_azure_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/288270 :green_circle: 
 -  sle-12-SP5-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE12_5_BYOS-qesap_aws_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/288271 :green_circle: here I intentionally cloned a job that systematically fails. Here the log http://openqaworker15.qa.suse.cz/tests/288271/logfile?filename=deploy-ansible.sap-hana-cluster.log.txt about the playbook that fails. The point is that it is no more an empty file http://openqaworker15.qa.suse.cz/tests/288271/logfile?filename=deploy-ansible.sap-hana-cluster.log.txt 
