### PR TITLE
AWS subnet split fixes

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -15,16 +15,14 @@ locals {
   iscsi_ip_start = 5
   iscsi_ips      = length(var.iscsi_ips) != 0 ? var.iscsi_ips : [for ip_index in range(local.iscsi_ip_start, var.iscsi_count + local.iscsi_ip_start) : cidrhost(local.infra_subnet_address_range, ip_index)]
 
-
-
   # The next locals are used to map the ip index with the subnet range (something like python enumerate method)
   hana_ip_start              = 10
-  hana_ips                   = length(var.hana_ips) != 0 ? var.hana_ips : [for index in range(var.hana_count) : cidrhost(element(local.hana_subnet_address_range, index % 2), index + local.hana_ip_start)]
+  hana_ips                   = length(var.hana_ips) != 0 ? var.hana_ips : [for ip_index in range(var.hana_count) : cidrhost(element(local.hana_subnet_address_range, ip_index), ip_index + local.hana_ip_start)]
   hana_cluster_vip           = var.hana_cluster_vip != "" ? var.hana_cluster_vip : cidrhost(var.virtual_address_range, local.hana_ip_start)
   hana_cluster_vip_secondary = var.hana_cluster_vip_secondary != "" ? var.hana_cluster_vip_secondary : cidrhost(var.virtual_address_range, local.hana_ip_start + 1)
 
   drbd_ip_start    = 20
-  drbd_ips         = length(var.drbd_ips) != 0 ? var.drbd_ips : [for index in range(2) : cidrhost(element(local.drbd_subnet_address_range, index % 2), index + local.drbd_ip_start)]
+  drbd_ips         = length(var.drbd_ips) != 0 ? var.drbd_ips : [for ip_index in range(2) : cidrhost(element(local.drbd_subnet_address_range, ip_index), ip_index + local.drbd_ip_start)]
   drbd_cluster_vip = var.drbd_cluster_vip != "" ? var.drbd_cluster_vip : cidrhost(var.virtual_address_range, local.drbd_ip_start)
 
   netweaver_xscs_server_count = var.netweaver_enabled ? (var.netweaver_ha_enabled ? 2 : 1) : 0
@@ -32,7 +30,7 @@ locals {
   netweaver_virtual_ips_count = var.netweaver_ha_enabled ? max(local.netweaver_count, 3) : max(local.netweaver_count, 2) # We need at least 2 virtual ips, if ASCS and PAS are in the same machine
 
   netweaver_ip_start    = 30
-  netweaver_ips         = length(var.netweaver_ips) != 0 ? var.netweaver_ips : [for index in range(local.netweaver_count) : cidrhost(element(local.netweaver_subnet_address_range, index % 2), index + local.netweaver_ip_start)]
+  netweaver_ips         = length(var.netweaver_ips) != 0 ? var.netweaver_ips : [for ip_index in range(local.netweaver_count) : cidrhost(element(local.netweaver_subnet_address_range, ip_index), ip_index + local.netweaver_ip_start)]
   netweaver_virtual_ips = length(var.netweaver_virtual_ips) != 0 ? var.netweaver_virtual_ips : [for ip_index in range(local.netweaver_ip_start, local.netweaver_ip_start + local.netweaver_virtual_ips_count) : cidrhost(var.virtual_address_range, ip_index)]
 
   # Check if iscsi server has to be created

--- a/terraform/aws/terraform.tfvars.example
+++ b/terraform/aws/terraform.tfvars.example
@@ -129,6 +129,7 @@ hana_count = "2"
 # HANA instance configuration
 # Find some references about the variables in:
 # https://help.sap.com
+
 # HANA instance number. It's composed of 2 integers string
 #hana_instance_number = "00"
 # HANA primary site name. Only used if HANA's system replication feature is enabled (hana_ha_enabled to true)

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -41,9 +41,9 @@ variable "vpc_address_range" {
   default     = "10.0.0.0/16"
   validation {
     condition = (
-      can(regex("^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$", var.vpc_address_range))
+      can(cidrnetmask(var.vpc_address_range))
     )
-    error_message = "Invalid IP range format. It must be something like: 102.168.10.5/24 ."
+    error_message = "Must be a valid IPv4 CIDR block address."
   }
 }
 
@@ -53,7 +53,7 @@ variable "virtual_address_range" {
   default     = "192.168.1.0/24"
   validation {
     condition = (
-      can(regex("^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$", var.virtual_address_range))
+      can(cidrnetmask(var.virtual_address_range))
     )
     error_message = "Invalid IP range format. It must be something like: 102.168.10.5/24 ."
   }


### PR DESCRIPTION
This PR does not change anything in qe-sap two typical use-cases:
- 1 HANA node for mr_test
- 2 HANA nodes for HanaSR

But is supposed to allow going beyond 2 hana nodes, and more in general reduce the code complexity, makes the code more similar to the Azure one, change variable validation from regexp to a dedicated CIDR validation function. 


# Verification

## HanaSR
 sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_fencing_native_test
 - http://openqaworker15.qa.suse.cz/tests/311576 :green_circle: from http://openqaworker15.qa.suse.cz/tests/311576/logfile?filename=deploy-terraform.plan.log.txt is like it was before.
```
 + resource "aws_subnet" "infra-subnet" {
      + cidr_block                                     = "10.0.0.0/24"

...

  # module.hana_node.aws_instance.hana[0] will be created
  + resource "aws_instance" "hana" {
      + private_ip                           = "10.0.1.10"

...

  # module.hana_node.aws_instance.hana[1] will be created
  + resource "aws_instance" "hana" {
      + private_ip                           = "10.0.2.11"

...

  # module.hana_node.aws_subnet.hana-subnet[0] will be created
  + resource "aws_subnet" "hana-subnet" {
      + cidr_block                                     = "10.0.1.0/24"
...

  # module.hana_node.aws_subnet.hana-subnet[1] will be created
  + resource "aws_subnet" "hana-subnet" {
      + cidr_block                                     = "10.0.2.0/24"
```
Job failure is later for timeout in `crm resource refresh msl_SAPHanaCtl_HQ0_HDB00`

 - http://openqaworker15.qa.suse.cz/tests/311635 :green_circle: 

## mr_test
sle-12-SP5-EC2-SAP-BYOS-Incidents-saptune-x86_64-Build:36967:kernel-ec2-sles4sap_gnome_saptune_delete_rename@ec2_r5b.metal -> http://openqaworker15.qa.suse.cz/tests/311636