### PR TITLE
Sync of resource names

### DIFF
--- a/ansible/playbooks/sap-hana-cluster.yaml
+++ b/ansible/playbooks/sap-hana-cluster.yaml
@@ -18,7 +18,7 @@
     crypto_cipher: aes256
     # Define some names in a central place
     rsc_socat: "rsc_socat_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}"
-    rsc_SAPHana: "rsc_SAPHana_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}"
+    rsc_saphanactl: "rsc_SAPHanaCtl_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}"
 
 
   handlers:
@@ -80,7 +80,7 @@
         cmd: >-
           crm resource
           refresh
-          msl_SAPHana_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+          msl_SAPHanaCtl_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
       when: is_primary
 
     - name: Wait for cluster to settle
@@ -93,6 +93,6 @@
         cmd: >-
           crm resource
           maintenance
-          msl_SAPHana_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+          msl_SAPHanaCtl_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
           off
       when: is_primary

--- a/ansible/playbooks/tasks/aws-cluster-hana.yaml
+++ b/ansible/playbooks/tasks/aws-cluster-hana.yaml
@@ -10,15 +10,15 @@
   ansible.builtin.set_fact:
     crm_maintainence_mode: "{{ (crm_conf_hana_show.stdout | regex_search('maintenance-mode=([a-z]*)', '\\1'))[0] | default('unknown') }}"
     stonith_timeout: "{{ crm_conf_hana_show.stdout | regex_search('stonith-timeout') }}"  # this should be variable!
-    hana_resource: "{{ crm_conf_hana_show.stdout | regex_search('primitive rsc_SAPHana_') }}"
-    hana_clone: "{{ crm_conf_hana_show.stdout | regex_search('ms msl_SAPHana_') }}"
-    hana_topology_resource: "{{ crm_conf_hana_show.stdout | regex_search('primitive rsc_SAPHanaTopology') }}"
-    hana_topology_clone: "{{ crm_conf_hana_show.stdout | regex_search('clone cln_SAPHanaTopology') }}"
+    hana_resource: "{{ crm_conf_hana_show.stdout | regex_search('primitive rsc_SAPHanaCtl_') }}"
+    hana_clone: "{{ crm_conf_hana_show.stdout | regex_search('ms msl_SAPHanaCtl_') }}"
+    hana_topology_resource: "{{ crm_conf_hana_show.stdout | regex_search('primitive rsc_SAPHanaTpg') }}"
+    hana_topology_clone: "{{ crm_conf_hana_show.stdout | regex_search('clone cln_SAPHanaTpg') }}"
     ip_resource: "{{ crm_conf_hana_show.stdout | regex_search('primitive rsc_ip_') }}"
     ip_nc: "{{ crm_conf_hana_show.stdout | regex_search('primitive rsc_socat_') }}"
     ip_grp: "{{ crm_conf_hana_show.stdout | regex_search('group g_ip_') }}"
     ip_colo: "{{ crm_conf_hana_show.stdout | regex_search('colocation col_saphana_ip_') }}"
-    cluster_order: "{{ crm_conf_hana_show.stdout | regex_search('order ord_SAPHana_') }}"
+    cluster_order: "{{ crm_conf_hana_show.stdout | regex_search('order ord_SAPHanaCtl_') }}"
   when: is_primary
   changed_when: false
 
@@ -31,10 +31,10 @@
   ansible.builtin.command:
     cmd: >-
       crm configure primitive
-      rsc_SAPHanaTopology_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+      rsc_SAPHanaTpg_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
       ocf:suse:SAPHanaTopology
       operations
-      $id="rsc_sap2_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}-operations"
+      $id="rsc_sap2_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}-operations"
       op monitor interval="10" timeout="600"
       op start interval="0" timeout="600"
       op stop interval="0" timeout="300"
@@ -48,8 +48,8 @@
   ansible.builtin.command:
     cmd: >-
       crm configure clone
-      cln_SAPHanaTopology_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
-      rsc_SAPHanaTopology_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+      cln_SAPHanaTpg_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
+      rsc_SAPHanaTpg_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
       meta
       clone-node-max="1"
       target-role="Started"
@@ -62,10 +62,10 @@
   ansible.builtin.command:
     cmd: >-
       crm configure primitive
-      rsc_SAPHana_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+      rsc_SAPHanaCtl_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
       ocf:suse:SAPHana
       operations
