### PR TITLE
Run aws set_facts conditionally

### DIFF
--- a/ansible/playbooks/tasks/cluster-bootstrap.yaml
+++ b/ansible/playbooks/tasks/cluster-bootstrap.yaml
@@ -222,7 +222,7 @@
     migration_threshold: "{{ (crm_rsc_options_show.stdout | regex_search('migration-threshold=([0-9]*)', '\\1'))[0] | default('false') }}"
     op_default_timeout: "{{ (crm_op_options_show.stdout | regex_search('timeout=([0-9]*)', '\\1'))[0] | default('false') }}"
 
-- name: Set corosync facts
+- name: Stonith command [AWS]
   ansible.builtin.set_fact:
     aws_stonith_cmd: |
       crm configure primitive rsc_aws_stonith stonith:external/ec2 \
@@ -231,6 +231,7 @@
       op monitor interval=120 timeout=60 \
       meta target-role=Started \
       params tag={{ aws_stonith_tag}} pcmk_delay_max=15
+  when: cloud_platform_is_aws
 
 - name: Enable SBD [sbd]
   ansible.builtin.command:


### PR DESCRIPTION
`Set corosync facts` in `cluster_bootstrap.yaml` is being run for both aws and gcp, but only applies to aws, uses an aws-specific variable and that causes gcp tests to fail due to missing variable. This pr conditionally runs the task, only if platform is aws.

- Related ticket: https://jira.suse.com/browse/TEAM-9643
- Verification runs:
http://openqaworker15.qa.suse.cz/tests/296118 (passed the point of trouble, fails due to native fencing not working)
http://openqaworker15.qa.suse.cz/tests/296122 (PASS, sbd implementation)