### PR TITLE
Remove machine type default from AWS

### DIFF
--- a/terraform/aws/modules/hana_node/variables.tf
+++ b/terraform/aws/modules/hana_node/variables.tf
@@ -19,38 +19,37 @@ variable "hana_count" {
 }
 
 variable "instance_type" {
-  type    = string
-  default = "r3.8xlarge"
+  type = string
 }
 
 variable "availability_zones" {
-  type        = list(string)
   description = "Used availability zones"
+  type        = list(string)
 }
 
 variable "vpc_id" {
-  type        = string
   description = "Id of the vpc used for this deployment"
+  type        = string
 }
 
 variable "subnet_address_range" {
-  type        = list(string)
   description = "List with subnet address ranges in cidr notation to create the netweaver subnets"
+  type        = list(string)
 }
 
 variable "key_name" {
-  type        = string
   description = "AWS key pair name"
+  type        = string
 }
 
 variable "security_group_id" {
-  type        = string
   description = "Security group id"
+  type        = string
 }
 
 variable "route_table_id" {
-  type        = string
   description = "Route table id"
+  type        = string
 }
 
 variable "aws_credentials" {

--- a/terraform/aws/modules/iscsi_server/variables.tf
+++ b/terraform/aws/modules/iscsi_server/variables.tf
@@ -3,13 +3,13 @@ variable "common_variables" {
 }
 
 variable "availability_zones" {
-  type        = list(string)
   description = "Used availability zones"
+  type        = list(string)
 }
 
 variable "subnet_ids" {
-  type        = list(string)
   description = "Subnet ids to attach the machines network interface"
+  type        = list(string)
 }
 
 variable "name" {
@@ -23,24 +23,23 @@ variable "network_domain" {
 }
 
 variable "iscsi_count" {
-  type        = number
   description = "Number of iscsi machines to deploy"
+  type        = number
 }
 
 variable "instance_type" {
-  type        = string
   description = "The instance type of iscsi server node."
-  default     = "t2.large"
+  type        = string
 }
 
 variable "key_name" {
-  type        = string
   description = "AWS key pair name"
+  type        = string
 }
 
 variable "security_group_id" {
-  type        = string
   description = "Security group id"
+  type        = string
 }
 
 variable "host_ips" {

--- a/terraform/aws/modules/monitoring/variables.tf
+++ b/terraform/aws/modules/monitoring/variables.tf
@@ -11,7 +11,6 @@ variable "monitoring_enabled" {
 variable "instance_type" {
   description = "The instance type of monitoring node."
   type        = string
-  default     = "t3.micro"
 }
 
 variable "name" {
@@ -25,13 +24,13 @@ variable "network_domain" {
 }
 
 variable "key_name" {
-  type        = string
   description = "AWS key pair name"
+  type        = string
 }
 
 variable "security_group_id" {
-  type        = string
   description = "Security group id"
+  type        = string
 }
 
 variable "monitoring_srv_ip" {
@@ -41,13 +40,13 @@ variable "monitoring_srv_ip" {
 }
 
 variable "availability_zones" {
-  type        = list(string)
   description = "Used availability zones"
+  type        = list(string)
 }
 
 variable "subnet_ids" {
-  type        = list(string)
   description = "List of subnet IDs"
+  type        = list(string)
 }
 
 variable "timezone" {

--- a/terraform/aws/modules/netweaver_node/variables.tf
+++ b/terraform/aws/modules/netweaver_node/variables.tf
@@ -13,8 +13,8 @@ variable "app_server_count" {
 }
 
 variable "instance_type" {
-  type    = string
-  default = "r3.8xlarge"
+  description = "The instance type of netweaver node."
+  type        = string
 }
 
 variable "name" {
@@ -28,38 +28,38 @@ variable "network_domain" {
 }
 
 variable "availability_zones" {
-  type        = list(string)
   description = "Used availability zones"
+  type        = list(string)
 }
 
 variable "vpc_id" {
-  type        = string
   description = "Id of the vpc used for this deployment"
+  type        = string
 }
 
 variable "subnet_address_range" {
-  type        = list(string)
   description = "List with subnet address ranges in cidr notation to create the netweaver subnets"
+  type        = list(string)
 }
 
 variable "key_name" {
-  type        = string
   description = "AWS key pair name"
+  type        = string
 }
 
 variable "security_group_id" {
-  type        = string
   description = "Security group id"
+  type        = string
 }
 
 variable "route_table_id" {
-  type        = string
   description = "Route table id"
+  type        = string
 }
 
 variable "efs_performance_mode" {
-  type        = string
   description = "Performance mode of the EFS storage used by Netweaver"
+  type        = string
   default     = "generalPurpose"
 }
 


### PR DESCRIPTION
Terraform AWS code variables has default about machine type in two place:
- HIGH: in the main variables.tf
- LOW: in each module variable.tf It is problematic to maintain these two level of defaults with the same values.
Removing defaults from the HIGH level result in all machine types variables to become mandatory in the terraform.tfvars and so in the conf.yaml.

This commit remove defaults from LOW level. Doing so does not change user experience as HIGH levels will always provide value to LOW level from user tfvars file or default.
This commit also ensure that each description field is at the first place if available.

Ticket https://jira.suse.com/browse/TEAM-7678

# Verification
- sle-15-SP5-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_5_BYOS-qesap_aws_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/295667
 - sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_r48xlarge_test@64bit -> http://openqaworker15.qa.suse.cz/tests/295668
 - sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_r58xlarge_test@64bit -> http://openqaworker15.qa.suse.cz/tests/295669
 - sle-15-SP5-HanaSr-Aws-Byos-x86_64-Build15-SP5_2024-08-29T02:03:22Z-hanasr_aws_test_fencing_sbd@64bit -> http://openqaworker15.qa.suse.cz/tests/295670