-      $id="rsc_sap_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}-operations"
+      $id="rsc_sap_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}-operations"
       op start interval="0" timeout="3600"
       op stop interval="0" timeout="3600"
       op promote interval="0" timeout="3600"
@@ -85,8 +85,8 @@
   ansible.builtin.command:
     cmd: >-
       crm configure ms
-      msl_SAPHana_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
-      rsc_SAPHana_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+      msl_SAPHanaCtl_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
+      rsc_SAPHanaCtl_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
       meta
       notify="true"
       clone-max="2"
@@ -101,10 +101,10 @@
   ansible.builtin.command:
     cmd: >-
       crm configure colocation
-      col_saphana_ip_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+      col_saphana_ip_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
       2000:
-      rsc_ip_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}:Started
-      msl_SAPHana_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}:Master
+      rsc_ip_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}:Started
+      msl_SAPHanaCtl_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}:Master
   when: ip_colo | length == 0
 
 - name: Configure order
@@ -113,8 +113,8 @@
       crm configure order
       ord_SAPHana
       2000:
-      cln_SAPHanaTopology_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
-      msl_SAPHana_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+      cln_SAPHanaTpg_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
+      msl_SAPHanaCtl_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
   when: cluster_order | length == 0
 
 # Get current maintainence state

--- a/ansible/playbooks/tasks/aws-cluster-hana.yaml
+++ b/ansible/playbooks/tasks/aws-cluster-hana.yaml
@@ -18,7 +18,7 @@
     ip_nc: "{{ crm_conf_hana_show.stdout | regex_search('primitive rsc_socat_') }}"
     ip_grp: "{{ crm_conf_hana_show.stdout | regex_search('group g_ip_') }}"
     ip_colo: "{{ crm_conf_hana_show.stdout | regex_search('colocation col_saphana_ip_') }}"
-    cluster_order: "{{ crm_conf_hana_show.stdout | regex_search('order ord_SAPHanaCtl_') }}"
+    cluster_order: "{{ crm_conf_hana_show.stdout | regex_search('order ord_SAPHana_') }}"
   when: is_primary
   changed_when: false
 

--- a/ansible/playbooks/tasks/azure-cluster-hana.yaml
+++ b/ansible/playbooks/tasks/azure-cluster-hana.yaml
@@ -18,7 +18,7 @@
     ip_nc: "{{ crm_conf_show.stdout | regex_search('primitive rsc_socat_') }}"
     ip_grp: "{{ crm_conf_show.stdout | regex_search('group g_ip_') }}"
     ip_colo: "{{ crm_conf_show.stdout | regex_search('colocation col_saphana_ip_') }}"
-    cluster_order: "{{ crm_conf_show.stdout | regex_search('order ord_SAPHanaCtl_') }}"
+    cluster_order: "{{ crm_conf_show.stdout | regex_search('order ord_SAPHana_') }}"
     resource_stickiness: "{{ (crm_conf_show.stdout | regex_search('resource-stickiness=([0-9]*)', '\\1'))[0] }}"
     migration_threshold: "{{ (crm_conf_show.stdout | regex_search('migration-threshold=([0-9]*)', '\\1'))[0] }}"
   changed_when: false
@@ -165,7 +165,7 @@
   ansible.builtin.command:
     cmd: >-
       crm configure order
-      ord_SAPHanaCtl_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
+      ord_SAPHana_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
       Optional:
       cln_SAPHanaTpg_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
       msl_SAPHanaCtl_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}

--- a/ansible/playbooks/tasks/azure-cluster-hana.yaml
+++ b/ansible/playbooks/tasks/azure-cluster-hana.yaml
@@ -119,7 +119,7 @@
   ansible.builtin.command:
     cmd: >-
       crm configure primitive
-      rsc_ip_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+      rsc_ip_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
       ocf:heartbeat:IPaddr2
       meta
       target-role="Started"
@@ -147,7 +147,7 @@
     cmd: >-
       crm configure group
       g_ip_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
-      rsc_ip_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+      rsc_ip_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
       {{ rsc_socat }}
   when: ip_grp | length == 0
 

--- a/ansible/playbooks/tasks/azure-cluster-hana.yaml
+++ b/ansible/playbooks/tasks/azure-cluster-hana.yaml
@@ -10,15 +10,15 @@
     crm_maintenance_mode: "{{ (crm_conf_show.stdout | regex_search('maintenance-mode=([a-z]*)', '\\1'))[0] }}"
     stonith_enabled: "{{ (crm_conf_show.stdout | regex_search('stonith-enabled=([a-z]*)', '\\1'))[0] | default('false') }}"
     stonith_timeout: "{{ crm_conf_show.stdout | regex_search('stonith-timeout') }}"  # this should be variable!
