### PR TITLE
Add az_key_name support at glue script level only

### DIFF
--- a/docs/secure_storage_account.md
+++ b/docs/secure_storage_account.md
@@ -49,11 +49,13 @@ az storage container create -n sapmedia --account-name qesapmedia
 ## Allowing secure access the SAS tokens
 
 If the storage account and container were created using the above
-instructions then the blobs stored within will not be available to the
+instructions then the blobs stored within will be available to the
 public. To allow secure, private access to blobs a SAS token needs to
-be generated. SAS tokens have start and expiration dates, allowing
-tokens to expire over time. To create a SAS token which allows read only
-access and expires on 1/1/2025 for the container created with the above
+be generated.
+SAS tokens have start and expiration dates, allowing tokens
+to expire over time.
+To create a SAS token which allows read only access and expires on
+a specific date for the container created with the above
 instructions, run the following:
 
 ```shell
@@ -61,7 +63,7 @@ az storage container generate-sas --account-name qesapmedia --expiry 2025-01-01 
 ```
 
 A token will be returned in the form of a string. Copy this token and store it
-securely. This token will not be recoverable from Azure!
+securely. This token will not be recoverable from Azure neither manually revokable!
 
 ## Uploading blobs
 
@@ -88,8 +90,7 @@ no public access to the data.
 
 ## How to consume with Ansible
 
-The old playbook used to take a single variable which was a list of blob urls.
-The new version of the playbook will take four variables:
+The playbook will take four variables:
 
 * az_storage_account_name: string
 * az_container_name:       string
@@ -102,8 +103,3 @@ correctly.
 The playbook will compile the complete urls and download the media to `hana_download_path`
 which by default is `/hana/shared/install`.
 
-## Next Steps
-
-The proposal at the moment is to have a long standing SAS token which is
-reusable, however, a better approach may be use short lived SAS tokens
-which are generated on demand.

--- a/scripts/qesap/lib/cmds.py
+++ b/scripts/qesap/lib/cmds.py
@@ -58,6 +58,8 @@ def create_hana_media(config_ansible, apiver):
     hanamedia_content['az_container_name'] = config_ansible['az_container_name']
     if 'az_sas_token' in config_ansible:
         hanamedia_content['az_sas_token'] = config_ansible['az_sas_token']
+    if 'az_key_name' in config_ansible:
+        hanamedia_content['az_key_name'] = config_ansible['az_key_name']
     hanamedia_content['az_blobs'] = config_ansible['hana_media']
     return hanamedia_content, None
 

--- a/scripts/qesap/lib/config.py
+++ b/scripts/qesap/lib/config.py
@@ -206,22 +206,25 @@ class CONF:
         if apiver < 3:
             log.error("Apiver: %d is no longer supported", apiver)
             return False
+
         if 'hana_media' not in ansible_conf or ansible_conf['hana_media'] is None:
             log.error("Missing or empty 'hana_media' in 'ansible' in the config")
             return False
+
         for media in ansible_conf['hana_media']:
             match = re.search(r'^http[s]?://.*', media)
             if match:
                 log.error("Media %s provided as full url. File name expected.", media)
                 return False
-        if 'az_storage_account_name' not in ansible_conf:
-            log.error("Missing 'az_storage_account_name' in 'ansible' in the config")
+
+        for var in ['az_storage_account_name', 'az_container_name']:
+            if var not in ansible_conf:
+                log.error("Missing '%s' in 'ansible' in the config", var)
+                return False
+
+        if 'az_sas_token' not in ansible_conf and 'az_key_name' not in ansible_conf:
+            log.error("Both az_sas_token and az_key_name missing in the config")
             return False
-        if 'az_container_name' not in ansible_conf:
-            log.error("Missing 'az_container_name' in 'ansible' in the config")
-            return False
-        if 'az_sas_token' not in ansible_conf:
-            log.warning("Missing 'az_sas_token' in 'ansible' in the config")
         return True
 
     def has_ansible_playbooks(self, sequence):

--- a/scripts/qesap/test/conftest.py
+++ b/scripts/qesap/test/conftest.py
@@ -73,6 +73,7 @@ terraform:
 ansible:
   az_storage_account_name: SOMEONE
   az_container_name: SOMETHING
+  az_sas_token: SECRET
   hana_media:
     - SAPCAR_EXE
     - SAP_HANA_EXE
@@ -111,6 +112,7 @@ provider: {}
 ansible:
   az_storage_account_name: SOMEONE
   az_container_name: SOMETHING
+  az_sas_token: SECRET
   hana_media:
     - SAPCAR_EXE
     - SAP_HANA_EXE
@@ -177,6 +179,7 @@ provider: {provider}
 ansible:
     az_container_name: pippo
     az_storage_account_name: pippo
