### PR TITLE
Stop generating cloudadmin ssh keys

### DIFF
--- a/ansible/playbooks/pre-cluster.yaml
+++ b/ansible/playbooks/pre-cluster.yaml
@@ -2,6 +2,8 @@
 - name: Cluster preparation
   hosts: all
   remote_user: cloudadmin
+  vars:
+    crm_rootless: false
   pre_tasks:
     - name: Detect cloud platform
       ansible.builtin.include_tasks:
@@ -37,7 +39,9 @@
         owner: "{{ ansible_user }}"
         group: users
         mode: '0700'
-      when: inventory_hostname in groups.hana
+      when:
+        - inventory_hostname in groups.hana
+        - crm_rootless
 
     - name: Generate public/private keys for root on hana hosts
       become: true
@@ -61,7 +65,9 @@
         type: rsa
         size: 4096
       register: ssh_user_keys
-      when: inventory_hostname in groups.hana
+      when:
+        - inventory_hostname in groups.hana
+        - crm_rootless
 
     - name: Apply root key to root Authorised Keys
       become: true
@@ -80,7 +86,11 @@
         user: "{{ ansible_user }}"
         state: present
         key: "{{ hostvars[item].ssh_user_keys.public_key }}"
-      when: inventory_hostname in groups.hana and hostvars[item]['ansible_hostname'] in groups.hana and ansible_hostname != item
+      when:
+        - inventory_hostname in groups.hana
+        - hostvars[item]['ansible_hostname'] in groups.hana
+        - ansible_hostname != item
+        - crm_rootless
       with_items: "{{ groups['all'] }}"
 
     - name: Slurp ssh daemon public key


### PR DESCRIPTION
Move all tasks to generate and exchange ssh keys for cloudadmin under an always false variable. So only leave the ssh keys for root.

Ticket TEAM-7760

# Verifications:

## Azure
sle-15-SP6-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_6_BYOS-qesap_azure_saptune_test
-  http://openqaworker15.qa.suse.cz/tests/300570 :green_book: 

sle-12-SP5-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE12_5_PAYG-qesap_azure_saptune_test
 - http://openqaworker15.qa.suse.cz/tests/300571 :green_book: 

## AWS
sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_fencing_native_test
 -  http://openqaworker15.qa.suse.cz/tests/300572 :green_book: 

sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_fencing_sbd_test
 -  http://openqaworker15.qa.suse.cz/tests/300573 :green_book: job fails but I do not think failure is related to the different set of ssh keys configured in the system. Cloned test used for this VR is genarally unstable and about a not fully supported config. Unfortunately the test does not use `crm cluster init/join` or any `crm cluster status`

 - sle-15-SP6-HanaSr-Aws-Byos-x86_64-Build15-SP6_2024-10-22T02:03:21Z-hanasr_aws_test_fencing_sbd_stop_kill ec2_r4.8xlarge -> http://openqaworker15.qa.suse.cz/tests/300649
 
## GCP 
 - sle-15-SP5-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE15_5_PAYG-qesap_gcp_sapconf_test@64bit -> http://openqaworker15.qa.suse.cz/tests/300574 :green_book: 