### PR TITLE
Fix AWS sporadic timeout at 'crm resource cleanup'

### DIFF
--- a/ansible/playbooks/tasks/cluster-hana.yaml
+++ b/ansible/playbooks/tasks/cluster-hana.yaml
@@ -166,6 +166,8 @@
 - name: Cleanup if needed
   ansible.builtin.command:
     cmd: "crm resource cleanup {{ rsc_SAPHana }}"
+  retries: 3
+  delay: 10
   when:
     - reg_crm_status.stdout | regex_search('Failed Resource Actions') | trim | length != 0
     - is_primary


### PR DESCRIPTION
Fix AWS Sporadic timeout at `crm resource cleanup rsc_SAPHana_HDB_HDB00` 

Related ticket: [TEAM-9503](https://jira.suse.com/browse/TEAM-9503) - [aws] Sporadic timeout at  `crm resource cleanup rsc_SAPHana_HDB_HDB00`

VRs:
- sle-15-SP4-Qesap-Aws-Byos:
passed at retry ("attempts": 2): https://openqaworker15.qa.suse.cz/tests/288764
passed at retry ("attempts": 2): https://openqaworker15.qa.suse.cz/tests/288765
passed at retry ("attempts": 2): https://openqaworker15.qa.suse.cz/tests/288763
passed at retry ("attempts": 2): https://openqaworker15.qa.suse.cz/tests/288762
passed at first time ("attempts": 1): https://openqaworker15.qa.suse.cz/tests/288761
- sle-15-SP5-Qesap-Aws-Payg:
passed at retry ("attempts": 2): http://openqaworker15.qa.suse.cz/tests/289021
passed at retry ("attempts": 2): http://openqaworker15.qa.suse.cz/tests/289022
passed at first time ("attempts": 1): http://openqaworker15.qa.suse.cz/tests/289023