### PR TITLE
Qesap log ansible filename

### DIFF
--- a/scripts/qesap/test/e2e/test.sh
+++ b/scripts/qesap/test/e2e/test.sh
@@ -309,7 +309,7 @@ grep -E "TASK.*Say hello" ansible.sambuconero.log.txt || test_die "Expected cont
 rm "${THIS_LOG}"
 rm ansible.*.log.txt
 
-test_step "[test_6.yaml] Check redirection to file of Ansible logs"
+test_step "[test_6.yaml] Check redirection to file of ansible-playbook logs"
 rm ansible.*.log.txt || echo "Nothing to delete"
 cp sambuconero.yaml "${QESAPROOT}/ansible/playbooks/timbio.yaml"
 cp sambuconero.yaml "${QESAPROOT}/ansible/playbooks/buga.yaml"
@@ -317,11 +317,11 @@ cp sambuconero.yaml "${QESAPROOT}/ansible/playbooks/purace.yaml"
 qesap.py -b ${QESAPROOT} -c test_6.yaml ansible || test_die "test_6.yaml fail on ansible"
 ansible_logs_number=$(find . -type f -name "ansible.*.log.txt" | wc -l)
 echo "--> ansible_logs_number:${ansible_logs_number}"
-# 3 playbooks plus a log file for the initial ansible (not ansible-playbook) call 
-[[ $ansible_logs_number -eq 4 ]] || test_die "ansible .log.txt are not 4 files but has ${ansible_logs_number}"
+# 3 playbooks means 3 logs
+[[ $ansible_logs_number -eq 3 ]] || test_die "ansible .log.txt are not 3 files but has ${ansible_logs_number}"
 rm ansible.*.log.txt
 
-test_step "[test_7.yaml] Check redirection to file of Ansible logs in case of error in the playbook execution"
+test_step "[test_7.yaml] Check redirection to file of ansible-playbook logs in case of error in the playbook execution"
 rm ansible.*.log.txt || echo "Nothing to delete"
 cp marasca.yaml "${QESAPROOT}/ansible/playbooks/"
 set +e
@@ -329,8 +329,8 @@ qesap.py --verbose -b ${QESAPROOT} -c test_7.yaml ansible
 rc=$?; [[ $rc -ne 0 ]] || test_die "qesap.py ansible has to fail if ansible-playbook fails rc:$rc"
 set -e
 ansible_logs_number=$(find . -type f -name "ansible.*.log.txt" | wc -l)
-# 2 playbooks plus a log file for the initial ansible (not ansible-playbook) call
-[[ $ansible_logs_number -eq 3 ]] || test_die "ansible .log.txt are not 3 files but has ${ansible_logs_number}"
+# 2 playbooks means 2 logs
+[[ $ansible_logs_number -eq 2 ]] || test_die "ansible .log.txt are not 2 files but has ${ansible_logs_number}"
 grep -E "TASK.*Say hello" ansible.sambuconero.log.txt || test_die "Expected content not found in ansible.sambuconero.log.txt"
 grep -E "TASK.*This fails" ansible.marasca.log.txt || test_die "Expected content not found in ansible.marasca.log.txt"
 rm ansible.*.log.txt

--- a/scripts/qesap/test/unit/test_qesap_ansible.py
+++ b/scripts/qesap/test/unit/test_qesap_ansible.py
@@ -690,7 +690,8 @@ def test_ansible_junit(
     mock_call_ansibleplaybook,
 ):
     """
-    Test that --junit result in Ansible called with two additional env variables
+    Test that using '--junit' on the glue script command line
+    results in two additional env variables added at each ansible command execution
 
         ANSIBLE_CALLBACKS_ENABLED=junit
         JUNIT_OUTPUT_DIR="/something/somewhere"

--- a/scripts/qesap/test/unit/test_qesap_lib_cmd_ansible.py
+++ b/scripts/qesap/test/unit/test_qesap_lib_cmd_ansible.py
@@ -29,7 +29,7 @@ def test_export_ansible_output():
         "-vvvv",
         "-i",
         "/root/qe-sap-deployment/terraform/aws/inventory.yaml",
-        "/some/immaginary/path/testAll.yaml",
+        "/some/immaginary/path/ansible/playbooks/testAll.yaml",
         "-e",
         "something=somevalue",
     ]


### PR DESCRIPTION
Reorganize the internal implementation of how the list of Ansible
command is composed by the glue script. This first commit does not result in any behavioral changes.
Improve the way the log filename is calculated from the Ansible playbook
name. Name is no more detected within the command at fixed position but
by parsing each element of the command and detecting playbook filename
by the path. This new approach allows further change in the
ansible-playbook command composition. This commit also restrict the dump
to file only at ansible-playbook execution, leaving out the first
Ansible command.

Preliminary PR to fix a limitation in https://github.com/SUSE/qe-sap-deployment/pull/234 
This PR is needed now as preliminary task for TEAM-9713, as adding the folder creation command in the glue script result in an exception at the point the glue script try to calculate the log filename for the mkdir command (that does not need to record any log).

Related ticket: TEAM-9713

# Verifications:

## qesap deployment

### Azure
 - sle-15-SP6-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_6_BYOS-qesap_azure_saptune_test -> http://openqaworker15.qa.suse.cz/tests/299398 :green_circle: 

 - sle-15-SP5-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_5_BYOS-qesap_azure_ansible_roles_test -> http://openqaworker15.qa.suse.cz/tests/299400

### AWS
 - sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_fencing_native_test -> http://openqaworker15.qa.suse.cz/tests/299399 

### GCP
 - sle-15-SP5-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE15_5_PAYG-qesap_gcp_sapconf_test -> http://openqaworker15.qa.suse.cz/tests/299401 :green_circle: 


## HanaSR

 - sle-15-SP6-HanaSr-Aws-Byos-x86_64-Build15-SP6_2024-10-08T02:03:26Z-hanasr_aws_test_fencing_sbd_stop_kill ec2_r4.8xlarge -> http://openqaworker15.qa.suse.cz/tests/299402

 - sle-15-SP6-HanaSr-Azure-Byos-x86_64-Build15-SP6_2024-10-08T02:03:26Z-hanasr_azure_test_saptune_msi az_Standard_E4s_v3 -> http://openqaworker15.qa.suse.cz/tests/299403