### PR TITLE
Rename internal Ansible value

### DIFF
--- a/ansible/playbooks/tasks/aws-cluster-hana.yaml
+++ b/ansible/playbooks/tasks/aws-cluster-hana.yaml
@@ -9,16 +9,16 @@
 - name: Set hana crm facts
   ansible.builtin.set_fact:
     crm_maintainence_mode: "{{ (crm_conf_hana_show.stdout | regex_search('maintenance-mode=([a-z]*)', '\\1'))[0] | default('unknown') }}"
-    hana_topology_clone: "{{ crm_conf_hana_show.stdout | regex_search('clone cln_SAPHanaTopology') }}"
     stonith_timeout: "{{ crm_conf_hana_show.stdout | regex_search('stonith-timeout') }}"  # this should be variable!
-    hana_topology_resource: "{{ crm_conf_hana_show.stdout | regex_search('primitive rsc_SAPHanaTopology') }}"
-    hana_resource_clone: "{{ crm_conf_hana_show.stdout | regex_search('ms msl_SAPHana_') }}"
     hana_resource: "{{ crm_conf_hana_show.stdout | regex_search('primitive rsc_SAPHana_') }}"
+    hana_clone: "{{ crm_conf_hana_show.stdout | regex_search('ms msl_SAPHana_') }}"
+    hana_topology_resource: "{{ crm_conf_hana_show.stdout | regex_search('primitive rsc_SAPHanaTopology') }}"
+    hana_topology_clone: "{{ crm_conf_hana_show.stdout | regex_search('clone cln_SAPHanaTopology') }}"
     ip_resource: "{{ crm_conf_hana_show.stdout | regex_search('primitive rsc_ip_') }}"
     ip_nc: "{{ crm_conf_hana_show.stdout | regex_search('primitive rsc_socat_') }}"
     ip_grp: "{{ crm_conf_hana_show.stdout | regex_search('group g_ip_') }}"
     ip_colo: "{{ crm_conf_hana_show.stdout | regex_search('colocation col_saphana_ip_') }}"
-    order: "{{ crm_conf_hana_show.stdout | regex_search('order ord_SAPHana_') }}"
+    cluster_order: "{{ crm_conf_hana_show.stdout | regex_search('order ord_SAPHana_') }}"
   when: is_primary
   changed_when: false
 
@@ -94,7 +94,7 @@
       target-role="Started"
       interleave="true"
   when:
-    - hana_resource_clone | length == 0
+    - hana_clone | length == 0
     - is_primary
 
 - name: Configure colocation
@@ -115,7 +115,7 @@
       2000:
       cln_SAPHanaTopology_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
       msl_SAPHana_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
-  when: order | length == 0
+  when: cluster_order | length == 0
 
 # Get current maintainence state
 - name: Refresh cluster status

--- a/ansible/playbooks/tasks/azure-cluster-hana.yaml
+++ b/ansible/playbooks/tasks/azure-cluster-hana.yaml
@@ -5,20 +5,20 @@
   register: crm_conf_show
   changed_when: false
 
-- name: Set crm facts
+- name: Set hana crm facts
   ansible.builtin.set_fact:
     crm_maintenance_mode: "{{ (crm_conf_show.stdout | regex_search('maintenance-mode=([a-z]*)', '\\1'))[0] }}"
     stonith_enabled: "{{ (crm_conf_show.stdout | regex_search('stonith-enabled=([a-z]*)', '\\1'))[0] | default('false') }}"
-    hana_topology_clone: "{{ crm_conf_show.stdout | regex_search('clone cln_SAPHanaTopology') }}"
     stonith_timeout: "{{ crm_conf_show.stdout | regex_search('stonith-timeout') }}"  # this should be variable!
-    hana_topology_resource: "{{ crm_conf_show.stdout | regex_search('primitive rsc_SAPHanaTopology') }}"
-    hana_resource_clone: "{{ crm_conf_show.stdout | regex_search('ms msl_SAPHana_') }}"
     hana_resource: "{{ crm_conf_show.stdout | regex_search('primitive rsc_SAPHana_') }}"
+    hana_clone: "{{ crm_conf_show.stdout | regex_search('ms msl_SAPHana_') }}"
+    hana_topology_resource: "{{ crm_conf_show.stdout | regex_search('primitive rsc_SAPHanaTopology') }}"
+    hana_topology_clone: "{{ crm_conf_show.stdout | regex_search('clone cln_SAPHanaTopology') }}"
     ip_resource: "{{ crm_conf_show.stdout | regex_search('primitive rsc_ip_') }}"
     ip_nc: "{{ crm_conf_show.stdout | regex_search('primitive rsc_socat_') }}"
     ip_grp: "{{ crm_conf_show.stdout | regex_search('group g_ip_') }}"
     ip_colo: "{{ crm_conf_show.stdout | regex_search('colocation col_saphana_ip_') }}"
