### PR TITLE
Install fence-agents-azure-arm also on 12-SP5

### DIFF
--- a/ansible/playbooks/tasks/azure-cluster-bootstrap.yaml
+++ b/ansible/playbooks/tasks/azure-cluster-bootstrap.yaml
@@ -25,7 +25,8 @@
   retries: 3
   delay: 60
   when:
-    - ansible_distribution_version is version('15.4', '>=')
+    - ansible_distribution_version is version('15.4', '>=') or
+      ansible_distribution_version is version('12.5', '==')
 
 - name: Get the status of all extensions
   ansible.builtin.command:


### PR DESCRIPTION
Bug https://bugzilla.suse.com/show_bug.cgi?id=1226671 was also reported in 12sp5 VMs in Azure, so a similar fix as the one applied for 15-SP4/5/6 has been implemented. As such, we also need to install fence-agents-azure-arm in 12sp5.

# Verification Runs 12-SP5

* BYOS+MSI: https://openqa.suse.de/tests/15167966 :green_circle: 
* BYOS+SPN: https://openqa.suse.de/tests/15166554 :green_circle: 
* PAYG+MSI: https://openqa.suse.de/tests/15166555 :green_circle: 
* PAYG+SPN: https://openqa.suse.de/tests/15166556 :green_circle: 

*Tests for regressions (extra package should not be installed in 15-SP3, and it should be installed in 15-SP4/5/6)*

* 15-SP3: https://openqaworker15.qa.suse.cz/tests/294508 :green_circle: 
* 15-SP4: https://openqaworker15.qa.suse.cz/tests/294509 :green_circle: 
* 15-SP5: https://openqaworker15.qa.suse.cz/tests/294506 :green_circle: 
* 15-SP6: https://openqaworker15.qa.suse.cz/tests/294572 :green_circle: 