### PR TITLE
Use vm_size in AWS modules

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -137,7 +137,7 @@ module "drbd_node" {
   name                  = var.drbd_name
   network_domain        = var.drbd_network_domain == "" ? var.network_domain : var.drbd_network_domain
   drbd_count            = var.drbd_enabled == true ? 2 : 0
-  instance_type         = var.drbd_instancetype
+  vm_size               = var.drbd_instancetype
   availability_zones    = data.aws_availability_zones.available.names
   os_image              = local.drbd_os_image
   os_owner              = local.drbd_os_owner
@@ -167,7 +167,7 @@ module "iscsi_server" {
   subnet_ids         = aws_subnet.infra-subnet.*.id
   os_image           = local.iscsi_os_image
   os_owner           = local.iscsi_os_owner
-  instance_type      = var.iscsi_instancetype
+  vm_size            = var.iscsi_instancetype
   key_name           = aws_key_pair.key-pair.key_name
   security_group_id  = local.security_group_id
   host_ips           = local.iscsi_ips
@@ -182,7 +182,7 @@ module "netweaver_node" {
   network_domain        = var.netweaver_network_domain == "" ? var.network_domain : var.netweaver_network_domain
   xscs_server_count     = local.netweaver_xscs_server_count
   app_server_count      = var.netweaver_enabled ? var.netweaver_app_server_count : 0
-  instance_type         = var.netweaver_instancetype
+  vm_size               = var.netweaver_instancetype
   availability_zones    = data.aws_availability_zones.available.names
   os_image              = local.netweaver_os_image
   os_owner              = local.netweaver_os_owner
@@ -207,7 +207,7 @@ module "hana_node" {
   name                  = var.hana_name
   network_domain        = var.hana_network_domain == "" ? var.network_domain : var.hana_network_domain
   hana_count            = var.hana_count
-  instance_type         = var.hana_instancetype
+  vm_size               = var.hana_instancetype
   availability_zones    = data.aws_availability_zones.available.names
   os_image              = local.hana_os_image
   os_owner              = local.hana_os_owner
@@ -231,7 +231,7 @@ module "monitoring" {
   name               = var.monitoring_name
   network_domain     = var.monitoring_network_domain == "" ? var.network_domain : var.monitoring_network_domain
   monitoring_enabled = var.monitoring_enabled
-  instance_type      = var.monitor_instancetype
+  vm_size            = var.monitor_instancetype
   key_name           = aws_key_pair.key-pair.key_name
   security_group_id  = local.security_group_id
   monitoring_srv_ip  = local.monitoring_ip

--- a/terraform/aws/modules/drbd_node/main.tf
+++ b/terraform/aws/modules/drbd_node/main.tf
@@ -38,7 +38,7 @@ module "get_os_image" {
 resource "aws_instance" "drbd" {
   count                       = var.drbd_count
   ami                         = module.get_os_image.image_id
-  instance_type               = var.instance_type
+  instance_type               = var.vm_size
   key_name                    = var.key_name
   associate_public_ip_address = true
   subnet_id                   = element(aws_subnet.drbd-subnet.*.id, count.index)

--- a/terraform/aws/modules/drbd_node/variables.tf
+++ b/terraform/aws/modules/drbd_node/variables.tf
@@ -18,40 +18,39 @@ variable "drbd_count" {
   default     = 2
 }
 
-variable "instance_type" {
+variable "vm_size" {
   description = "The instance type of drbd node"
   type        = string
-  default     = "t2.large"
 }
 
 variable "availability_zones" {
-  type        = list(string)
   description = "Used availability zones"
+  type        = list(string)
 }
 
 variable "vpc_id" {
-  type        = string
   description = "Id of the vpc used for this deployment"
+  type        = string
 }
 
 variable "subnet_address_range" {
-  type        = list(string)
   description = "List with subnet address ranges in cidr notation to create the netweaver subnets"
+  type        = list(string)
 }
 
 variable "key_name" {
-  type        = string
   description = "AWS key pair name"
+  type        = string
 }
 
 variable "security_group_id" {
-  type        = string
   description = "Security group id"
+  type        = string
 }
 
 variable "route_table_id" {
-  type        = string
   description = "Route table id"
+  type        = string
 }
 
 variable "aws_credentials" {

--- a/terraform/aws/modules/hana_node/main.tf
+++ b/terraform/aws/modules/hana_node/main.tf
@@ -50,7 +50,7 @@ module "get_os_image" {
 resource "aws_instance" "hana" {
   count                       = var.hana_count
   ami                         = module.get_os_image.image_id
-  instance_type               = var.instance_type
+  instance_type               = var.vm_size
   key_name                    = var.key_name
   associate_public_ip_address = true
   #disable_api_stop            = false # see https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-cluster-configuration.html

--- a/terraform/aws/modules/hana_node/variables.tf
+++ b/terraform/aws/modules/hana_node/variables.tf
@@ -18,8 +18,9 @@ variable "hana_count" {
   default     = 2
 }
 
-variable "instance_type" {
-  type = string
+variable "vm_size" {
+  description = "The instance type of hana node"
+  type        = string
 }
 
 variable "availability_zones" {

--- a/terraform/aws/modules/iscsi_server/main.tf
+++ b/terraform/aws/modules/iscsi_server/main.tf
@@ -13,7 +13,7 @@ module "get_os_image" {
 resource "aws_instance" "iscsisrv" {
   count                       = var.iscsi_count
   ami                         = module.get_os_image.image_id
-  instance_type               = var.instance_type
+  instance_type               = var.vm_size
   key_name                    = var.key_name
   associate_public_ip_address = true
   subnet_id                   = element(var.subnet_ids, count.index)

--- a/terraform/aws/modules/iscsi_server/variables.tf
+++ b/terraform/aws/modules/iscsi_server/variables.tf
@@ -27,7 +27,7 @@ variable "iscsi_count" {
   type        = number
 }
 
-variable "instance_type" {
+variable "vm_size" {
   description = "The instance type of iscsi server node."
   type        = string
 }

--- a/terraform/aws/modules/monitoring/main.tf
+++ b/terraform/aws/modules/monitoring/main.tf
@@ -11,7 +11,7 @@ module "get_os_image" {
 resource "aws_instance" "monitoring" {
   count                       = var.monitoring_enabled == true ? 1 : 0
   ami                         = module.get_os_image.image_id
-  instance_type               = var.instance_type
+  instance_type               = var.vm_size
   key_name                    = var.key_name
   associate_public_ip_address = true
   subnet_id                   = element(var.subnet_ids, 0)

--- a/terraform/aws/modules/monitoring/variables.tf
+++ b/terraform/aws/modules/monitoring/variables.tf
@@ -2,21 +2,22 @@ variable "common_variables" {
   description = "Output of the common_variables module"
 }
 
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+}
+
 variable "monitoring_enabled" {
   description = "enable the host to be monitored by exporters, e.g node_exporter"
   type        = bool
   default     = false
 }
 
-variable "instance_type" {
+variable "vm_size" {
   description = "The instance type of monitoring node."
   type        = string
 }
 
-variable "name" {
-  description = "hostname, without the domain part"
-  type        = string
-}
 
 variable "network_domain" {
   description = "hostname's network domain"

--- a/terraform/aws/modules/netweaver_node/main.tf
+++ b/terraform/aws/modules/netweaver_node/main.tf
@@ -83,7 +83,7 @@ module "get_os_image" {
 resource "aws_instance" "netweaver" {
   count                       = local.vm_count
   ami                         = module.get_os_image.image_id
-  instance_type               = var.instance_type
+  instance_type               = var.vm_size
   key_name                    = var.key_name
   associate_public_ip_address = true
   subnet_id                   = element(aws_subnet.netweaver-subnet.*.id, count.index % 2) # %2 is used because there are not more than 2 subnets

--- a/terraform/aws/modules/netweaver_node/variables.tf
+++ b/terraform/aws/modules/netweaver_node/variables.tf
@@ -2,19 +2,9 @@ variable "common_variables" {
   description = "Output of the common_variables module"
 }
 
-variable "xscs_server_count" {
-  type    = number
-  default = 2
-}
-
 variable "app_server_count" {
   type    = number
   default = 2
-}
-
-variable "instance_type" {
-  description = "The instance type of netweaver node."
-  type        = string
 }
 
 variable "name" {
@@ -24,6 +14,17 @@ variable "name" {
 
 variable "network_domain" {
   description = "hostname's network domain"
+  type        = string
+}
+
+variable "xscs_server_count" {
+  description = "Number of xscs nodes"
+  type        = number
+  default     = 2
+}
+
+variable "vm_size" {
+  description = "The instance type of netweaver node."
   type        = string
 }
 

--- a/terraform/azure/modules/drbd_node/variables.tf
+++ b/terraform/azure/modules/drbd_node/variables.tf
@@ -11,18 +11,27 @@ variable "resource_group_name" {
   type = string
 }
 
+variable "drbd_count" {
+  description = "Number of drbd machines to create the cluster"
+  type        = number
+  default     = 2
+}
+
+variable "vm_size" {
+  description = "The instance type of drbd node"
+  type        = string
+  default     = "Standard_D2s_v3"
+}
+
 variable "network_subnet_id" {
   type = string
 }
 
 variable "storage_account" {
-  type = string
+  description = "Storage account name needed for the boot diagnostic"
+  type        = string
 }
 
-variable "drbd_count" {
-  type    = string
-  default = "2"
-}
 
 variable "host_ips" {
   description = "ip addresses to set to the nodes"
@@ -45,10 +54,6 @@ variable "name" {
   type        = string
 }
 
-variable "vm_size" {
-  type    = string
-  default = "Standard_D2s_v3"
-}
 
 variable "network_domain" {
   description = "hostname's network domain"

--- a/terraform/azure/modules/hana_node/variables.tf
+++ b/terraform/azure/modules/hana_node/variables.tf
@@ -20,7 +20,8 @@ variable "network_subnet_netapp_id" {
 }
 
 variable "storage_account" {
-  type = string
+  description = "Storage account name needed for the boot diagnostic"
+  type        = string
 }
 
 variable "hana_count" {


### PR DESCRIPTION
Try to use a uniform naming convention for modules across different cloud providers.
This PR intentionally only change internal modules API and does not touch `terraform/aws/variables.tf`.
In this way the end user has not to change anything in the conf.yaml.
Remove some vm_size default at module level, only to have defaults in the upper layer and in a single place.
Reorder variables fields always to have description at first place.

Ticket: https://jira.suse.com/browse/TEAM-7678

# Verification

 ## sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_r48xlarge_test@64bit
 
- http://openqaworker15.qa.suse.cz/tests/296104 :green_circle:  Variable file http://openqaworker15.qa.suse.cz/tests/296104/file/configure-terraform.tfvars has `hana_instancetype = "r4.8xlarge"` and it result in http://openqaworker15.qa.suse.cz/tests/296104/logfile?filename=deploy-terraform.plan.log.txt to have 

```
# module.hana_node.aws_instance.hana[0] will be created
  + resource "aws_instance" "hana" {
    ...
      + instance_type                        = "r4.8xlarge"
```

##  sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_r5bmetal_test@64bit 
 - http://openqaworker15.qa.suse.cz/tests/296105 :green_circle: it has `hana_instancetype = "r5b.metal"` in http://openqaworker15.qa.suse.cz/tests/296105/file/configure-terraform.tfvars and the same used in http://openqaworker15.qa.suse.cz/tests/296105/logfile?filename=deploy-terraform.plan.log.txt
