### PR TITLE
Add comment for GCP firewall rules

### DIFF
--- a/terraform/gcp/infrastructure.tf
+++ b/terraform/gcp/infrastructure.tf
@@ -39,6 +39,8 @@ resource "google_compute_subnetwork" "ha_subnet" {
 }
 
 # Network firewall rules
+# All ports open for internal traffic, in line with what google suggests for cases like 
+# the load balancer and health checks. Outside traffic is only allowed through select ports.
 resource "google_compute_firewall" "ha_firewall_allow_internal" {
   name          = "${local.deployment_name}-fw-internal"
   network       = local.vpc_name


### PR DESCRIPTION
This pr adds a comment clarifying the logic behind the GCP firewall rules in our deployment.

- Related ticket: https://jira.suse.com/browse/TEAM-9879

* only comments added, so no VR