### PR TITLE
Add support for additional module registration

### DIFF
--- a/ansible/playbooks/registration.yaml
+++ b/ansible/playbooks/registration.yaml
@@ -97,6 +97,30 @@
         - not_registered_found
         - "(rcg.rc != 0) or (use_suseconnect | bool)"
 
+    # Latest version of cloud-regionsrv-client is needed in PAYG, and image
+    # needs to be registered in order for zypper up to work.
+    # see https://www.suse.com/c/long-term-service-pack-support-for-payg-instances-simplified/
+    - name: Ensure cloud-regionsrv-client is on latest version.
+      community.general.zypper:
+        name: cloud-regionsrv-client
+        state: latest
+      when:
+        - not not_registered_found
+        - sles_modules is defined and sles_modules | length > 0
+
+    - name: Add additional authenticated modules
+      ansible.builtin.command: SUSEConnect -p {{ item.key }} -r {{ item.value }}
+      register: result
+      until: result is succeeded
+      retries: 10
+      delay: 60
+      when:
+        - not_registered_found
+        - sles_modules is defined and sles_modules | length > 0
+      loop: "{{ sles_modules }}"
+      loop_control:
+        label: "{{ item.key }}"
+
     - name: Check if repos are added after registration
       ansible.builtin.command: zypper lr -u
       register: repos_after

--- a/docs/playbooks/README.md
+++ b/docs/playbooks/README.md
@@ -33,6 +33,7 @@ Variables:
 
 * reg_code
 * email_address
+* sles_modules
 
 Variable Source = ./variables.sh
 
@@ -45,6 +46,17 @@ If no repos are found, the playbook will first attempt to register with SCC
 using `registercloudguest`. If the command is available, it will be used for
 registration. If `registercloudguest` is not available then `SUSEConnect` will
 be used.
+
+
+There's a task allowing register additional modules that require a dedicated regcode.
+The module names and regcodes can be provided in the `ansible-playbook` command line as list of hashes (named sles_modules).
+
+The format should be like this:
+
+```
+create:
+    - registration.yaml (.......other variables here......) -e sles_modules='[{"key":"<module1>","value":"<regcode1>"},{"key":"<module2","value":"<regcode2>"}]'
+```
 
 ## pre-cluster
 


### PR DESCRIPTION
This adds a task to add any number of additional modules that require a regcode during execution of `registration.yaml` playbook. The module names and regcodes are injected in the command that calls the playbook as arguments, either if the playbook is ran standalone, or if it is run through the config.yaml file.

The format should be like this:

```
create:
    - registration.yaml (.......other variables here......) -e sles_modules='[{"key":"<module_to_activate","value":"<regcode-for-module>"}]'
```

or without the `create` part if running playbook directly.

I tried 2 manual deployments, one with use_suseconnect=true and one without it, and ran ansible (containing only registration module).
I put this in config.yaml, in the line calling the registration.yaml file :

```
create:
    - registration.yaml -e reg_code=...-e email_address='' -e sles_modules='[{"key":"(...LTSS module name)","value":"(ltss regcode)"}]'
 ```
 
- first case, general registration done with SUSEConnect, then new task also ran with suseconnect, after the playbook LTSS is activated.
- second case, general registration done with registercloudguest, new task ran with SUSEConnect, after the playbook LTSS is activated.

Used: https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_loops.html#iterating-over-a-list-of-hashes (added a label as proposed in https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_loops.html#limiting-loop-output-with-label, not sure if we need it in our case)

- Related ticket: https://jira.suse.com/browse/TEAM-9808