### PR TITLE
Update stonith-timeout value according to GCP official document

### DIFF
--- a/ansible/playbooks/tasks/cluster-bootstrap.yaml
+++ b/ansible/playbooks/tasks/cluster-bootstrap.yaml
@@ -346,7 +346,7 @@
     cmd: >-
       crm configure property
       $id="cib-bootstrap-options"
-      stonith-timeout=600s
+      stonith-timeout=300s
   when:
     - stonith_timeout != '300s'
     - is_primary


### PR DESCRIPTION
stonith-timeout is set to 600s for qe-sap-deployment Ansible GCP native fencing, and it is probably typo according to the code:

```
- name: Set stonith timeout [native - gcp]
  ansible.builtin.command:
    cmd: >-
      crm configure property
      $id="cib-bootstrap-options"
      stonith-timeout=600s        <---- set to 600s
  when:
    - stonith_timeout != '300s'   <----- condition is 300s
    - is_primary
```
and it also suggests to 300s in the official documentation
https://cloud.google.com/solutions/sap/docs/sap-hana-scaleout-ha-tf-deployment?hl=it

- Ticket: https://jira.suse.com/browse/TEAM-9248
- VR: http://openqaworker15.qa.suse.cz/tests/298302