### PR TITLE
Use proper default for the iscsi machine type

### DIFF
--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -470,7 +470,7 @@ variable "iscsi_os_owner" {
 variable "iscsi_instancetype" {
   description = "The instance type of the iscsi server node."
   type        = string
-  default     = "t3a.small"
+  default     = "t3.small"
 }
 
 variable "iscsi_ips" {


### PR DESCRIPTION
t3a.small is not a supported size by sles4sap 15sp5. Change to a size that is valid for majority of modern sles4sap.