### PR TITLE
Local SAS token generation as normal user

### DIFF
--- a/ansible/playbooks/sap-hana-download-media.yaml
+++ b/ansible/playbooks/sap-hana-download-media.yaml
@@ -2,8 +2,6 @@
 - name: SAP HANA download media
   hosts: hana
   remote_user: cloudadmin
-  become: true
-  become_user: root
   vars:
     hana_download_path: /hana/shared/install
     url_timeout: 30
@@ -14,14 +12,6 @@
 
     - name: Include external variables
       ansible.builtin.include_vars: ./vars/hana_media.yaml
-
-    - name: Create software directory
-      ansible.builtin.file:
-        path: "{{ hana_download_path }}"
-        state: directory
-        owner: root
-        group: root
-        mode: 0755
 
     - name: Retrieve account key
       ansible.builtin.command: >-
@@ -65,6 +55,16 @@
       run_once: true
       when: az_sas_token is not defined or az_sas_token == ""
 
+    - name: Create software directory
+      ansible.builtin.file:
+        path: "{{ hana_download_path }}"
+        state: directory
+        owner: root
+        group: root
+        mode: 0755
+      become: true
+      become_user: root
+
     - name: Download HANA media with SAS token
       ansible.builtin.get_url:
         url: "https://{{ az_storage_account_name }}.blob.core.windows.net/{{ az_container_name }}/{{ item }}?{{ az_sas_token }}"
@@ -78,19 +78,6 @@
       retries: "{{ url_retries_cnt }}"
       delay: "{{ url_retries_delay }}"
       with_items: "{{ az_blobs }}"
+      become: true
+      become_user: root
       when: az_sas_token is defined
-
-    - name: Download HANA media without SAS token
-      ansible.builtin.get_url:
-        url: "https://{{ az_storage_account_name }}.blob.core.windows.net/{{ az_container_name }}/{{ item }}"
-        dest: "{{ hana_download_path + '/' + item | split('/') | last }}"
-        owner: root
-        group: root
-        mode: 0600
-        timeout: "{{ url_timeout }}"
-      register: result
-      until: result is succeeded
-      retries: "{{ url_retries_cnt }}"
-      delay: "{{ url_retries_delay }}"
-      with_items: "{{ az_blobs }}"
-      when: az_sas_token is not defined

--- a/ansible/playbooks/tasks/cluster-bootstrap.yaml
+++ b/ansible/playbooks/tasks/cluster-bootstrap.yaml
@@ -270,8 +270,8 @@
   register: stonith_config_result
   failed_when: "'ERROR' in stonith_config_result.stderr"
 
-# Thee following STONITH commands for GCP have been adapted from
-# https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles
+# The following STONITH commands for GCP have been adapted from
+# https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#create_the_fencing_device_resources
 - name: Configure GCP Native Fencing STONITH for Primary
   ansible.builtin.command: >
     crm configure primitive rsc_gce_stonith_primary stonith:fence_gce
@@ -287,6 +287,8 @@
     - is_primary
     - not (use_sbd | bool)
 
+# Command to configure the Secondary has to be executed on the primary
+# https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#create_the_fencing_device_resources
 - name: Configure GCP Native Fencing STONITH for Secondary
   ansible.builtin.command: >
     crm configure primitive rsc_gce_stonith_secondary stonith:fence_gce


### PR DESCRIPTION
Do not run the SAS token local generation as root. This prevents tools like az not to be found when running the deployment as normal user.

Related ticket: https://jira.suse.com/browse/TEAM-9540


# Verification
 - sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/298426 :green_circle: 
 - 