### PR TITLE
Make Glue script --profile and --junit work

### DIFF
--- a/.github/workflows/gluescript.yml
+++ b/.github/workflows/gluescript.yml
@@ -60,4 +60,5 @@ jobs:
     - name: Test e2e
       run: |
         python -m pip install -r requirements.txt
+        ansible-galaxy install -r requirements.yml
         make test-e2e

--- a/scripts/qesap/lib/cmds.py
+++ b/scripts/qesap/lib/cmds.py
@@ -305,11 +305,14 @@ def ansible_command_sequence(configure_data_ansible, base_project, sequence, ver
     ansible_cmd_seq.append({'cmd': ssh_share})
     original_env = dict(os.environ)
     original_env['ANSIBLE_PIPELINING'] = 'True'
+    ansible_callbacks = []
     if profile:
-        original_env['ANSIBLE_CALLBACK_WHITELIST'] = 'ansible.posix.profile_tasks'
+        ansible_callbacks.append('ansible.posix.profile_tasks')
     if junit:
-        original_env['ANSIBLE_CALLBACKS_ENABLED'] = 'junit'
+        ansible_callbacks.append('junit')
         original_env['JUNIT_OUTPUT_DIR'] = junit
+    if len(ansible_callbacks) > 0:
+        original_env['ANSIBLE_CALLBACKS_ENABLED'] = ','.join(ansible_callbacks)
     if 'roles_path' in configure_data_ansible:
         original_env['ANSIBLE_ROLES_PATH'] = configure_data_ansible['roles_path']
 

--- a/scripts/qesap/test/e2e/goji.yaml
+++ b/scripts/qesap/test/e2e/goji.yaml
@@ -1,0 +1,15 @@
+---
+- name: Bacche di goji
+  hosts: all
+  tasks:
+    - name: Say hello
+      ansible.builtin.debug:
+        msg: "Hello worlds"
+
+    - name: Pause for 10 seconds to rest
+      ansible.builtin.pause:
+        seconds: 10
+
+    - name: Say goodbye
+      ansible.builtin.debug:
+        msg: "Bye bye"

--- a/scripts/qesap/test/e2e/test.sh
+++ b/scripts/qesap/test/e2e/test.sh
@@ -288,3 +288,33 @@ ansible_logs_number=$(find . -type f -name "ansible.*.log.txt" | wc -l)
 # 3 playbooks plus a log file for the initial ansible (not ansible-playbook) call 
 [[ $ansible_logs_number -eq 4 ]] || test_die "ansible .log.txt are not 4 files but has ${ansible_logs_number}"
 rm ansible.*.log.txt
+
+test_step "[test_4.yaml] Run Ansible with --junit"
+find . -type f -name "sambuconero*.xml" -delete || echo "Nothing to delete"
+qesap.py --verbose -b ${QESAPROOT} -c test_4.yaml ansible --junit . || test_die "test_4.yaml fail on ansible"
+junit_logs_number=$(find . -type f -name "sambuconero*.xml" | wc -l)
+echo "--> junit_logs_number:${junit_logs_number}"
+[[ $junit_logs_number -eq 1 ]] || test_die "ansible JUNIT reports should be 1 files but are ${junit_logs_number}"
+find . -type f -name "sambuconero*.xml" -delete
+
+test_step "[test_8.yaml] Run Ansible with --profile"
+rm ansible.*.log.txt || echo "Nothing to delete"
+cp goji.yaml "${QESAPROOT}/ansible/playbooks/"
+qesap.py --verbose -b ${QESAPROOT} -c test_8.yaml ansible --profile || test_die "test_8.yaml fail on ansible"
+time_reports=$(grep -cE " -+ [0-9.]+s" ansible.goji.log.txt)
+echo "--> time_reports:${time_reports}"
+[[ $time_reports -gt 1 ]] || test_die "ansible profile reports should be at least 1 but is ${time_reports}"
+rm ansible.*.log.txt
+
+test_step "[test_8.yaml] Run Ansible with --profile and --junit"
+rm ansible.*.log.txt || echo "Nothing to delete"
+find . -type f -name "goji*.xml" -delete || echo "Nothing to delete"
+qesap.py --verbose -b ${QESAPROOT} -c test_8.yaml ansible --profile --junit . || test_die "test_8.yaml fail on ansible"
+junit_logs_number=$(find . -type f -name "goji*.xml" | wc -l)
+echo "--> junit_logs_number:${junit_logs_number}"
+[[ $junit_logs_number -eq 1 ]] || test_die "ansible JUNIT reports should be 1 files but are ${junit_logs_number}"
+time_reports=$(grep -cE " -+ [0-9.]+s" ansible.goji.log.txt) || test_die "Test fails at profile output check"
+echo "--> time_reports:${time_reports}"
+[[ $time_reports -gt 1 ]] || test_die "ansible profile reports should be at least 1 but is ${time_reports}"
+rm ansible.*.log.txt
+find . -type f -name "goji*.xml" -delete

--- a/scripts/qesap/test/e2e/test_8.yaml
+++ b/scripts/qesap/test/e2e/test_8.yaml
@@ -1,0 +1,16 @@
+---
+apiver: 3
+provider: fragola
+terraform:
+  variables:
+    fruit: lampone
+ansible:
+  hana_media:
+    - mora
+    - corniolo
+  hana_urls: mirtillo
+  az_storage_account_name: ribes
+  az_container_name: uvaspina
+  az_sas_token: '***'
+  create:
+    - goji.yaml

--- a/scripts/qesap/test/unit/test_qesap_ansible.py
+++ b/scripts/qesap/test/unit/test_qesap_ansible.py
@@ -633,7 +633,7 @@ def test_ansible_profile(
     """
     Test that --profile result in Ansible called with an additional env variable
 
-        ANSIBLE_CALLBACK_WHITELIST=ansible.posix.profile_tasks
+        ANSIBLE_CALLBACKS_ENABLED=ansible.posix.profile_tasks
     """
     provider = "grilloparlante"
     playbooks = {"create": ["get_cherry_wood", "made_pinocchio_head"]}
@@ -653,7 +653,7 @@ def test_ansible_profile(
     calls = []
     expected_env = {"MELAMPO": "cane"}
     expected_env["ANSIBLE_PIPELINING"] = "True"
-    expected_env["ANSIBLE_CALLBACK_WHITELIST"] = "ansible.posix.profile_tasks"
+    expected_env["ANSIBLE_CALLBACKS_ENABLED"] = "ansible.posix.profile_tasks"
     for playbook in playbook_files_list:
         calls.append(mock_call_ansibleplaybook(inventory, playbook, env=expected_env))
 


### PR DESCRIPTION
Fix Glue script --profile and --junit features does not work at the same time 
Add e2e test for junit and profile

Related ticket: [TEAM-9475](https://jira.suse.com/browse/TEAM-9475) - Glue script --profile and --junit features does not work at the same time

VRS: 
(The `deploy-qesap_exec_ansible.log.txt` contains lines like: `DEBUG    OUTPUT: Sunday 07 July 2024  23:39:58 -0400 (0:00:02.735)       0:00:02.741 *********** `)
15-SP3: https://openqaworker15.qa.suse.cz/tests/288381
12-sp5: https://openqaworker15.qa.suse.cz/tests/288422