### PR TITLE
Add e2e test for junit and profile

### DIFF
--- a/scripts/qesap/test/e2e/test.sh
+++ b/scripts/qesap/test/e2e/test.sh
@@ -246,6 +246,7 @@ touch "${TEST_PROVIDER}/inventory.yaml"
 rm ansible.*.log.txt || echo "Nothing to delete"
 qesap.py -b ${QESAPROOT} -c test_3.yaml ansible || test_die "test_3.yaml fail on ansible"
 ansible_logs_number=$(find . -type f -name "ansible.*.log.txt" | wc -l)
+echo "--> ansible_logs_number:${ansible_logs_number}"
 [[ $ansible_logs_number -eq 0 ]] || test_die "ansible .log.txt are not 0 files but has ${ansible_logs_number}"
 
 test_step "[test_3.yaml] Run Ansible with no playbooks and verbosity"


### PR DESCRIPTION
Ticket [TEAM-9475](https://jira.suse.com/browse/TEAM-9475)

What I did:
- create a new playbook that has a test using `ansible.builtin.pause`. It add 30sec to the time profile
- create a new config.yaml to use the new playbook
- add a test step to call the gluescript with `--profile` and grep for the profile string in the output
- add a test to call the gluescript with `--junit` and look for .xml junit reports