### PR TITLE
WIP: Fix azure sbd stonith-timeout

### DIFF
--- a/ansible/playbooks/tasks/azure-cluster-hana.yaml
+++ b/ansible/playbooks/tasks/azure-cluster-hana.yaml
@@ -39,7 +39,7 @@
       InstanceNumber="{{ sap_hana_install_instance_number }}"
   when: hana_topology_resource | length == 0
 
-- name: Set stonith-timeout [sdb]
+- name: Set stonith-timeout [sbd]
   ansible.builtin.command:
     cmd: crm configure property stonith-timeout=144
   when:
@@ -51,12 +51,19 @@
     cmd: crm configure property stonith-timeout=900
   when:
     - stonith_timeout | length == 0
-    - use_sbd | bool
+    - not use_sbd | bool
 
 - name: Enable stonith
   ansible.builtin.command:
     cmd: crm configure property stonith-enabled=true
   when: stonith_enabled != 'true'
+
+  # see https://learn.microsoft.com/en-us/azure/sap/workloads/high-availability-guide-suse-pacemaker?tabs=msi#create-a-fencing-device-on-the-pacemaker-cluster
+- name: Enable concurrent fencing (native fencing)
+  ansible.builtin.command:
+    cmd: crm configure property concurrent-fencing=true
+  when:
+    - not use_sbd | bool
 
 - name: Create HANA topology clone
   ansible.builtin.command:


### PR DESCRIPTION
As discovered by @jankohoutek , stonith-timeout was set erroneously for both azure sbd and native fencing cases. This pr attempts to fix that.

**Verification Runs:**
SBD: 
https://openqa.suse.de/tests/15879961 PASS
https://openqa.suse.de/tests/15882210 PASS
https://openqa.suse.de/tests/15882212 PASS
https://openqa.suse.de/tests/15882213 PASS

MSI:  
https://openqa.suse.de/tests/15879960 PASS
https://openqa.suse.de/tests/15882208 PASS
https://openqa.suse.de/tests/15882209 FAIL (crash site A)
https://openqa.suse.de/tests/15882211 PASS

SPN:
https://openqa.suse.de/tests/15882224 FAIL (crash site A)
https://openqa.suse.de/tests/15882225 PASS
https://openqa.suse.de/tests/15882226 FAIL (kill site A - primary)
https://openqa.suse.de/tests/15892130 PASS

**VRs for the concurrent fencing:**

- PASS (23):
https://openqa.suse.de/tests/15893608
https://openqa.suse.de/tests/15893612 (failed for irrelevant reason at the end)
https://openqa.suse.de/tests/15893618
https://openqa.suse.de/tests/15894470
https://openqa.suse.de/tests/15894472
https://openqa.suse.de/tests/15894494
https://openqa.suse.de/tests/15894495
https://openqa.suse.de/tests/15894496
https://openqa.suse.de/tests/15894765
https://openqa.suse.de/tests/15894834
https://openqa.suse.de/tests/15894768
https://openqa.suse.de/tests/15894770
https://openqa.suse.de/tests/15894771
https://openqa.suse.de/tests/15894772
https://openqa.suse.de/tests/15894767
https://openqa.suse.de/tests/15895221
https://openqa.suse.de/tests/15895222
https://openqa.suse.de/tests/15895479
https://openqa.suse.de/tests/15895480
https://openqa.suse.de/tests/15895481
https://openqa.suse.de/tests/15895483
https://openqa.suse.de/tests/15898297
https://openqa.suse.de/tests/15898327
https://openqa.suse.de/tests/15898791
https://openqa.suse.de/tests/15898792
https://openqa.suse.de/tests/15898793

- FAIL (1) at `crash_replica` due to ssh issues:
https://openqa.suse.de/tests/15895479