-    hana_resource: "{{ crm_conf_show.stdout | regex_search('primitive rsc_SAPHana_') }}"
-    hana_clone: "{{ crm_conf_show.stdout | regex_search('ms msl_SAPHana_') }}"
-    hana_topology_resource: "{{ crm_conf_show.stdout | regex_search('primitive rsc_SAPHanaTopology') }}"
-    hana_topology_clone: "{{ crm_conf_show.stdout | regex_search('clone cln_SAPHanaTopology') }}"
+    hana_resource: "{{ crm_conf_show.stdout | regex_search('primitive rsc_SAPHanaCtl_') }}"
+    hana_clone: "{{ crm_conf_show.stdout | regex_search('ms msl_SAPHanaCtl_') }}"
+    hana_topology_resource: "{{ crm_conf_show.stdout | regex_search('primitive rsc_SAPHanaTpg') }}"
+    hana_topology_clone: "{{ crm_conf_show.stdout | regex_search('clone cln_SAPHanaTpg') }}"
     ip_resource: "{{ crm_conf_show.stdout | regex_search('primitive rsc_ip_') }}"
     ip_nc: "{{ crm_conf_show.stdout | regex_search('primitive rsc_socat_') }}"
     ip_grp: "{{ crm_conf_show.stdout | regex_search('group g_ip_') }}"
     ip_colo: "{{ crm_conf_show.stdout | regex_search('colocation col_saphana_ip_') }}"
-    cluster_order: "{{ crm_conf_show.stdout | regex_search('order ord_SAPHana_') }}"
+    cluster_order: "{{ crm_conf_show.stdout | regex_search('order ord_SAPHanaCtl_') }}"
     resource_stickiness: "{{ (crm_conf_show.stdout | regex_search('resource-stickiness=([0-9]*)', '\\1'))[0] }}"
     migration_threshold: "{{ (crm_conf_show.stdout | regex_search('migration-threshold=([0-9]*)', '\\1'))[0] }}"
   changed_when: false
@@ -27,10 +27,10 @@
   ansible.builtin.command:
     cmd: >-
       crm configure primitive
-      rsc_SAPHanaTopology_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+      rsc_SAPHanaTpg_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
       ocf:suse:SAPHanaTopology
       operations
-      $id="rsc_sap2_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}-operations"
+      $id="rsc_sap2_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}-operations"
       op monitor interval="10" timeout="600"
       op start interval="0" timeout="600"
       op stop interval="0" timeout="300"
@@ -62,8 +62,8 @@
   ansible.builtin.command:
     cmd: >-
       crm configure clone
-      cln_SAPHanaTopology_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
-      rsc_SAPHanaTopology_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+      cln_SAPHanaTpg_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
+      rsc_SAPHanaTpg_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
       meta
       clone-node-max="1"
       target-role="Started"
@@ -74,10 +74,10 @@
   ansible.builtin.command:
     cmd: >-
       crm configure primitive
-      {{ rsc_SAPHana }}
+      {{ rsc_saphanactl }}
       ocf:suse:SAPHana
       operations
-      $id="rsc_sap_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}-operations"
+      $id="rsc_sap_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}-operations"
       op start interval="0" timeout="3600"
       op stop interval="0" timeout="3600"
       op promote interval="0" timeout="3600"
@@ -95,8 +95,8 @@
   ansible.builtin.command:
     cmd: >-
       crm configure ms
-      msl_SAPHana_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
-      {{ rsc_SAPHana }}
+      msl_SAPHanaCtl_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
+      {{ rsc_saphanactl }}
       meta
       notify="true"
       clone-max="2"
@@ -124,7 +124,7 @@
       meta
       target-role="Started"
       operations
-      $id="rsc_ip_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}-operations"
+      $id="rsc_ip_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}-operations"
       op monitor interval="10s" timeout="20s"
       params ip="{{ cluster_ip }}"
   when: ip_resource | length == 0
@@ -146,7 +146,7 @@
   ansible.builtin.command:
     cmd: >-
       crm configure group
-      g_ip_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+      g_ip_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
       rsc_ip_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
       {{ rsc_socat }}
   when: ip_grp | length == 0