-    order: "{{ crm_conf_show.stdout | regex_search('order ord_SAPHana_') }}"
+    cluster_order: "{{ crm_conf_show.stdout | regex_search('order ord_SAPHana_') }}"
     resource_stickiness: "{{ (crm_conf_show.stdout | regex_search('resource-stickiness=([0-9]*)', '\\1'))[0] }}"
     migration_threshold: "{{ (crm_conf_show.stdout | regex_search('migration-threshold=([0-9]*)', '\\1'))[0] }}"
   changed_when: false
@@ -104,7 +104,7 @@
       target-role="Started"
       interleave="true"
       maintenance="true"
-  when: hana_resource_clone | length == 0
+  when: hana_clone | length == 0
 
 - name: Validate cluster IP
   vars:
@@ -169,7 +169,7 @@
       Optional:
       cln_SAPHanaTopology_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
       msl_SAPHana_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
-  when: order | length == 0
+  when: cluster_order | length == 0
 
 - name: Wait for cluster to settle
   ansible.builtin.command:

--- a/ansible/playbooks/tasks/cluster-hana.yaml
+++ b/ansible/playbooks/tasks/cluster-hana.yaml
@@ -9,16 +9,16 @@
 - name: Set hana crm facts
   ansible.builtin.set_fact:
     crm_maintainence_mode: "{{ (crm_conf_hana_show.stdout | regex_search('maintenance-mode=([a-z]*)', '\\1'))[0] | default('unknown') }}"
-    hana_topology_clone: "{{ crm_conf_hana_show.stdout | regex_search('clone cln_SAPHanaTopology') }}"
     stonith_timeout: "{{ crm_conf_hana_show.stdout | regex_search('stonith-timeout') }}"  # this should be variable!
-    hana_topology_resource: "{{ crm_conf_hana_show.stdout | regex_search('primitive rsc_SAPHanaTopology') }}"
-    hana_resource_clone: "{{ crm_conf_hana_show.stdout | regex_search('ms msl_SAPHana_') }}"
     hana_resource: "{{ crm_conf_hana_show.stdout | regex_search('primitive rsc_SAPHana_') }}"
+    hana_clone: "{{ crm_conf_hana_show.stdout | regex_search('ms msl_SAPHana_') }}"
+    hana_topology_resource: "{{ crm_conf_hana_show.stdout | regex_search('primitive rsc_SAPHanaTopology') }}"
+    hana_topology_clone: "{{ crm_conf_hana_show.stdout | regex_search('clone cln_SAPHanaTopology') }}"
     ip_resource: "{{ crm_conf_hana_show.stdout | regex_search('primitive rsc_ip_') }}"
     ip_nc: "{{ crm_conf_hana_show.stdout | regex_search('primitive rsc_socat_') }}"
     ip_grp: "{{ crm_conf_hana_show.stdout | regex_search('group g_ip_') }}"
     ip_colo: "{{ crm_conf_hana_show.stdout | regex_search('colocation col_saphana_ip_') }}"
-    order: "{{ crm_conf_hana_show.stdout | regex_search('order ord_SAPHana') }}"
+    cluster_order: "{{ crm_conf_hana_show.stdout | regex_search('order ord_SAPHana') }}"
   when: is_primary
   changed_when: false
 
@@ -97,7 +97,7 @@
       interleave="true"
   when:
     - is_primary
-    - hana_resource_clone | length == 0
+    - hana_clone | length == 0
 
 - name: Configure colocation [aws]
   ansible.builtin.command:
@@ -135,7 +135,7 @@
       msl_SAPHana_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
   when:
     - is_primary
-    - order | length == 0
+    - cluster_order | length == 0
 
 
 # Get current maintenance state


### PR DESCRIPTION
Rename hana_resource_clone to hana_clone. Because resource is resource and clone is clone of that resource and because all others was named just clone w/o resource.

Code from Jan Kohoutek

Related to ticket : https://jira.suse.com/browse/TEAM-9426


# Verifications


## qesap regression

sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_saptune_test
 -  http://openqaworker15.qa.suse.cz/tests/299056 :green_apple: 

sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_fencing_native_test
 -  http://openqaworker15.qa.suse.cz/tests/299057 :green_apple: 

sle-15-SP5-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE15_5_PAYG-qesap_gcp_sapconf_test
 - http://openqaworker15.qa.suse.cz/tests/299058 :green_apple: 

## HanaSR

 - sle-15-SP6-HanaSr-Azure-Byos-x86_64-Build15-SP6_2024-10-04T02:03:19Z-hanasr_azure_test_saptune_msi az_Standard_E4s_v3
 -  http://openqaworker15.qa.suse.cz/tests/299060


 - sle-15-SP6-HanaSr-Aws-Byos-x86_64-Build15-SP6_2024-10-04T02:03:19Z-hanasr_aws_test_fencing_sbd_stop_kill ec2_r4.8xlarge
 -  http://openqaworker15.qa.suse.cz/tests/299059


- sle-15-SP6-HanaSr-Gcp-Payg-x86_64-Build15-SP6_2024-10-04T02:03:19Z-hanasr_gcp_test_fencing_sbd_stop_kill gce_n1_highmem_8 
-  http://openqaworker15.qa.suse.cz/tests/299061