+    az_sas_token: SECRET
     hana_media:
     - pippo"""
 
@@ -425,6 +428,7 @@ def validate_hana_media():
     az_storage_account_name: <ACCOUNT>
     az_container_name:       <CONTAINER>
     az_sas_token:            <SAS_TOKEN>
+    az_key_name:             <KEY>
     az_blobs:
       - <SAPCAR_EXE>
       - <IMDB_SERVER_SAR>
@@ -437,6 +441,7 @@ def validate_hana_media():
         account="ACCOUNT",
         container="CONTAINER",
         token=None,
+        key=None,
         sapcar="SAPCAR_EXE",
         imdb_srv="IMDB_SERVER_SAR",
         imdb_cln="IMDB_CLIENT_SAR",
@@ -477,6 +482,19 @@ def validate_hana_media():
                     return (
                         False,
                         f"az_sas_token value is {data['az_sas_token']} and not expected {token}",
+                    )
+
+            # az_key_name is optional, test it only if requested
+            if key:
+                if "az_key_name" not in data:
+                    return (
+                        False,
+                        "az_key_name missing in the generated hana_media.yaml",
+                    )
+                if key != data["az_key_name"]:
+                    return (
+                        False,
+                        f"az_key_name value is {data['az_key_name']} and not expected {key}",
                     )
 
             blob_key = "az_blobs"

--- a/scripts/qesap/test/e2e/test_3.yaml
+++ b/scripts/qesap/test/e2e/test_3.yaml
@@ -11,3 +11,4 @@ ansible:
   hana_urls: mirtillo
   az_storage_account_name: ribes
   az_container_name: uvaspina
+  az_sas_token: SECRET

--- a/scripts/qesap/test/unit/test_qesap_ansible.py
+++ b/scripts/qesap/test/unit/test_qesap_ansible.py
@@ -381,6 +381,7 @@ provider: grilloparlante
 ansible:
     az_storage_account_name: pippo
     az_container_name: pippo
+    az_sas_token: SECRET
     hana_media:
     - somesome
     create:
@@ -432,6 +433,7 @@ provider: grilloparlante
 ansible:
     az_storage_account_name: pippo
     az_container_name: pippo
+    az_sas_token: SECRET
     hana_media:
     - somesome
     create:
@@ -490,6 +492,7 @@ provider: grilloparlante
 ansible:
     az_storage_account_name: pippo
     az_container_name: pippo
+    az_sas_token: SECRET
     hana_media:
     - somesome
     create:
@@ -746,6 +749,7 @@ provider: {provider}
 ansible:
     az_storage_account_name: pippo
     az_container_name: pippo
+    az_sas_token: SECRET
     hana_media:
     - somesome
     roles_path: somewhere

--- a/scripts/qesap/test/unit/test_qesap_configure_ansible.py
+++ b/scripts/qesap/test/unit/test_qesap_configure_ansible.py
@@ -9,7 +9,7 @@ def test_configure_create_ansible_hanamedia(configure_helper, config_yaml_sample
     Test that 'configure' write a hana_media.yaml file in
     <BASE_DIR>/ansible/playbooks/vars
     """
-    provider = 'pinocchio'
+    provider = "pinocchio"
     conf = config_yaml_sample(provider)
     args, _, hana_media, _ = configure_helper(provider, conf)
 
