### PR TITLE
Fix stdout not defined in hana_hsr_srstate

### DIFF
--- a/ansible/roles/sap_ha_install_hana_hsr/tasks/configure_hsr.yml
+++ b/ansible/roles/sap_ha_install_hana_hsr/tasks/configure_hsr.yml
@@ -11,6 +11,9 @@
   register: __sap_ha_install_hana_hsr_srstate
   changed_when: false
   failed_when: false
+  until: __sap_ha_install_hana_hsr_srstate.rc == 0
+  retries: 3
+  delay: 60
 
 # assert that the previous task produced a meaningful result
 # specifically, ensure that the result has an 'stdout' attribute


### PR DESCRIPTION
Fix stdout not defined in hana_hsr_srstate

[TEAM-9545](https://jira.suse.com/browse/TEAM-9545?filter=-1) - [PC][Azure] deploy_qesap_ansible sporadically fails with error: 'stdout' is not defined in '__sap_ha_install_hana_hsr_srstate'

VRs:
- ssh failed and retry works: search `"attempts": 2,` in serial_terminal.txt ):
https://openqa.suse.de/tests/15066108/logfile?filename=serial_terminal.txt
Reproduced the failure at the test step: `DEBUG    OUTPUT: FAILED - RETRYING: [vmhana02]: SAP HSR - Check System Replication Status (3 retries left).Result was: {`
- ssh passed and do not need to retry: 
https://openqa.suse.de/tests/15065226# 
  
NOTE: The new failure of `"SUSEConnect -s"` is a product bug: https://bugzilla.suse.com/show_bug.cgi?id=1228774