### PR TITLE
Remove not used terraform variables about registration

### DIFF
--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -168,6 +168,7 @@ Internally to the subnet, all traffic is allowed.
 
 By default, this configuration creates 3 instances in AWS: one for support services (mainly iSCSI as most other services - DHCP, NTP, etc - are provided by Amazon) and 2 cluster nodes, but this can be changed to deploy more cluster nodes as needed.
 
+Once the infrastructure is created by Terraform, the servers can be provisioned with Ansible.
 
 ## Customization
 

--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -168,7 +168,6 @@ Internally to the subnet, all traffic is allowed.
 
 By default, this configuration creates 3 instances in AWS: one for support services (mainly iSCSI as most other services - DHCP, NTP, etc - are provided by Amazon) and 2 cluster nodes, but this can be changed to deploy more cluster nodes as needed.
 
-Once the infrastructure is created by Terraform, the servers are provisioned with Ansible.
 
 ## Customization
 

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -63,19 +63,12 @@ module "common_variables" {
   provider_type                       = "aws"
   deployment_name                     = local.deployment_name
   deployment_name_in_hostname         = var.deployment_name_in_hostname
-  reg_code                            = var.reg_code
-  reg_email                           = var.reg_email
-  reg_additional_modules              = var.reg_additional_modules
-  additional_packages                 = var.additional_packages
   public_key                          = var.public_key
   authorized_keys                     = var.authorized_keys
   authorized_user                     = var.admin_user
   monitoring_enabled                  = var.monitoring_enabled
   monitoring_srv_ip                   = var.monitoring_enabled ? local.monitoring_ip : ""
-  hana_hwcct                          = var.hwcct
-  hana_sid                            = var.hana_sid
   hana_instance_number                = var.hana_instance_number
-  hana_cost_optimized_sid             = var.hana_cost_optimized_sid
   hana_cost_optimized_instance_number = var.hana_cost_optimized_instance_number
   hana_primary_site                   = var.hana_primary_site
   hana_secondary_site                 = var.hana_secondary_site
@@ -104,7 +97,6 @@ module "common_variables" {
   netweaver_nfs_share                 = var.drbd_enabled ? "${local.drbd_cluster_vip}:/${var.netweaver_sid}" : var.netweaver_nfs_share
   netweaver_sapmnt_path               = var.netweaver_sapmnt_path
   netweaver_hana_ip                   = var.hana_ha_enabled ? local.hana_cluster_vip : element(local.hana_ips, 0)
-  netweaver_hana_sid                  = var.hana_sid
   netweaver_hana_instance_number      = var.hana_instance_number
   netweaver_ha_enabled                = var.netweaver_ha_enabled
   netweaver_cluster_vip_mechanism     = "route"
@@ -150,24 +142,6 @@ module "drbd_node" {
   iscsi_srv_ip          = join("", module.iscsi_server.iscsisrv_ip)
   nfs_mounting_point    = var.drbd_nfs_mounting_point
   nfs_export_name       = var.netweaver_sid
-}
-
-module "iscsi_server" {
-  source             = "./modules/iscsi_server"
-  common_variables   = module.common_variables.configuration
-  name               = var.iscsi_name
-  network_domain     = var.iscsi_network_domain == "" ? var.network_domain : var.iscsi_network_domain
-  iscsi_count        = local.iscsi_enabled == true ? var.iscsi_count : 0
-  availability_zones = data.aws_availability_zones.available.names
-  subnet_ids         = aws_subnet.infra-subnet.*.id
-  os_image           = local.iscsi_os_image
-  os_owner           = local.iscsi_os_owner
-  vm_size            = var.iscsi_instancetype
-  key_name           = aws_key_pair.key-pair.key_name
-  security_group_id  = local.security_group_id
-  host_ips           = local.iscsi_ips
-  lun_count          = var.iscsi_lun_count
-  iscsi_disk_size    = var.iscsi_disk_size
 }
 
 module "netweaver_node" {
@@ -236,3 +210,22 @@ module "monitoring" {
   subnet_ids         = aws_subnet.infra-subnet.*.id
   timezone           = var.timezone
 }
+
+module "iscsi_server" {
+  source             = "./modules/iscsi_server"
+  common_variables   = module.common_variables.configuration
+  name               = var.iscsi_name
+  network_domain     = var.iscsi_network_domain == "" ? var.network_domain : var.iscsi_network_domain
+  iscsi_count        = local.iscsi_enabled == true ? var.iscsi_count : 0
+  availability_zones = data.aws_availability_zones.available.names
+  subnet_ids         = aws_subnet.infra-subnet.*.id
+  os_image           = local.iscsi_os_image
+  os_owner           = local.iscsi_os_owner
+  vm_size            = var.iscsi_instancetype
+  key_name           = aws_key_pair.key-pair.key_name
+  security_group_id  = local.security_group_id
+  host_ips           = local.iscsi_ips
+  lun_count          = var.iscsi_lun_count
+  iscsi_disk_size    = var.iscsi_disk_size
+}
+

--- a/terraform/aws/modules/hana_node/variables.tf
+++ b/terraform/aws/modules/hana_node/variables.tf
@@ -148,8 +148,3 @@ variable "iscsi_srv_ip" {
   description = "iscsi server address"
   type        = string
 }
-
-variable "reg_code" {
-  description = "If informed, register the product using SUSEConnect"
-  default     = ""
-}

--- a/terraform/aws/terraform.tfvars.example
+++ b/terraform/aws/terraform.tfvars.example
@@ -39,18 +39,6 @@ deployment_name = "mydeployment"
 # aws-cli credentials file. Located on ~/.aws/credentials on Linux, MacOS or Unix or at C:\Users\USERNAME\.aws\credentials on Windows
 #aws_credentials = "~/.aws/credentials"
 
-# Supply SCC registration code to register BYOS images to SCC. Keep it commented if using PAYG images or if registration of BYOS
-# images is not required
-#reg_code = "<<REG_CODE>>"
-#reg_email = "<<your email>>"
-
-# To add additional modules from SCC. None of them is needed by default
-#reg_additional_modules = {
-#    "sle-module-adv-systems-management/12/x86_64" = ""
-#    "sle-module-containers/12/x86_64" = ""
-#    "sle-ha-geo/12.4/x86_64" = "<<REG_CODE>>"
-#}
-
 # Default os_image and os_owner. These values are not used if the specific values are set (e.g.: hana_os_image)
 # BYOS example with sles4sap 15 sp3 (this value is a pattern, it will select the latest version that matches this name)
 #os_image = "suse-sles-sap-15-sp3-byos"
@@ -83,10 +71,6 @@ public_key  = "/home/myuser/.ssh/id_rsa.pub"
 # Disable all extra packages that do not come from the image
 # true or false (default)
 #offline_mode = false
-
-# Execute HANA Hardware Configuration Check Tool to bench filesystems
-# true or false (default)
-#hwcct = false
 
 #########################
 # HANA machines variables
@@ -146,7 +130,6 @@ hana_count = "2"
 # Find some references about the variables in:
 # https://help.sap.com
 # HANA instance system identifier. The system identifier must be composed by 3 uppercase chars/digits string starting always with a character (there are some restricted options).
-#hana_sid = "PRD"
 # HANA instance number. It's composed of 2 integers string
 #hana_instance_number = "00"
 # HANA primary site name. Only used if HANA's system replication feature is enabled (hana_ha_enabled to true)

--- a/terraform/aws/terraform.tfvars.example
+++ b/terraform/aws/terraform.tfvars.example
@@ -129,7 +129,6 @@ hana_count = "2"
 # HANA instance configuration
 # Find some references about the variables in:
 # https://help.sap.com
-# HANA instance system identifier. The system identifier must be composed by 3 uppercase chars/digits string starting always with a character (there are some restricted options).
 # HANA instance number. It's composed of 2 integers string
 #hana_instance_number = "00"
 # HANA primary site name. Only used if HANA's system replication feature is enabled (hana_ha_enabled to true)

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -83,7 +83,6 @@ variable "admin_user" {
 }
 
 # Deployment variables
-
 variable "deployment_name" {
   description = "Suffix string added to some of the infrastructure resources names. If it is not provided, the terraform workspace string is used as suffix"
   type        = string
@@ -122,37 +121,6 @@ variable "os_owner" {
 variable "timezone" {
   description = "Timezone setting for all VMs"
   default     = "Europe/Berlin"
-}
-
-variable "reg_code" {
-  description = "If informed, register the product using SUSEConnect"
-  type        = string
-  default     = ""
-}
-
-variable "reg_email" {
-  description = "Email used for the registration"
-  default     = ""
-}
-
-# The module format must follow SUSEConnect convention:
-# <module_name>/<product_version>/<architecture>
-# Example: Suggested modules for SLES for SAP 15
-# - sle-module-basesystem/15/x86_64
-# - sle-module-desktop-applications/15/x86_64
-# - sle-module-server-applications/15/x86_64
-# - sle-ha/15/x86_64 (Need the same regcode as SLES for SAP)
-# - sle-module-sap-applications/15/x86_64
-
-variable "reg_additional_modules" {
-  description = "Map of the modules to be registered. Module name = Regcode, when needed."
-  type        = map(string)
-  default     = {}
-}
-
-variable "additional_packages" {
-  description = "Extra packages to be installed"
-  default     = []
 }
 
 # Hana related variables
@@ -226,18 +194,6 @@ variable "hana_fstype" {
   description = "Filesystem type used by the disk where HANA is installed"
   type        = string
   default     = "xfs"
-}
-
-variable "hana_sid" {
-  description = "System identifier of the HANA system. It must be a 3 characters string (check the restrictions in the SAP documentation pages). Examples: PRD, HA1"
-  type        = string
-  default     = "PRD"
-}
-
-variable "hana_cost_optimized_sid" {
-  description = "System identifier of the HANA cost-optimized system. It must be a 3 characters string (check the restrictions in the SAP documentation pages). Examples: PRD, HA1"
-  type        = string
-  default     = "QAS"
 }
 
 variable "hana_instance_number" {
@@ -775,13 +731,8 @@ variable "netweaver_shared_storage_type" {
 
 # Testing and QA variables
 
-# Execute HANA Hardware Configuration Check Tool to bench filesystems.
+# TODO: Execute HANA Hardware Configuration Check Tool to bench filesystems.
 # The test takes several hours. See results in /root/hwcct_out
-variable "hwcct" {
-  description = "Execute HANA Hardware Configuration Check Tool to bench filesystems"
-  type        = bool
-  default     = false
-}
 
 variable "hana_remote_python" {
   description = "Remote python interpreter that Ansible will use on HANA nodes"

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -64,19 +64,13 @@ module "common_variables" {
   provider_type                       = "azure"
   deployment_name                     = local.deployment_name
   deployment_name_in_hostname         = var.deployment_name_in_hostname
-  reg_code                            = var.reg_code
-  reg_email                           = var.reg_email
-  reg_additional_modules              = var.reg_additional_modules
-  additional_packages                 = var.additional_packages
   public_key                          = var.public_key
   authorized_keys                     = var.authorized_keys
   authorized_user                     = var.admin_user
   monitoring_enabled                  = var.monitoring_enabled
   monitoring_srv_ip                   = var.monitoring_enabled ? local.monitoring_ip : ""
   hana_hwcct                          = var.hwcct
-  hana_sid                            = var.hana_sid
   hana_instance_number                = var.hana_instance_number
-  hana_cost_optimized_sid             = var.hana_cost_optimized_sid
   hana_cost_optimized_instance_number = var.hana_cost_optimized_instance_number
   hana_primary_site                   = var.hana_primary_site
   hana_secondary_site                 = var.hana_secondary_site
@@ -105,7 +99,6 @@ module "common_variables" {
   netweaver_nfs_share                 = var.drbd_enabled ? "${local.drbd_cluster_vip}:/${var.netweaver_sid}" : var.netweaver_nfs_share
   netweaver_sapmnt_path               = var.netweaver_sapmnt_path
   netweaver_hana_ip                   = var.hana_ha_enabled ? local.hana_cluster_vip : element(local.hana_ips, 0)
-  netweaver_hana_sid                  = var.hana_sid
   netweaver_hana_instance_number      = var.hana_instance_number
   netweaver_ha_enabled                = var.netweaver_ha_enabled
   netweaver_cluster_vip_mechanism     = "load-balancer"

--- a/terraform/azure/terraform.tfvars.example
+++ b/terraform/azure/terraform.tfvars.example
@@ -186,8 +186,6 @@ hana_count = "2"
 # HANA instance configuration
 # Find some references about the variables in:
 # https://help.sap.com
-# HANA instance system identifier. The system identifier must be composed by 3 uppercase chars/digits string starting always with a character (there are some restricted options).
-#hana_sid = "PRD"
 # HANA instance number. It's composed of 2 integers string
 #hana_instance_number = "00"
 

--- a/terraform/azure/terraform.tfvars.example
+++ b/terraform/azure/terraform.tfvars.example
@@ -25,18 +25,6 @@ subnet_address_range = "10.10.1.0/24"
 # The name must be unique among different deployments
 deployment_name = "mydeployment"
 
-# If BYOS images are used in the deployment, SCC registration code is required. Set `reg_code` and `reg_email` variables below
-# By default, all the images are PAYG, so these next parameters are not needed
-#reg_code = "<<REG_CODE>>"
-#reg_email = "<<your email>>"
-
-# To add additional modules from SCC. None of them is needed by default
-#reg_additional_modules = {
-#    "sle-module-adv-systems-management/12/x86_64" = ""
-#    "sle-module-containers/12/x86_64" = ""
-#    "sle-ha-geo/12.4/x86_64" = "<<REG_CODE>>"
-#}
-
 # Default os_image. This value is not used if the specific values are set (e.g.: hana_os_image)
 # Run the next command to get the possible options and use the 4th column value (version can be changed by `latest`)
 # az vm image list --output table --publisher SUSE --all

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -131,37 +131,6 @@ variable "timezone" {
   default     = "Europe/Berlin"
 }
 
-variable "reg_code" {
-  description = "If informed, register the product using SUSEConnect"
-  type        = string
-  default     = ""
-}
-
-variable "reg_email" {
-  description = "Email used for the registration"
-  default     = ""
-}
-
-# The module format must follow SUSEConnect convention:
-# <module_name>/<product_version>/<architecture>
-# Example: Suggested modules for SLES for SAP 15
-# - sle-module-basesystem/15/x86_64
-# - sle-module-desktop-applications/15/x86_64
-# - sle-module-server-applications/15/x86_64
-# - sle-ha/15/x86_64 (Need the same regcode as SLES for SAP)
-# - sle-module-sap-applications/15/x86_64
-
-variable "reg_additional_modules" {
-  description = "Map of the modules to be registered. Module name = Regcode, when needed."
-  type        = map(string)
-  default     = {}
-}
-
-variable "additional_packages" {
-  description = "Extra packages to be installed"
-  default     = []
-}
-
 # Hana related variables
 variable "hana_name" {
   description = "hostname, without the domain part"
@@ -279,18 +248,6 @@ variable "hana_fstype" {
   description = "Filesystem type used by the disk where HANA is installed"
   type        = string
   default     = "xfs"
-}
-
-variable "hana_sid" {
-  description = "System identifier of the HANA system. It must be a 3 characters string (check the restrictions in the SAP documentation pages). Examples: PRD, HA1"
-  type        = string
-  default     = "PRD"
-}
-
-variable "hana_cost_optimized_sid" {
-  description = "System identifier of the HANA cost-optimized system. It must be a 3 characters string (check the restrictions in the SAP documentation pages). Examples: PRD, HA1"
-  type        = string
-  default     = "QAS"
 }
 
 variable "hana_instance_number" {

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -73,10 +73,6 @@ module "common_variables" {
   region                      = var.region
   deployment_name             = local.deployment_name
   deployment_name_in_hostname = var.deployment_name_in_hostname
-  reg_code                    = var.reg_code
-  reg_email                   = var.reg_email
-  reg_additional_modules      = var.reg_additional_modules
-  additional_packages         = var.additional_packages
   public_key                  = var.public_key
   authorized_keys             = var.authorized_keys
   authorized_user             = var.admin_user
@@ -84,9 +80,7 @@ module "common_variables" {
   monitoring_enabled                  = var.monitoring_enabled
   monitoring_srv_ip                   = var.monitoring_enabled ? local.monitoring_srv_ip : ""
   hana_hwcct                          = var.hwcct
-  hana_sid                            = var.hana_sid
   hana_instance_number                = var.hana_instance_number
-  hana_cost_optimized_sid             = var.hana_cost_optimized_sid
   hana_cost_optimized_instance_number = var.hana_cost_optimized_instance_number
   hana_primary_site                   = var.hana_primary_site
   hana_secondary_site                 = var.hana_secondary_site
@@ -115,7 +109,6 @@ module "common_variables" {
   netweaver_nfs_share                 = var.drbd_enabled ? "${local.drbd_cluster_vip}:/${var.netweaver_sid}" : var.netweaver_nfs_share
   netweaver_sapmnt_path               = var.netweaver_sapmnt_path
   netweaver_hana_ip                   = var.hana_ha_enabled ? local.hana_cluster_vip : element(local.hana_ips, 0)
-  netweaver_hana_sid                  = var.hana_sid
   netweaver_hana_instance_number      = var.hana_instance_number
   netweaver_ha_enabled                = var.netweaver_ha_enabled
   netweaver_cluster_vip_mechanism     = var.netweaver_cluster_vip_mechanism

--- a/terraform/gcp/terraform.tfvars.example
+++ b/terraform/gcp/terraform.tfvars.example
@@ -142,7 +142,6 @@ machine_type = "n1-highmem-32"
 # HANA instance configuration
 # Find some references about the variables in:
 # https://help.sap.com
-# HANA instance system identifier. The system identifier must be composed by 3 uppercase chars/digits string starting always with a character (there are some restricted options).
 #hana_sid = "PRD"
 # HANA instance number. It's composed of 2 integers string
 #hana_instance_number = "00"

--- a/terraform/gcp/terraform.tfvars.example
+++ b/terraform/gcp/terraform.tfvars.example
@@ -38,18 +38,6 @@ deployment_name = "mydeployment"
 # Add the "deployment_name" as a prefix to the hostname.
 #deployment_name_in_hostname = true
 
-# If BYOS images are used in the deployment, SCC registration code is required. Set `reg_code` and `reg_email` variables below
-# By default, all the images are PAYG, so these next parameters are not needed
-#reg_code = "<<REG_CODE>>"
-#reg_email = "<<your email>>"
-
-# To add additional modules from SCC. None of them is needed by default
-#reg_additional_modules = {
-#    "sle-module-adv-systems-management/12/x86_64" = ""
-#    "sle-module-containers/12/x86_64" = ""
-#    "sle-ha-geo/12.4/x86_64" = "<<REG_CODE>>"
-#}
-
 # Default os_image. This value is not used if the specific values are set (e.g.: hana_os_image)
 # If `gcloud` utility is available in your local machine, the next command shows some of the available options
 # gcloud compute images list --standard-images --filter=sles

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -103,37 +103,6 @@ variable "timezone" {
   default     = "Europe/Berlin"
 }
 
-variable "reg_code" {
-  description = "If informed, register the product using SUSEConnect"
-  type        = string
-  default     = ""
-}
-
-variable "reg_email" {
-  description = "Email used for the registration"
-  default     = ""
-}
-
-# The module format must follow SUSEConnect convention:
-# <module_name>/<product_version>/<architecture>
-# Example: Suggested modules for SLES for SAP 15
-# - sle-module-basesystem/15/x86_64
-# - sle-module-desktop-applications/15/x86_64
-# - sle-module-server-applications/15/x86_64
-# - sle-ha/15/x86_64 (Need the same regcode as SLES for SAP)
-# - sle-module-sap-applications/15/x86_64
-
-variable "reg_additional_modules" {
-  description = "Map of the modules to be registered. Module name = Regcode, when needed."
-  type        = map(string)
-  default     = {}
-}
-
-variable "additional_packages" {
-  description = "Extra packages to be installed"
-  default     = []
-}
-
 # Hana related variables
 variable "hana_name" {
   description = "hostname, without the domain part"
@@ -217,18 +186,6 @@ variable "hana_fstype" {
   description = "Filesystem type used by the disk where HANA is installed"
   type        = string
   default     = "xfs"
-}
-
-variable "hana_sid" {
-  description = "System identifier of the HANA system. It must be a 3 characters string (check the restrictions in the SAP documentation pages). Examples: PRD, HA1"
-  type        = string
-  default     = "PRD"
-}
-
-variable "hana_cost_optimized_sid" {
-  description = "System identifier of the HANA cost-optimized system. It must be a 3 characters string (check the restrictions in the SAP documentation pages). Examples: PRD, HA1"
-  type        = string
-  default     = "QAS"
 }
 
 variable "hana_instance_number" {

--- a/terraform/generic_modules/common_variables/hana_variables.tf
+++ b/terraform/generic_modules/common_variables/hana_variables.tf
@@ -1,25 +1,3 @@
-variable "hana_sid" {
-  description = "System identifier of the HANA system. It must be a 3 characters string (check the restrictions in the SAP documentation pages). Examples: prd, ha1"
-  type        = string
-  validation {
-    condition = (
-      can(regex("^[A-Z][A-Z0-9]{2}$", var.hana_sid))
-    )
-    error_message = "The HANA system identifier must be composed by 3 uppercase chars/digits string starting always with a character (there are some restricted options)."
-  }
-}
-
-variable "hana_cost_optimized_sid" {
-  description = "System identifier of the HANA cost-optimized system. It must be a 3 characters string (check the restrictions in the SAP documentation pages). Examples: prd, ha1"
-  type        = string
-  validation {
-    condition = (
-      can(regex("^[A-Z][A-Z0-9]{2}$", var.hana_cost_optimized_sid))
-    )
-    error_message = "The HANA system identifier must be composed by 3 uppercase chars/digits string starting always with a character (there are some restricted options)."
-  }
-}
-
 variable "hana_instance_number" {
   description = "Instance number of the HANA system. It must be a 2 digits string. Examples: 00, 01, 10"
   type        = string

--- a/terraform/generic_modules/common_variables/netweaver_variables.tf
+++ b/terraform/generic_modules/common_variables/netweaver_variables.tf
@@ -111,17 +111,6 @@ variable "netweaver_hana_ip" {
   type        = string
 }
 
-variable "netweaver_hana_sid" {
-  description = "System identifier of the HANA system (e.g.: HA1 or PRD)"
-  type        = string
-  validation {
-    condition = (
-      can(regex("^[A-Z][A-Z0-9]{2}$", var.netweaver_hana_sid))
-    )
-    error_message = "The HANA system identifier must be composed by 3 uppercase chars/digits string starting always with a character (there are some restricted options)."
-  }
-}
-
 variable "netweaver_hana_instance_number" {
   description = "Instance number of the HANA system. It must be a 2 digits string. Examples: 00, 01, 10"
   type        = string

--- a/terraform/generic_modules/common_variables/outputs.tf
+++ b/terraform/generic_modules/common_variables/outputs.tf
@@ -19,10 +19,6 @@ output "configuration" {
     region                      = var.region
     deployment_name             = var.deployment_name
     deployment_name_in_hostname = var.deployment_name_in_hostname
-    reg_code                    = var.reg_code
-    reg_email                   = var.reg_email
-    reg_additional_modules      = var.reg_additional_modules
-    additional_packages         = var.additional_packages
     public_key                  = local.public_key
     private_key                 = local.private_key
     authorized_keys             = var.authorized_keys
@@ -30,9 +26,7 @@ output "configuration" {
     monitoring_enabled          = var.monitoring_enabled
     monitoring_srv_ip           = var.monitoring_srv_ip
     hana = {
-      sid                            = var.hana_sid
       instance_number                = var.hana_instance_number
-      cost_optimized_sid             = var.hana_cost_optimized_sid
       cost_optimized_instance_number = var.hana_cost_optimized_instance_number
       primary_site                   = var.hana_primary_site
       secondary_site                 = var.hana_secondary_site
@@ -67,7 +61,6 @@ output "configuration" {
       nfs_share             = var.netweaver_nfs_share
       sapmnt_path           = var.netweaver_sapmnt_path
       hana_ip               = var.netweaver_hana_ip
-      hana_sid              = var.netweaver_hana_sid
       hana_instance_number  = var.netweaver_hana_instance_number
       hana_sr_enabled       = var.hana_ha_enabled
       shared_storage_type   = var.netweaver_shared_storage_type

--- a/terraform/generic_modules/common_variables/variables.tf
+++ b/terraform/generic_modules/common_variables/variables.tf
@@ -26,28 +26,6 @@ variable "deployment_name_in_hostname" {
   type        = bool
 }
 
-variable "reg_code" {
-  description = "If informed, register the product using SUSEConnect"
-  default     = ""
-}
-
-variable "reg_email" {
-  description = "Email used for the registration"
-  default     = ""
-}
-
-variable "reg_additional_modules" {
-  description = "Map of the modules to be registered. Module name = Regcode, when needed."
-  type        = map(string)
-  default     = {}
-}
-
-variable "additional_packages" {
-  description = "extra packages which should be installed"
-  type        = list(any)
-  default     = []
-}
-
 variable "public_key" {
   description = "Content of a SSH public key or path to an already existing SSH public key. The key is only used to provision the machines and it is authorized for future accesses"
   type        = string

--- a/terraform/libvirt/main.tf
+++ b/terraform/libvirt/main.tf
@@ -62,18 +62,12 @@ module "common_variables" {
   provider_type                       = "libvirt"
   deployment_name                     = local.deployment_name
   deployment_name_in_hostname         = var.deployment_name_in_hostname
-  reg_code                            = var.reg_code
-  reg_email                           = var.reg_email
-  reg_additional_modules              = var.reg_additional_modules
-  additional_packages                 = var.additional_packages
   authorized_keys                     = var.authorized_keys
   authorized_user                     = "root"
   monitoring_enabled                  = var.monitoring_enabled
   monitoring_srv_ip                   = var.monitoring_enabled ? local.monitoring_srv_ip : ""
   hana_hwcct                          = var.hwcct
-  hana_sid                            = var.hana_sid
   hana_instance_number                = var.hana_instance_number
-  hana_cost_optimized_sid             = var.hana_cost_optimized_sid
   hana_cost_optimized_instance_number = var.hana_cost_optimized_instance_number
   hana_primary_site                   = var.hana_primary_site
   hana_secondary_site                 = var.hana_secondary_site
@@ -102,7 +96,6 @@ module "common_variables" {
   netweaver_nfs_share                 = var.drbd_enabled ? "${local.drbd_cluster_vip}:/${var.netweaver_sid}" : var.netweaver_nfs_share
   netweaver_sapmnt_path               = var.netweaver_sapmnt_path
   netweaver_hana_ip                   = var.hana_ha_enabled ? local.hana_cluster_vip : element(local.hana_ips, 0)
-  netweaver_hana_sid                  = var.hana_sid
   netweaver_hana_instance_number      = var.hana_instance_number
   netweaver_ha_enabled                = var.netweaver_ha_enabled
   netweaver_cluster_vip_mechanism     = "vip-only"

--- a/terraform/libvirt/terraform.tfvars.example
+++ b/terraform/libvirt/terraform.tfvars.example
@@ -40,17 +40,6 @@ iprange = "192.168.XXX.Y/24"
 # Add the "deployment_name" as a prefix to the hostname.
 #deployment_name_in_hostname = true
 
-# SUSE Customer Center Registration parameters.
-#reg_code = "<<REG_CODE>>"
-#reg_email = "<<your email>>"
-
-# For any sle12 version the additional module sle-module-adv-systems-management/12/x86_64 is mandatory if reg_code is provided
-#reg_additional_modules = {
-#    "sle-module-adv-systems-management/12/x86_64" = ""
-#    "sle-module-containers/12/x86_64" = ""
-#    "sle-ha-geo/12.4/x86_64" = "<<REG_CODE>>"
-#}
-
 # Authorize additional keys optionally (in this case, the private key is not required)
 # Path to local files or keys content
 #authorized_keys = ["/home/myuser/.ssh/id_rsa_second_key.pub", "/home/myuser/.ssh/id_rsa_third_key.pub", "ssh-rsa AAAAB3NzaC1yc2EAAAA...."]

--- a/terraform/libvirt/terraform.tfvars.example
+++ b/terraform/libvirt/terraform.tfvars.example
@@ -103,7 +103,6 @@ iprange = "192.168.XXX.Y/24"
 # HANA instance configuration
 # Find some references about the variables in:
 # https://help.sap.com
-# HANA instance system identifier. The system identifier must be composed by 3 uppercase chars/digits string starting always with a character (there are some restricted options).
 #hana_sid = "PRD"
 # HANA instance number. It's composed of 2 integers string
 #hana_instance_number = "00"

--- a/terraform/libvirt/variables.tf
+++ b/terraform/libvirt/variables.tf
@@ -79,36 +79,6 @@ variable "network_domain" {
   default     = "tf.local"
 }
 
-variable "reg_code" {
-  description = "If informed, register the product using SUSEConnect"
-  default     = ""
-}
-
-variable "reg_email" {
-  description = "Email used for the registration"
-  default     = ""
-}
-
-# The module format must follow SUSEConnect convention:
-# <module_name>/<product_version>/<architecture>
-# Example: Suggested modules for SLES for SAP 15
-# - sle-module-basesystem/15/x86_64
-# - sle-module-desktop-applications/15/x86_64
-# - sle-module-server-applications/15/x86_64
-# - sle-ha/15/x86_64 (Need the same regcode as SLES for SAP)
-# - sle-module-sap-applications/15/x86_64
-variable "reg_additional_modules" {
-  description = "Map of the modules to be registered. Module name = Regcode, when needed."
-  type        = map(string)
-  default     = {}
-}
-
-variable "additional_packages" {
-  description = "extra packages which should be installed"
-  type        = list(any)
-  default     = []
-}
-
 #
 # Hana related variables
 

--- a/terraform/libvirt/variables.tf
+++ b/terraform/libvirt/variables.tf
@@ -178,18 +178,6 @@ variable "hana_ips" {
   }
 }
 
-variable "hana_sid" {
-  description = "System identifier of the HANA system. It must be a 3 characters string (check the restrictions in the SAP documentation pages). Examples: PRD, HA1"
-  type        = string
-  default     = "PRD"
-}
-
-variable "hana_cost_optimized_sid" {
-  description = "System identifier of the HANA cost-optimized system. It must be a 3 characters string (check the restrictions in the SAP documentation pages). Examples: PRD, HA1"
-  type        = string
-  default     = "QAS"
-}
-
 variable "hana_instance_number" {
   description = "Instance number of the HANA system. It must be a 2 digits string. Examples: 00, 01, 10"
   type        = string


### PR DESCRIPTION
Remove variables that are not used in terraform. All of them are about configurations now managed by Ansible, like registration and SID.


# Verification

## Azure
 - sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_saptune_test_msi -> http://openqaworker15.qa.suse.cz/tests/311551 :green_circle: 

## AWS
 - sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_fencing_native_test -> http://openqaworker15.qa.suse.cz/tests/311552 :green_circle: 

## GCP
 - sle-15-SP6-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE15_6_PAYG-qesap_gcp_sapconf_test -> http://openqaworker15.qa.suse.cz/tests/311550 :green_circle: 
