### PR TITLE
Move token generation to ansible

### DIFF
--- a/ansible/playbooks/sap-hana-download-media.yaml
+++ b/ansible/playbooks/sap-hana-download-media.yaml
@@ -23,6 +23,48 @@
         group: root
         mode: 0755
 
+    - name: Retrieve account key
+      ansible.builtin.command: >-
+        az storage account keys list \
+        --account-name {{ az_storage_account_name }} \
+        --query "[?contains(keyName,'{{ az_key_name }}')].value" \
+        -o tsv
+      delegate_to: 127.0.0.1
+      no_log: true
+      run_once: true
+      register: az_account_key
+      when: az_sas_token is not defined or az_sas_token == ""
+
+    - name: "Set expiry"
+      ansible.builtin.command: "date -u +'%Y-%m-%dT%H:%MZ' -d '+3 hours'"
+      delegate_to: 127.0.0.1
+      run_once: true
+      register: expiry
+      when: az_sas_token is not defined or az_sas_token == ""
+
+    - name: Generate SAS token
+      ansible.builtin.command: >-
+        az storage container generate-sas \
+          --account-name {{ az_storage_account_name }} \
+          --account-key {{ az_account_key.stdout }} \
+          --name {{ az_container_name.split('/')[0] }} \
+          --permission r \
+          --expiry {{ expiry.stdout }} \
+          --out tsv
+      delegate_to: 127.0.0.1
+      changed_when: false
+      no_log: true
+      run_once: true
+      register: az_sas_token_output
+      when: az_sas_token is not defined or az_sas_token == ""
+
+    - name: Set az_sas_token fact
+      ansible.builtin.set_fact:
+        az_sas_token: "{{ az_sas_token_output.stdout }}"
+      delegate_to: 127.0.0.1
+      run_once: true
+      when: az_sas_token is not defined or az_sas_token == ""
+
     - name: Download HANA media with SAS token
       ansible.builtin.get_url:
         url: "https://{{ az_storage_account_name }}.blob.core.windows.net/{{ az_container_name }}/{{ item }}?{{ az_sas_token }}"


### PR DESCRIPTION
This pr enables qe-sap-deployment to generate the SAS token in ansible when it is not defined in the config.yaml. It requires providing the key name for the generation of the token. It can be used both for manual deployments (by providing the key name instead of the generated key) and openqa runs (if the key is provided as a setting instead of the generated SAS token).

- Related ticket: https://jira.suse.com/browse/TEAM-9540
- Verification Runs: 
**With token generated in openqa and '`QESAPDEPLOY_HANA_KENAME` not set:**
https://openqaworker15.qa.suse.cz/tests/295828
**Without token generated in openqa and `QESAPDEPLOY_HANA_KEYNAME` set as an openqa variable:**
https://openqaworker15.qa.suse.cz/tests/296013