### PR TITLE
Install missing fence_gce dependency

### DIFF
--- a/ansible/playbooks/tasks/cluster-bootstrap.yaml
+++ b/ansible/playbooks/tasks/cluster-bootstrap.yaml
@@ -270,6 +270,16 @@
   register: stonith_config_result
   failed_when: "'ERROR' in stonith_config_result.stderr"
 
+# This is a workaround for https://bugzilla.suse.com/show_bug.cgi?id=1231153
+# If it is fixed, this task will no longer be needed
+- name: Install python-httplib2 via zypper
+  zypper:
+    name: python-httplib2
+    state: present
+  when: ansible_distribution_major_version == '12'
+  register: httplib2_zypper
+  ignore_errors: true
+
 # The following STONITH commands for GCP have been adapted from
 # https://cloud.google.com/solutions/sap/docs/sap-hana-ha-config-sles#create_the_fencing_device_resources
 - name: Configure GCP Native Fencing STONITH for Primary


### PR DESCRIPTION
This PR adds a task to install a missing fence_gce dependency using zypper. More details on the ticket comments.

- Related ticket: https://jira.suse.com/browse/TEAM-9693 and https://bugzilla.suse.com/show_bug.cgi?id=1231153
- VR: https://openqaworker15.qa.suse.cz/tests/299391