### PR TITLE
Harmonize variable name for cluster_ip across CSP

### DIFF
--- a/ansible/playbooks/tasks/aws-cluster-bootstrap.yaml
+++ b/ansible/playbooks/tasks/aws-cluster-bootstrap.yaml
@@ -341,7 +341,7 @@
       crm configure primitive
       rsc_ip_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
       ocf:suse:aws-vpc-move-ip params
-      ip={{ aws_cluster_ip }}
+      ip={{ cluster_ip }}
       routing_table={{ aws_route_table_id }}
       interface=eth0
       profile=default

--- a/ansible/playbooks/tasks/gcp-cluster-bootstrap.yaml
+++ b/ansible/playbooks/tasks/gcp-cluster-bootstrap.yaml
@@ -330,7 +330,7 @@
       crm configure primitive
       rsc_ip_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}
       IPaddr2
-      params ip={{ gcp_cluster_ip }}
+      params ip={{ cluster_ip }}
       cidr_netmask=32
       nic=eth0
       op monitor interval=3600s timeout=60s

--- a/terraform/aws/inventory.tmpl
+++ b/terraform/aws/inventory.tmpl
@@ -3,7 +3,7 @@ all:
     cloud_platform_name: aws
     use_sbd: ${use_sbd}
     aws_route_table_id: ${routetable_id}
-    aws_cluster_ip: ${virtual_ip}
+    cluster_ip: ${cluster_ip}
     aws_stonith_tag: ${stonith_tag}
     aws_region: ${region}
   children:

--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -107,7 +107,7 @@ resource "local_file" "ansible_inventory" {
       iscsi_remote_python = var.iscsi_remote_python,
       use_sbd             = local.use_sbd,
       routetable_id       = aws_route_table.route-table.id,
-      virtual_ip          = local.hana_cluster_vip,
+      cluster_ip          = local.hana_cluster_vip,
       stonith_tag         = module.hana_node.stonith_tag,
       region              = var.aws_region
   })

--- a/terraform/gcp/inventory.tmpl
+++ b/terraform/gcp/inventory.tmpl
@@ -2,7 +2,7 @@ all:
   vars:
     cloud_platform_name: gcp
     use_sbd: ${use_sbd}
-    gcp_cluster_ip: ${hana-vip}
+    cluster_ip: ${cluster_ip}
     prefix: ${name_prefix}
     project: ${gcp_project}
     primary_zone: ${gcp_primary_zone}

--- a/terraform/gcp/outputs.tf
+++ b/terraform/gcp/outputs.tf
@@ -100,7 +100,7 @@ resource "local_file" "ansible_inventory" {
     {
       hana_name           = module.hana_node.hana_name,
       hana_pip            = module.hana_node.hana_public_ip,
-      hana-vip            = module.hana_node.hana_vip,
+      cluster_ip          = module.hana_node.hana_vip,
       hana_remote_python  = var.hana_remote_python,
       iscsi_name          = module.iscsi_server.iscsisrv_name,
       iscsi_pip           = module.iscsi_server.iscsisrv_public_ip,


### PR DESCRIPTION
# Verification

## GCP
sle-15-SP6-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE15_6_PAYG-qesap_gcp_sapconf_test
- http://openqaworker15.qa.suse.cz/tests/312877 :green_circle: inventory use the new name http://openqaworker15.qa.suse.cz/tests/312877/file/deploy-inventory.yaml `cluster_ip`. Value is used in composition of the crm command to create the `Ipaddr2` resource http://openqaworker15.qa.suse.cz/tests/312877/logfile?filename=deploy-ansible.sap-hana-cluster.log.txt named `rsc_ip_HQ0_HDB00`. Resource in healthy in http://openqaworker15.qa.suse.cz/tests/312877#step/test_cluster/43

## Azure
sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_saptune_test
- http://openqaworker15.qa.suse.cz/tests/312878  :green_circle:  `Ipaddr2` resource is healthy http://openqaworker15.qa.suse.cz/tests/312878#step/test_cluster/43
 
## AWS
sle-15-SP6-Qesap-Aws-Payg-x86_64-BuildLATEST_AWS_SLE15_6_PAYG-qesap_aws_saptune_test
- http://openqaworker15.qa.suse.cz/tests/312879 variable `cluster_ip`  is in the inventory http://openqaworker15.qa.suse.cz/tests/312879/file/deploy-inventory.yaml and used to create resource named `rsc_ip_HQ0_HDB00` of type `ocf:suse:aws-vpc-move-ip` http://openqaworker15.qa.suse.cz/tests/312879/logfile?filename=deploy-ansible.sap-hana-cluster.log.txt . test fails during cluster configuration as waiting resource `msl_SAPHanaCtl_HQ0_HDB00` refresh.
- http://openqaworker15.qa.suse.cz/tests/312886

sle-15-SP5-Qesap-Aws-Payg-x86_64-BuildLATEST_AWS_SLE15_5_PAYG-qesap_aws_saptune_test
- http://openqaworker15.qa.suse.cz/tests/312887