### PR TITLE
Remove gcp_credentials_file variable at module level

### DIFF
--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -138,23 +138,22 @@ module "common_variables" {
 }
 
 module "drbd_node" {
-  source               = "./modules/drbd_node"
-  common_variables     = module.common_variables.configuration
-  name                 = var.drbd_name
-  network_domain       = var.drbd_network_domain == "" ? var.network_domain : var.drbd_network_domain
-  drbd_count           = var.drbd_enabled == true ? 2 : 0
-  vm_size              = var.drbd_machine_type
-  compute_zones        = local.compute_zones
-  network_name         = local.vpc_name
-  network_subnet_name  = local.subnet_name
-  os_image             = local.drbd_os_image
-  drbd_data_disk_size  = var.drbd_data_disk_size
-  drbd_data_disk_type  = var.drbd_data_disk_type
-  gcp_credentials_file = var.gcp_credentials_file
-  host_ips             = local.drbd_ips
-  iscsi_srv_ip         = module.iscsi_server.iscsisrv_ip
-  nfs_mounting_point   = var.drbd_nfs_mounting_point
-  nfs_export_name      = var.netweaver_sid
+  source              = "./modules/drbd_node"
+  common_variables    = module.common_variables.configuration
+  name                = var.drbd_name
+  network_domain      = var.drbd_network_domain == "" ? var.network_domain : var.drbd_network_domain
+  drbd_count          = var.drbd_enabled == true ? 2 : 0
+  vm_size             = var.drbd_machine_type
+  compute_zones       = local.compute_zones
+  network_name        = local.vpc_name
+  network_subnet_name = local.subnet_name
+  os_image            = local.drbd_os_image
+  drbd_data_disk_size = var.drbd_data_disk_size
+  drbd_data_disk_type = var.drbd_data_disk_type
+  host_ips            = local.drbd_ips
+  iscsi_srv_ip        = module.iscsi_server.iscsisrv_ip
+  nfs_mounting_point  = var.drbd_nfs_mounting_point
+  nfs_export_name     = var.netweaver_sid
 }
 
 module "netweaver_node" {
@@ -169,7 +168,6 @@ module "netweaver_node" {
   network_name              = local.vpc_name
   network_subnet_name       = local.subnet_name
   os_image                  = local.netweaver_os_image
-  gcp_credentials_file      = var.gcp_credentials_file
   host_ips                  = local.netweaver_ips
   iscsi_srv_ip              = module.iscsi_server.iscsisrv_ip
   netweaver_software_bucket = var.netweaver_software_bucket
@@ -187,7 +185,6 @@ module "hana_node" {
   network_name          = local.vpc_name
   network_subnet_name   = local.subnet_name
   os_image              = local.hana_os_image
-  gcp_credentials_file  = var.gcp_credentials_file
   host_ips              = local.hana_ips
   iscsi_srv_ip          = module.iscsi_server.iscsisrv_ip
   hana_data_disk_type   = var.hana_data_disk_type

--- a/terraform/gcp/modules/drbd_node/variables.tf
+++ b/terraform/gcp/modules/drbd_node/variables.tf
@@ -56,11 +56,6 @@ variable "drbd_data_disk_type" {
   default     = "pd-standard"
 }
 
-variable "gcp_credentials_file" {
-  description = "Path to your local gcp credentials file"
-  type        = string
-}
-
 variable "host_ips" {
   description = "ip addresses to set to the nodes"
   type        = list(string)

--- a/terraform/gcp/modules/hana_node/variables.tf
+++ b/terraform/gcp/modules/hana_node/variables.tf
@@ -43,11 +43,6 @@ variable "network_domain" {
   type        = string
 }
 
-variable "gcp_credentials_file" {
-  description = "Path to your local gcp credentials file"
-  type        = string
-}
-
 variable "host_ips" {
   description = "ip addresses to set to the nodes"
   type        = list(string)

--- a/terraform/gcp/modules/netweaver_node/variables.tf
+++ b/terraform/gcp/modules/netweaver_node/variables.tf
@@ -47,11 +47,6 @@ variable "network_domain" {
   type        = string
 }
 
-variable "gcp_credentials_file" {
-  description = "Path to your local gcp credentials file"
-  type        = string
-}
-
 variable "host_ips" {
   description = "ip addresses to set to the nodes"
   type        = list(string)


### PR DESCRIPTION
Remove gcp_credentials_file  setting at module level as it is not needed there. This setting and the credential file is only needed in a single place when defining the provider: https://github.com/SUSE/qe-sap-deployment/blob/a752147a6b3b25c2376696908b713872c6accf94/terraform/gcp/version.tf#L17


Verification:
- sle-15-SP5-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE15_5_PAYG-qesap_gcp_sapconf_test@64bit -> http://openqaworker15.qa.suse.cz/tests/302602 :green_circle: 