### PR TITLE
Add GCP peering to terraform

### DIFF
--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -775,3 +775,29 @@ variable "iscsi_remote_python" {
   default     = "/usr/bin/python3"
 }
 
+# Peering related variables
+
+variable "enable_ibsm_peering" {
+  description = "Enable netwrk peering between hana vpc and ibsm vpc (0 to disable, 1 to enable)"
+  type        = number
+  default     = 0
+}
+
+variable "ibsm_vpc_name" {
+  description = "Name of the ibsm VPC network"
+  type        = string
+  default     = ""
+}
+
+variable "ibsm_subnet_name" {
+  description = "Name of the ibsm subnet"
+  type        = string
+  default     = ""
+}
+
+variable "ibsm_subnet_region" {
+  description = "Region of the ibsm subnet"
+  type        = string
+  default     = ""
+}
+


### PR DESCRIPTION
This pr **conditionally** adds peering with IBSM to GCP innside terraform, during resource creation. Nothing else will need to be done for the creation or the destruction of the peering (it will be managed exclusively by terraform). If the control variable `` doesn't exist, it defaults to false, and the deployment continues as before without creating the peering or related resources.

To make use of this and create a deployment with IBSM Peering, user (or openqa) needs to provide the following variables in config.yaml:

```
enable_ibsm_peering: 'true'
ibsm_vpc_name: '<gcp mirror vpc name>'
ibsm_subnet_name: '<gcp mirror subnet name>'
ibsm_subnet_region: '<gcp mirror region>'

```

And that's it. By providing those 4 variables, the hana nodes will be created peered with gcp IBSM, and the peering and related resources will be automaticlly destroyed when terraform destroy is called.

- Verification Run:
https://openqaworker15.qa.suse.cz/tests/305879 (this is without any of the new variables set - so no peering or associated resources are created, and test runs like before)