@@ -155,20 +155,20 @@
   ansible.builtin.command:
     cmd: >-
       crm configure colocation
-      col_saphana_ip_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+      col_saphana_ip_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
       4000:
-      g_ip_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}:Started
-      msl_SAPHana_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}:Master
+      g_ip_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}:Started
+      msl_SAPHanaCtl_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}:Master
   when: ip_colo | length == 0
 
 - name: Configure order
   ansible.builtin.command:
     cmd: >-
       crm configure order
-      ord_SAPHana_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+      ord_SAPHanaCtl_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
       Optional:
-      cln_SAPHanaTopology_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
-      msl_SAPHana_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+      cln_SAPHanaTpg_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
+      msl_SAPHanaCtl_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
   when: cluster_order | length == 0
 
 - name: Wait for cluster to settle
@@ -180,7 +180,7 @@
 # Plus the linter doesn't like it!
 - name: Cleanup
   ansible.builtin.command:
-    cmd: crm resource cleanup {{ rsc_SAPHana }}
+    cmd: crm resource cleanup {{ rsc_saphanactl }}
 
 - name: Wait for cluster to settle
   ansible.builtin.command:

--- a/ansible/playbooks/tasks/cluster-bootstrap.yaml
+++ b/ansible/playbooks/tasks/cluster-bootstrap.yaml
@@ -423,7 +423,7 @@
   ansible.builtin.command:
     cmd: >-
       crm configure primitive
-      rsc_ip_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+      rsc_ip_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
       ocf:suse:aws-vpc-move-ip params
       ip={{ aws_cluster_ip }}
       routing_table={{ aws_route_table_id }}
@@ -441,7 +441,7 @@
   ansible.builtin.command:
     cmd: >-
       crm configure primitive
-      rsc_ip_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+      rsc_ip_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
       IPaddr2
       params ip={{ gcp_cluster_ip }}
       cidr_netmask=32
@@ -457,7 +457,7 @@
   ansible.builtin.command:
     cmd: >-
       crm resource locate
-      rsc_ip_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+      rsc_ip_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
   register: reg_vip_location
   changed_when: false
   when: is_primary
@@ -469,7 +469,7 @@
   ansible.builtin.command:
     cmd: >-
       crm resource move
-      rsc_ip_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+      rsc_ip_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
       {{ primary_hostname }}
   register: reg_move_cmd
   when:
@@ -483,7 +483,7 @@
   ansible.builtin.command:
     cmd: >-
       crm resource locate
-      rsc_ip_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+      rsc_ip_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
   register: reg_vip_location2
   when:
     - is_primary
@@ -496,7 +496,7 @@
   ansible.builtin.command:
     cmd: >-
       crm resource clear
-      rsc_ip_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+      rsc_ip_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
   when:
     - is_primary
     - reg_vip_location.stdout | trim | split(' ') | last != primary_hostname
@@ -521,7 +521,7 @@
     cmd: >-
       crm configure group
       grp_ip_hc
-      rsc_ip_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+      rsc_ip_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
       rsc_healthcheck_primary
   when:
     - is_primary

--- a/ansible/playbooks/tasks/cluster-hana.yaml
+++ b/ansible/playbooks/tasks/cluster-hana.yaml
@@ -10,10 +10,10 @@
   ansible.builtin.set_fact:
     crm_maintainence_mode: "{{ (crm_conf_hana_show.stdout | regex_search('maintenance-mode=([a-z]*)', '\\1'))[0] | default('unknown') }}"
     stonith_timeout: "{{ crm_conf_hana_show.stdout | regex_search('stonith-timeout') }}"  # this should be variable!
-    hana_resource: "{{ crm_conf_hana_show.stdout | regex_search('primitive rsc_SAPHana_') }}"
-    hana_clone: "{{ crm_conf_hana_show.stdout | regex_search('ms msl_SAPHana_') }}"
-    hana_topology_resource: "{{ crm_conf_hana_show.stdout | regex_search('primitive rsc_SAPHanaTopology') }}"
-    hana_topology_clone: "{{ crm_conf_hana_show.stdout | regex_search('clone cln_SAPHanaTopology') }}"
+    hana_resource: "{{ crm_conf_hana_show.stdout | regex_search('primitive rsc_SAPHanaCtl_') }}"
+    hana_clone: "{{ crm_conf_hana_show.stdout | regex_search('ms msl_SAPHanaCtl_') }}"
+    hana_topology_resource: "{{ crm_conf_hana_show.stdout | regex_search('primitive rsc_SAPHanaTpg') }}"
+    hana_topology_clone: "{{ crm_conf_hana_show.stdout | regex_search('clone cln_SAPHanaTpg') }}"
     ip_resource: "{{ crm_conf_hana_show.stdout | regex_search('primitive rsc_ip_') }}"
     ip_nc: "{{ crm_conf_hana_show.stdout | regex_search('primitive rsc_socat_') }}"
     ip_grp: "{{ crm_conf_hana_show.stdout | regex_search('group g_ip_') }}"
