### PR TITLE
Install httplib2 in GCE

### DIFF
--- a/ansible/playbooks/tasks/gcp-cluster-bootstrap.yaml
+++ b/ansible/playbooks/tasks/gcp-cluster-bootstrap.yaml
@@ -22,7 +22,6 @@
   zypper:
     name: python-httplib2
     state: present
-  when: ansible_distribution_major_version == '12'
   register: httplib2_zypper
   ignore_errors: true
 


### PR DESCRIPTION
This pr lets httplib2 installation task run on all sle versions, instead of 12 only. This task was introduced due to a missing dependency on 12sp5, but now it seems that this dependency is missing in 15 too.

No ticket, unless we open one.

- Verification run: http://openqaworker15.qa.suse.cz/tests/313668 (see next/previous: they fail in `qesap_ansible`)