### PR TITLE
Install fence-agents-azure-arm explicitly.

### DIFF
--- a/ansible/playbooks/registration.yaml
+++ b/ansible/playbooks/registration.yaml
@@ -98,7 +98,7 @@
         - "(rcg.rc != 0) or (use_suseconnect | bool)"
 
     - name: Check if repos are added after registration
-      ansible.builtin.command: zypper lr
+      ansible.builtin.command: zypper lr -u
       register: repos_after
       failed_when: repos_after.rc != 0
       when:

--- a/ansible/playbooks/tasks/azure-cluster-bootstrap.yaml
+++ b/ansible/playbooks/tasks/azure-cluster-bootstrap.yaml
@@ -14,6 +14,19 @@
   retries: 3
   delay: 60
 
+- name: Ensure cluster dependencies for SLES >= 15-SP4 are installed
+  community.general.zypper:
+    name: "{{ item }}"  # Caution, no version control here (yet)
+    state: present
+  loop:
+    - fence-agents-azure-arm    # Workaround for bsc#1224797. We should remove this line once the base OS images include the package
+  register: result
+  until: result is succeeded
+  retries: 3
+  delay: 60
+  when:
+    - ansible_distribution_version is version('15.4', '>=')
+
 - name: Get the status of all extensions
   ansible.builtin.command:
     cmd: SUSEConnect -s


### PR DESCRIPTION
Workaround for [bsc#1224797](https://bugzilla.suse.com/show_bug.cgi?id=1224797): bug was opened because the update of `python3-azure-sdk` to `python311-azure-sdk` caused `fence_azure_arm` to fail to start due to missing dependencies. New package `fence-agents-azure-arm` was created to supply to impacted service packs a native Azure fence agent compatible with `python311-azure-sdk`, but this package needs to be manually installed as it was not shipped as part of the base OS image.

## Verification runs:

- 15-SP3: https://openqaworker15.qa.suse.cz/tests/291024 :green_circle:  (regression test, to confirm it does _not_ try to install the new package in this SP)
- 15-SP4: https://openqa.suse.de/tests/15000334 :green_circle: 
- 15-SP5: https://openqa.suse.de/tests/15000332 :green_circle: 
- 15-SP6: https://openqa.suse.de/tests/15000330 :green_circle: 