### PR TITLE
Add mkdir command when using --junit

### DIFF
--- a/scripts/qesap/lib/cmds.py
+++ b/scripts/qesap/lib/cmds.py
@@ -289,7 +289,7 @@ def ansible_command_sequence(configure_data_ansible, base_project, sequence, ver
         # the folder is not created.
         # Create an empty folder in advance, if it is not already there
         # so that the glue script called can always suppose that at least the folder is present.
-        ansible_cmd_seq.append({'cmd': ['mkdir', junit]})
+        ansible_cmd_seq.append({'cmd': ['mkdir', '-p', junit]})
 
     ssh_share = ansible_common.copy()
     ssh_share[0] = ansible_bin_paths['ansible']

--- a/scripts/qesap/lib/cmds.py
+++ b/scripts/qesap/lib/cmds.py
@@ -281,6 +281,16 @@ def ansible_command_sequence(configure_data_ansible, base_project, sequence, ver
     # 4. Start composing and accumulating the list of all needed commands
     ansible_cmd = []
     ansible_cmd_seq = []
+
+    if junit and not os.path.isdir(junit):
+        # This is the folder also used in the Ansible configuration JUNIT_OUTPUT_DIR.
+        # ansible-playbook is able to create it from its own but
+        # is a failure occur in the first sequence command, that is ansible and not ansible-playbook,
+        # the folder is not created.
+        # Create an empty folder in advance, if it is not already there
+        # so that the glue script called can always suppose that at least the folder is present.
+        ansible_cmd_seq.append({'cmd': ['mkdir', junit]})
+
     ssh_share = ansible_common.copy()
     ssh_share[0] = ansible_bin_paths['ansible']
     # Don't set '--ssh-extra-args="..."' but 'ssh-extra-args=...'

--- a/scripts/qesap/test/e2e/test.sh
+++ b/scripts/qesap/test/e2e/test.sh
@@ -389,14 +389,16 @@ rm "${QESAPROOT}/ansible/playbooks/marasca.yaml"
 rm "${TEST_PROVIDER}/inventory.yaml"
 
 test_step "[test_4.yaml] Run Ansible with --junit"
+THIS_REPORT_DIR="${QESAPROOT}/junit_reports/nested/nested"
 cp sambuconero.yaml "${QESAPROOT}/ansible/playbooks/sambuconero.yaml"
 cp inventory.yaml "${TEST_PROVIDER}/inventory.yaml"
 find . -type f -name "sambuconero*.xml" -delete || echo "Nothing to delete"
-qesap.py --verbose -b ${QESAPROOT} -c test_4.yaml ansible --junit . || test_die "test_4.yaml fail on ansible"
+qesap.py --verbose -b ${QESAPROOT} -c test_4.yaml ansible --junit ${THIS_REPORT_DIR} || test_die "test_4.yaml fail on ansible"
 junit_logs_number=$(find . -type f -name "sambuconero*.xml" | wc -l)
 echo "--> junit_logs_number:${junit_logs_number}"
 [[ $junit_logs_number -eq 1 ]] || test_die "ansible JUNIT reports should be 1 files but are ${junit_logs_number}"
 find . -type f -name "sambuconero*.xml" -delete
+rm -rf ${THIS_REPORT_DIR}
 
 test_step "[test_8.yaml] Run Ansible with --profile"
 rm ansible.*.log.txt || echo "Nothing to delete"


### PR DESCRIPTION
Add mkdir command to create the report folder later used by ansible-playbook to store junit reports.

Ticket: https://jira.suse.com/browse/TEAM-9713

# Verification

 - sle-15-SP6-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_6_BYOS-qesap_azure_saptune_test@64bit -> http://openqaworker15.qa.suse.cz/tests/299484 :green_circle:  `mkdir` is visible at the beginning of http://openqaworker15.qa.suse.cz/tests/299484/logfile?filename=deploy-qesap_exec_ansible.log.txt
```
INFO     Run:       'mkdir /tmp/results/'
```
