### PR TITLE
Replace depracated crm commands aws/gcp

### DIFF
--- a/ansible/playbooks/tasks/cluster-hana.yaml
+++ b/ansible/playbooks/tasks/cluster-hana.yaml
@@ -24,6 +24,19 @@
   when: is_primary
   changed_when: false
 
+- name: Gather package facts
+  ansible.builtin.package_facts:
+    manager: auto
+
+- name: Set variables for clone command and promoted term
+  set_fact:
+    clone_command: >-
+      {{ 'ms' if ansible_facts.packages['pacemaker'][0].version is version('2.1.9', '<')
+         else 'clone' }}
+    promoted_term: >-
+      {{ 'Master' if ansible_facts.packages['pacemaker'][0].version is version('2.1.9', '<')
+         else 'Promoted' }}
+
 - name: Ensure maintenance mode is active
   ansible.builtin.command:
     cmd: crm maintenance on
@@ -114,7 +127,7 @@
 - name: Create HANA resource clone
   ansible.builtin.command:
     cmd: >-
-      crm configure ms
+      crm configure {{ clone_command }}
       {{ ms_saphanactl }}
       {{ rsc_saphanactl }}
       meta
@@ -123,6 +136,7 @@
       clone-node-max="1"
       target-role="Started"
       interleave="true"
+      {% if clone_command == 'clone' %}promotable="true"{% endif %}
   when:
     - is_primary
     - hana_clone | length == 0
@@ -172,7 +186,7 @@
       col_saphana_ip_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
       2000:
       rsc_ip_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}:Started
-      {{ ms_saphanactl }}:Master
+      {{ ms_saphanactl }}:{{ promoted_term }}
   when:
     - is_primary
     - ip_colo | length == 0
@@ -185,7 +199,7 @@
       col_saphana_ip_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
       4000:
       rsc_ip_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}:Started
-      {{ ms_saphanactl }}:Master
+      {{ ms_saphanactl }}:{{ promoted_term }}
   when:
     - is_primary
     - ip_colo | length == 0


### PR DESCRIPTION
A followup and the aws/gcp equivalent of https://github.com/SUSE/qe-sap-deployment/pull/308

The warnings about the deprecated `ms` command and the Master/Slave attributes were there from previous versions, but in sp7 they became fatal. This pr is about replacing the deprecated commands with their proposed equivalents.

**- Verification runs:** 
http://openqaworker15.qa.suse.cz/tests/311557