### PR TITLE
Update lint tools and remove pylint exceptions

### DIFF
--- a/scripts/qesap/pylint.rc
+++ b/scripts/qesap/pylint.rc
@@ -144,24 +144,12 @@ confidence=HIGH,
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-#disable=raw-checker-failed,
-#        bad-inline-option,
-#        locally-disabled,
-#        file-ignored,
-#        suppressed-message,
-#        useless-suppression,
-#        deprecated-pragma,
-#        use-symbolic-message-instead
 
 disable=line-too-long,
-        missing-class-docstring,
-        missing-function-docstring,
         missing-module-docstring,
-        too-many-branches,
-        unused-argument,
         too-many-locals,
         too-many-arguments,
-        duplicate-code
+        too-many-positional-arguments
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/scripts/qesap/requirements-dev.txt
+++ b/scripts/qesap/requirements-dev.txt
@@ -1,10 +1,10 @@
-flake8==6.*
-flake8-bugbear==23.5.*
+flake8==7.*
+flake8-bugbear==24.12.*
 hypothesis==6.*
-pylint==3.1.*
+pylint==3.3.*
 pytest==8.2.*
 pytest-subprocess
 pytest-find-dependencies
 detect-test-pollution
-yamllint==1.35.*
+yamllint==1.36.*
 ansible-lint


### PR DESCRIPTION
Update some python and yaml related linter tools and remove pylint warning exceptions that are no more needed as the code has been previously fixed about them.