### PR TITLE
WIP: Add alternative authenticated module task

### DIFF
--- a/ansible/playbooks/registration.yaml
+++ b/ansible/playbooks/registration.yaml
@@ -31,15 +31,11 @@
     # Is registercloudguest available?
     # only run it if:
     #  - there's at least one 'Not Registered' module
-    #  - the user does not require only use SUSEConnect with `use_suseconnect`
     - name: Check for registercloudguest
       ansible.builtin.command: which registercloudguest
       register: is_registercloudguest_bin
       failed_when: false
       changed_when: false
-      when:
-        - not_registered_found
-        - not use_suseconnect | bool
 
     # Execute Section
 
@@ -123,7 +119,7 @@
       when:
         - sles_modules is defined and sles_modules | length > 0
 
-    - name: Add additional authenticated modules
+    - name: Add additional authenticated modules [SUSEConnnect]
       ansible.builtin.command: SUSEConnect -p {{ item.key }} -r {{ item.value }}
       register: result
       until: result is succeeded
@@ -131,6 +127,21 @@
       delay: 60
       when:
         - sles_modules is defined and sles_modules | length > 0
+        - "(is_registercloudguest_bin.rc != 0) or (use_suseconnect | bool)"
+      loop: "{{ sles_modules }}"
+      loop_control:
+        label: "{{ item.key }}"
+
+    - name: Add additional authenticated modules [registercloudguest]
+      ansible.builtin.command: registercloudguest -r {{ item.value }}
+      register: result
+      until: result is succeeded
+      retries: 10
+      delay: 60
+      when:
+        - sles_modules is defined and sles_modules | length > 0
+        - is_registercloudguest_bin.rc == 0
+        - not use_suseconnect | bool
       loop: "{{ sles_modules }}"
       loop_control:
         label: "{{ item.key }}"


### PR DESCRIPTION
Adds a task to register additional authenticated modules with registercloudguest instead of SUSEConnect.

- Related ticket: https://jira.suse.com/browse/TEAM-9808
# Verification Runs

## BYOS
BYOS without LTSS
sle-12-SP5-HanaSr-Azure-Byos-x86_64-Build12-SP5_2024-11-12T03:03:21Z-hanasr_azure_test_sbd az_Standard_E4s_v3
- http://openqaworker15.qa.suse.cz/tests/302982

BYOS **with ltss** and so test code should enable use_suseconnect
sle-12-SP5-HanaSr-Azure-Byos-x86_64-Build12-SP5_2024-11-12T03:03:21Z-hanasr_azure_test_sbd az_Standard_E4s_v3
-  http://openqaworker15.qa.suse.cz/tests/302981

## PAYG
Has BYOS in the openQA name but it is PAYG, without ltss

sle-12-SP5-HanaSr-Azure-Byos-x86_64-Build12-SP5_2024-11-12T03:03:21Z-hanasr_azure_test_sbd az_Standard_E4s_v3
- http://openqaworker15.qa.suse.cz/tests/302983

**with ltss**
sle-12-SP5-HanaSr-Azure-Byos-x86_64-Build12-SP5_2024-11-12T03:03:21Z-hanasr_azure_test_sbd az_Standard_E4s_v3
- http://openqaworker15.qa.suse.cz/tests/302984