### PR TITLE
Made pacemaker service as enabled

### DIFF
--- a/ansible/playbooks/sap-hana-cluster.yaml
+++ b/ansible/playbooks/sap-hana-cluster.yaml
@@ -30,6 +30,7 @@
       ansible.builtin.systemd:
         name: pacemaker
         state: started
+        enabled: true
 
   pre_tasks:
     - name: Detect cloud platform


### PR DESCRIPTION
# Verification

## AWS

### Native fencing
 - sle-15-SP6-HanaSr-Aws-Byos-x86_64-Build15-SP6_2024-10-15T02:03:19Z-hanasr_aws_test_saptune_fencing_native_crash ec2_r4.8xlarge -> http://openqaworker15.qa.suse.cz/tests/300009
test fails in CrashSite_a, here the issue look more like https://jira.suse.com/browse/TEAM-9686 as the crashed node never come back reachable at its public IP address 

### SBD
- sle-15-SP6-HanaSr-Aws-Byos-x86_64-Build15-SP6_2024-10-15T02:03:19Z-hanasr_aws_test_fencing_sbd_crash ec2_r4.8xlarge -> http://openqaworker15.qa.suse.cz/tests/300008 :green_circle: pacemaker is active after the crash http://openqaworker15.qa.suse.cz/tests/300008#step/Crash_site_a-primary/638 but no such more than this as cluster is not working after that http://openqaworker15.qa.suse.cz/tests/300008#step/Crash_site_a-primary/771 as vmhana02 fenced it

## GCP

### Native
- sle-15-SP6-HanaSr-Gcp-Payg-x86_64-Build15-SP6_2024-10-15T02:03:19Z-hanasr_gcp_test_saptune_fencing_native_crash gce_n1_highmem_8 -> http://openqaworker15.qa.suse.cz/tests/300014 :green_circle:  . So this PR is changing a solid failure in `Crash_site_a-primary` to a failure in `[Crash_site_b-primary](http://openqaworker15.qa.suse.cz/tests/300014#step/Crash_site_b-primary/707)`

### SBD
- sle-15-SP6-HanaSr-Gcp-Payg-x86_64-Build15-SP6_2024-10-15T02:03:19Z-hanasr_gcp_test_fencing_sbd_crash gce_n1_highmem_8 -> http://openqaworker15.qa.suse.cz/tests/300015  `is_system_running` is `degradated` http://openqaworker15.qa.suse.cz/tests/300015#step/Crash_site_a-primary/741
