### PR TITLE
Reintroduce condition about SLES 12 Advanced Systems Modules

### DIFF
--- a/ansible/playbooks/registration.yaml
+++ b/ansible/playbooks/registration.yaml
@@ -131,6 +131,8 @@
       delay: 60
       when:
         - ansible_facts['distribution_major_version'] == "12"
+        - not_registered_found
+        - "(is_registercloudguest_bin.rc != 0) or (use_suseconnect | bool)"
 
     - name: Add SLES 12 public cloud module
       ansible.builtin.command: SUSEConnect -p sle-module-public-cloud/12/{{ ansible_facts['architecture'] }}


### PR DESCRIPTION
Reintroduce couple of condition removed by mpagot@fc7ccbb6fb30af765b3c034ea24e9b7980267103 This is to avoid SUSEConnect call in PAYG images

Partially revert code from https://github.com/SUSE/qe-sap-deployment/pull/293

Ticket: https://jira.suse.com/browse/TEAM-9808


## Verification:

### 12sp5
sle-12-SP5-HanaSr-Aws-Payg-x86_64-Build12-SP5_2025-02-27T03:03:18Z-hanasr_aws_test_fencing_native_ltss ec2_r4.8xlarge PAYG with LTSS
- http://openqaworker15.qa.suse.cz/tests/315531 :green_circle:  task now is no more executed, module is in anycase registered `{\"identifier\":\"sle-module-adv-systems-management\",\"version\":\"12\",\"arch\":\"x86_64\",\"status\":\"Registered\"}`  http://openqaworker15.qa.suse.cz/tests/315531/logfile?filename=deploy_qesap_ansible-ansible.registration.log.txt
 
- http://openqaworker15.qa.suse.cz/tests/315546 :red_circle: registration part was ok, but next playbook about system update fails
- http://openqaworker15.qa.suse.cz/tests/315607 :green_circle: fail later after Ansible end 
- http://openqaworker15.qa.suse.cz/tests/315619 :red_circle: 

sle-12-SP5-HanaSr-Azure-Byos-x86_64-Build12-SP5_2025-02-27T03:03:18Z-hanasr_azure_test_msi_ltss_es az_Standard_E4s_v3  BYOS with LTSS-ES
- http://openqaworker15.qa.suse.cz/tests/315547 :green_circle: 
- http://openqaworker15.qa.suse.cz/tests/315605  :green_circle: 
 
### 15sp6
sle-15-SP6-HanaSr-Aws-Payg-x86_64-Build15-SP6_2025-02-27T03:03:18Z-hanasr_aws_test_fencing_native_crash ec2_r4.8xlarge
- http://openqaworker15.qa.suse.cz/tests/315533 :green_circle: task `Add SLES 12 Advanced Systems Modules` is skipped as expected and as before the PR 

sle-15-SP6-Qesap-Gcp-Byos-x86_64-BuildLATEST_GCE_SLE15_6_BYOS-qesap_gcp_sapconf_test 64bit
- http://openqaworker15.qa.suse.cz/tests/315534 :green_circle: task `Add SLES 12 Advanced Systems Modules` is skipped as expected and as before the PR 