@@ -17,9 +17,11 @@ def test_configure_create_ansible_hanamedia(configure_helper, config_yaml_sample
     assert os.path.isfile(hana_media)
 
 
-def test_configure_ansible_hanamedia_content_apiver3(configure_helper, validate_hana_media):
+def test_configure_ansible_hanamedia_content_apiver3(
+    configure_helper, validate_hana_media
+):
     """
-    Test that an new apiver:3 config.yaml
+    Test that a new apiver:3 config.yaml
 
     ```
     ansible:
@@ -45,7 +47,7 @@ def test_configure_ansible_hanamedia_content_apiver3(configure_helper, validate_
       - <IMDB_CLIENT_SAR>
     ```
     """
-    provider = 'pinocchio'
+    provider = "pinocchio"
     conf = f"""---
 apiver: 3
 provider: {provider}
@@ -55,6 +57,7 @@ terraform:
 ansible:
   az_storage_account_name: SOMEONE
   az_container_name: SOMETHING
+  az_sas_token: SECRET
   hana_media:
     - MY_SAPCAR_EXE
     - MY_IMDB_SERVER
@@ -62,17 +65,27 @@ ansible:
     args, _, hana_media, _ = configure_helper(provider, conf)
     assert main(args) == 0
 
-    res, msg = validate_hana_media(hana_media, account='SOMEONE', container='SOMETHING', token=None, sapcar='MY_SAPCAR_EXE', imdb_srv='MY_IMDB_SERVER', imdb_cln='MY_IMDB_CLIENT')
+    res, msg = validate_hana_media(
+        hana_media,
+        account="SOMEONE",
+        container="SOMETHING",
+        token="SECRET",
+        sapcar="MY_SAPCAR_EXE",
+        imdb_srv="MY_IMDB_SERVER",
+        imdb_cln="MY_IMDB_CLIENT",
+    )
     assert res, msg
 
 
-def test_configure_ansible_hanamedia_content_apiver3_with_apiver2_uri_format(configure_helper, validate_hana_media):
+def test_configure_ansible_hanamedia_content_apiver3_with_apiver2_uri_format(
+    configure_helper, validate_hana_media
+):
     """
     Test that the script reports an error if the user
     is using conf.yaml with new apiver:3
     but providing hana_media as full url like for apiver2
     """
-    provider = 'pinocchio'
+    provider = "pinocchio"
     conf = f"""---
 apiver: 3
 provider: {provider}
@@ -82,6 +95,7 @@ terraform:
 ansible:
   az_storage_account_name: SOMEONE
   az_container_name: SOMETHING
+  az_sas_token: SECRET
   hana_media:
     - https://SOMEONE.blob.core.windows.net/SOMETHING/MY_SAPCAR_EXE
     - https://SOMEONE.blob.core.windows.net/SOMETHING/MY_IMDB_SERVER
@@ -90,22 +104,24 @@ ansible:
     assert main(args) == 1
 
 
-def test_configure_ansible_hanamedia_content_apiver3_token(configure_helper, validate_hana_media):
+def test_configure_ansible_hanamedia_content_apiver3_key(
+    configure_helper, validate_hana_media
+):
     """
-    Test that an new apiver:3 config.yaml optional param
+    Test that config.yaml without token but with key
 
     ```
     ansible:
-      az_sas_token: <SAS_TOKEN>
+      az_key_name: <KEY>
     ```
 
     during 'configure', write a hana_media.yaml with
 
     ```
-    az_sas_token:            <SAS_TOKEN>
+    az_key_name:  <KEY>
     ```
     """
-    provider = 'pinocchio'
+    provider = "pinocchio"
     conf = f"""---
 apiver: 3
 provider: {provider}
@@ -115,7 +131,7 @@ terraform:
 ansible:
   az_storage_account_name: SOMEONE
   az_container_name: SOMETHING
-  az_sas_token: SUPERSECRET
+  az_key_name: SUPERSECRET
   hana_media:
     - MY_SAPCAR_EXE
     - MY_IMDB_SERVER
@@ -123,7 +139,15 @@ ansible:
     args, _, hana_media, _ = configure_helper(provider, conf)
     assert main(args) == 0
 
-    res, msg = validate_hana_media(hana_media, account='SOMEONE', container='SOMETHING', token='SUPERSECRET', sapcar='MY_SAPCAR_EXE', imdb_srv='MY_IMDB_SERVER', imdb_cln='MY_IMDB_CLIENT')
+    res, msg = validate_hana_media(
+        hana_media,
+        account="SOMEONE",
+        container="SOMETHING",
+        key="SUPERSECRET",
+        sapcar="MY_SAPCAR_EXE",
+        imdb_srv="MY_IMDB_SERVER",
+        imdb_cln="MY_IMDB_CLIENT",
+    )
     assert res, msg
 
 
@@ -132,7 +156,7 @@ def test_configure_create_ansible_hanavars(configure_helper, config_yaml_sample)
     Test that 'configure' write a hana_vars.yaml file in
     <BASE_DIR>/ansible/playbooks/vars
     """
-    provider = 'pinocchio'
+    provider = "pinocchio"
     conf = config_yaml_sample(provider)
     args, _, _, hana_vars = configure_helper(provider, conf)
 
@@ -145,7 +169,7 @@ def test_configure_ansible_hanavar_content(configure_helper):
     Test that 'configure' write a hana_vars.yaml with
     expected content
     """
-    provider = 'pinocchio'
+    provider = "pinocchio"
     conf = f"""---
 apiver: 3
 provider: {provider}
@@ -155,6 +179,7 @@ terraform:
 ansible:
   az_storage_account_name: SOMEONE
   az_container_name: SOMETHING
+  az_sas_token: SECRET
   hana_media:
     - MY_SAPCAR_EXE
   hana_vars:
@@ -172,14 +197,14 @@ ansible:
     args, _, _, hana_vars = configure_helper(provider, conf)
     assert main(args) == 0
 
-    with open(hana_vars, 'r', encoding='utf-8') as file:
+    with open(hana_vars, "r", encoding="utf-8") as file:
         data = yaml.load(file, Loader=yaml.FullLoader)
-        assert 'zanzara' in data
-        assert 'Moskito' in data
-        assert 'moustique' in data
-        assert data['zanzara'] == 'mosquito'
-        assert data['Moskito'] == 'komar'
-        assert data['moustique'] == 'komarac'
+        assert "zanzara" in data
+        assert "Moskito" in data
+        assert "moustique" in data
+        assert data["zanzara"] == "mosquito"
+        assert data["Moskito"] == "komar"
+        assert data["moustique"] == "komarac"
         assert len(data) == 10
 
 
@@ -194,7 +219,7 @@ def test_configure_ansible_hanavar_values(configure_helper):
     primary_site: name of the primary 'site' for HANA System Replication
     secondary_site: name of the secondary 'site' for HANA System Replication
     """
-    provider = 'pinocchio'
+    provider = "pinocchio"
     conf = """---
 apiver: 3
 provider: {}
@@ -204,6 +229,7 @@ terraform:
 ansible:
   az_storage_account_name: SOMEONE
   az_container_name: SOMETHING
+  az_sas_token: SECRET
   hana_media:
     - MY_SAPCAR_EXE
   hana_vars:
@@ -215,25 +241,43 @@ ansible:
     primary_site: 'goofy'
     secondary_site: 'miky'
 """
-    args, _, _, hana_vars = configure_helper(provider, conf.format(provider, '/aaa/bbb/ccc', 'HDB', '00'))
+    args, _, _, hana_vars = configure_helper(
+        provider, conf.format(provider, "/aaa/bbb/ccc", "HDB", "00")
+    )
     assert main(args) == 0
-    args, _, _, hana_vars = configure_helper(provider, conf.format(provider, 'ccc', 'HDB', '00'))
-    assert main(args) != 0, "Wrong 'sap_hana_install_software_directory'='ccc' not detected."
-    args, _, _, hana_vars = configure_helper(provider, conf.format(provider, '/aaa/bbb/ccc', 'HD', '00'))
+    args, _, _, hana_vars = configure_helper(
+        provider, conf.format(provider, "ccc", "HDB", "00")
+    )
+    assert (
+        main(args) != 0
+    ), "Wrong 'sap_hana_install_software_directory'='ccc' not detected."
+    args, _, _, hana_vars = configure_helper(
+        provider, conf.format(provider, "/aaa/bbb/ccc", "HD", "00")
+    )
     assert main(args) != 0, "Wrong 'sap_hana_install_sid'='HD' not detected."
-    args, _, _, hana_vars = configure_helper(provider, conf.format(provider, '/aaa/bbb/ccc', 'HDB', '0'))
+    args, _, _, hana_vars = configure_helper(
+        provider, conf.format(provider, "/aaa/bbb/ccc", "HDB", "0")
+    )
     assert main(args) != 0, "Wrong 'sap_hana_install_instance_number'='0' not detected."
-    args, _, _, hana_vars = configure_helper(provider, conf.format(provider, '/aaa/bbb/ccc', 'HDB', 'AA'))
-    assert main(args) != 0, "Wrong 'sap_hana_install_instance_number'='AA' not detected."
-    args, _, _, hana_vars = configure_helper(provider, conf.format(provider, '/aaa/bbb/ccc', 'HDB', '000'))
-    assert main(args) != 0, "Wrong 'sap_hana_install_instance_number'='000' not detected."
+    args, _, _, hana_vars = configure_helper(
+        provider, conf.format(provider, "/aaa/bbb/ccc", "HDB", "AA")
+    )
+    assert (
+        main(args) != 0
+    ), "Wrong 'sap_hana_install_instance_number'='AA' not detected."
+    args, _, _, hana_vars = configure_helper(
+        provider, conf.format(provider, "/aaa/bbb/ccc", "HDB", "000")
+    )
+    assert (
+        main(args) != 0
+    ), "Wrong 'sap_hana_install_instance_number'='000' not detected."
 
 
 def test_configure_ansible_hana(configure_helper):
     """
     Test that 'configure' fails if manadatory params are missing
     """
-    provider = 'pinocchio'
+    provider = "pinocchio"
     conf = f"""---
 apiver: 3
 provider: {provider}


### PR DESCRIPTION
Add validation and hana_media.yaml write of this new parameter. In a second commit it will be used to generate the SAS token in Ansible.

Ticket: TEAM-9540

# Verification


## HanaSR

 - sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_r48xlarge_test@64bit -> http://openqaworker15.qa.suse.cz/tests/295703

 # qesap

 - sle-15-SP5-HanaSr-Aws-Byos-x86_64-Build15-SP5_2024-08-29T02:03:22Z-hanasr_aws_test_fencing_sbd@64bit -> http://openqaworker15.qa.suse.cz/tests/295704