### PR TITLE
[DO NOT MERGE] Manage extra dependency for 12sp5 fence-agents

### DIFF
--- a/ansible/playbooks/tasks/azure-cluster-bootstrap.yaml
+++ b/ansible/playbooks/tasks/azure-cluster-bootstrap.yaml
@@ -27,6 +27,20 @@
   when:
     - ansible_distribution_version is version('15.4', '>=')
 
+- name: Ensure cluster dependencies for SLES 12-SP5 are installed
+  community.general.zypper:
+    name: "{{ item }}"  # Caution, no version control here (yet)
+    state: present
+  loop:
+    - python3-pycurl    # Workaround for bsc#1226671.
+    - python3-azure-identity
+  register: result
+  until: result is succeeded
+  retries: 3
+  delay: 60
+  when:
+    - ansible_distribution_version is version('12.5', '==')
+
 - name: Get the status of all extensions
   ansible.builtin.command:
     cmd: SUSEConnect -s


### PR DESCRIPTION
Refer to :
- https://bugzilla.suse.com/show_bug.cgi?id=1226671
- https://www.suse.com/support/update/announcement/2024/suse-ru-20242693-1/

# Verification

## sle-12-SP5-Azure-SAP-BYOS-Incidents-x86_64-Build:34935:systemd-SAPHanaSR-ScaleUp-PerfOpt-spn@az_Standard_E8s_v3
- http://openqaworker15.qa.suse.cz/tests/293542 :red_circle:  fails in Terraform, not reach the code under test
- http://openqaworker15.qa.suse.cz/tests/293784
 
 ## sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_saptune_test@64bit 
 -  http://openqaworker15.qa.suse.cz/tests/293543 :green_circle:  but as is 15sp6 it mostly does not use new code

 ## sle-12-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE12_5_BYOS-qesap_azure_saptune_test@64bit 
 -  http://openqaworker15.qa.suse.cz/tests/293544 :green_circle: 

 ## sle-12-SP5-HanaSr-Azure-Byos-x86_64-Build12-SP5_2024-08-06T02:03:21Z-hanasr_azure_test_msi@64bit 
 -  http://openqaworker15.qa.suse.cz/tests/293545 :green_circle: as [Verify_azure_fence_agent_MSI](http://openqaworker15.qa.suse.cz/tests/293545/modules/Verify_azure_fence_agent_MSI/steps/1/src) is passing