@@ -31,10 +31,10 @@
   ansible.builtin.command:
     cmd: >-
       crm configure primitive
-      rsc_SAPHanaTopology_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+      rsc_SAPHanaTpg_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
       ocf:suse:SAPHanaTopology
       operations
-      $id="rsc_sap2_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}-operations"
+      $id="rsc_sap2_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}-operations"
       op monitor interval="10" timeout="600"
       op start interval="0" timeout="600"
       op stop interval="0" timeout="300"
@@ -49,8 +49,8 @@
   ansible.builtin.command:
     cmd: >-
       crm configure clone
-      cln_SAPHanaTopology_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
-      rsc_SAPHanaTopology_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+      cln_SAPHanaTpg_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
+      rsc_SAPHanaTpg_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
       meta
       clone-node-max="1"
       target-role="Started"
@@ -63,10 +63,10 @@
   ansible.builtin.command:
     cmd: >-
       crm configure primitive
-      {{ rsc_SAPHana }}
+      {{ rsc_saphanactl }}
       ocf:suse:SAPHana
       operations
-      $id="rsc_sap_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}-operations"
+      $id="rsc_sap_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}-operations"
       op start interval="0" timeout="3600"
       op stop interval="0" timeout="3600"
       op promote interval="0" timeout="3600"
@@ -87,8 +87,8 @@
   ansible.builtin.command:
     cmd: >-
       crm configure ms
-      msl_SAPHana_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
-      {{ rsc_SAPHana }}
+      msl_SAPHanaCtl_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
+      {{ rsc_saphanactl }}
       meta
       notify="true"
       clone-max="2"
@@ -103,10 +103,10 @@
   ansible.builtin.command:
     cmd: >-
       crm configure colocation
-      col_saphana_ip_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+      col_saphana_ip_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
       2000:
-      rsc_ip_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}:Started
-      msl_SAPHana_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}:Master
+      rsc_ip_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}:Started
+      msl_SAPHanaCtl_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}:Master
   when:
     - is_primary
     - ip_colo | length == 0
@@ -116,10 +116,10 @@
   ansible.builtin.command:
     cmd: >-
       crm configure colocation
-      col_saphana_ip_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+      col_saphana_ip_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
       4000:
-      rsc_ip_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}:Started
-      msl_SAPHana_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}:Master
+      rsc_ip_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}:Started
+      msl_SAPHanaCtl_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}:Master
   when:
     - is_primary
     - ip_colo | length == 0
@@ -131,8 +131,8 @@
       crm configure order
       ord_SAPHana
       2000:
-      cln_SAPHanaTopology_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
-      msl_SAPHana_HDB_{{ sap_hana_install_sid }}{{ sap_hana_install_instance_number }}
+      cln_SAPHanaTpg_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
+      msl_SAPHanaCtl_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
   when:
     - is_primary
     - cluster_order | length == 0
@@ -165,7 +165,7 @@
 
 - name: Cleanup if needed
   ansible.builtin.command:
-    cmd: "crm resource cleanup {{ rsc_SAPHana }}"
+    cmd: "crm resource cleanup {{ rsc_saphanactl }}"
   retries: 3
   delay: 10
   when:


### PR DESCRIPTION
The name of cluster resources should be same all along all of our tests.

Must be merged together with https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/20401

- https://openqaworker15.qa.suse.cz/tests/300016 - PASSED
- https://openqaworker15.qa.suse.cz/tests/300017 - PASSED
- https://openqaworker15.qa.suse.cz/tests/300018 - PASSED
- https://openqaworker15.qa.suse.cz/tests/299517 - PASSED
- https://openqaworker15.qa.suse.cz/tests/299518 - PASSED
- https://openqaworker15.qa.suse.cz/tests/299519 - PASSED
