### PR TITLE
If registration is needed check that reg_code is provided

### DIFF
--- a/ansible/playbooks/registration.yaml
+++ b/ansible/playbooks/registration.yaml
@@ -38,6 +38,17 @@
       changed_when: false
 
     # Execute Section
+    - name: Validate reg code
+      ansible.builtin.assert:
+        that:
+          - reg_code | length > 0
+        fail_msg: "'reg_code' must not be empty"
+        success_msg: "'reg_code' is OK"
+      changed_when: false
+      when:
+        - not_registered_found
+        - is_registercloudguest_bin.rc == 0
+        - not use_suseconnect | bool
 
     # Start by pre-cleaning all. Only run it if:
     #  - the registercloudguest binary is available
@@ -45,6 +56,8 @@
     #  - the user does not require only use SUSEConnect with 'use_suseconnect'
     - name: Pre-run cleaning registercloudguest
       ansible.builtin.command: registercloudguest --clean
+      register: cleanout
+      changed_when: cleanout.rc == 0
       when:
         - not_registered_found
         - is_registercloudguest_bin.rc == 0


### PR DESCRIPTION
Related ticket: https://jira.suse.com/browse/TEAM-9867

# Verification
sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_saptune_test_msi
- http://openqaworker15.qa.suse.cz/tests/304508 :green_circle: fails as properly detect reg_code is missing

sle-15-SP6-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_6_BYOS-qesap_azure_saptune_test
- http://openqaworker15.qa.suse.cz/tests/304510