### PR TITLE
Update gcloud installer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,16 @@ RUN zypper ref && zypper up -y && \
 WORKDIR /root
 
 ## GCP
-RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-387.0.0-linux-x86_64.tar.gz | \
-    tar zpxf - && \
+# Methods are described in:
+#  - https://cloud.google.com/sdk/docs/install
+#  - https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/3270ae9ac3a8b4e455fe2109cadb65b432b910a3/tests/publiccloud/prepare_tools.pm#L113
+#
+RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz && \
+    tar -xf google-cloud-cli-linux-x86_64.tar.gz && \
     google-cloud-sdk/install.sh --quiet --usage-reporting false --command-completion true && \
     echo 'source /root/google-cloud-sdk/completion.bash.inc' >> ~/.bashrc && \
-    echo 'source ~/google-cloud-sdk/path.bash.inc' >> ~/.bashrc
+    echo 'source ~/google-cloud-sdk/path.bash.inc' >> ~/.bashrc && \
+    rm google-cloud-cli-linux-x86_64.tar.gz
 
 ## Terraform
 RUN curl https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_amd64.zip -o terraform.zip && \
@@ -30,11 +35,10 @@ ENV VIRTUAL_ENV=/opt/venv
 RUN python3.11 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 COPY requirements.txt .
-RUN pip install --upgrade pip && \
-    pip install -r requirements.txt
-
 COPY requirements.yml .
-RUN  ansible-galaxy install -r requirements.yml
+RUN pip install --upgrade pip && \
+    pip install -r requirements.txt && \
+    ansible-galaxy install -r requirements.yml
 
 RUN mkdir /src
 WORKDIR /src

--- a/tools/image_test.sh
+++ b/tools/image_test.sh
@@ -5,21 +5,27 @@ cre="${cre:-"podman"}"
 
 #$cre build -f Dockerfile -t "${img_name}"
 
+echo "=== Test terraform binary"
 $cre run "${img_name}" terraform --version | grep 1.5.7 || ( echo "ERROR[$?] wrong or not usable Terraform" ; exit 1 )
 $cre run -v $(pwd):/src "${img_name}" terraform -chdir=/src/terraform/azure init || ( echo "ERROR[$?] terraform init does not work for azure" ; exit 1 )
 $cre run -v $(pwd):/src "${img_name}" terraform -chdir=/src/terraform/aws init || ( echo "ERROR[$?] terraform init does not work for aws" ; exit 1 )
 $cre run  -v $(pwd):/src "${img_name}" terraform -chdir=/src/terraform/gcp init || ( echo "ERROR[$?] terraform init does not work for google" ; exit 1 )
 
+echo "=== Test ansible"
 $cre run "${img_name}" python3.11 --version | grep 3.11 || ( echo "ERROR[$?] wrong or not usable Python" ; exit 1 )
 $cre run "${img_name}" pip3.11 --version || ( echo "ERROR[$?] wrong or not usable pip" ; exit 1 )
 $cre run "${img_name}" pip3.11 freeze | grep ansible-core || ( echo "ERROR[$?] ansible-core not installed" ; exit 1 )
 $cre run "${img_name}" ansible --version || ( echo "ERROR[$?] wrong or not usable Terraform" ; exit 1 )
 $cre run "${img_name}" ansible-galaxy --version || ( echo "ERROR[$?] wrong or not usable Terraform" ; exit 1 )
 
+echo "=== Test awscli"
 $cre run "${img_name}" pip3.11 freeze | grep aws || ( echo "ERROR[$?] aws cli not installed" ; exit 1 )
 $cre run "${img_name}" aws --version || ( echo "ERROR[$?] wrong or not usable aws" ; exit 1 )
-$cre run "${img_name}" az --version || ( echo "ERROR[$?] wrong or not usable az" ; exit 1 )
-#$cre run "${img_name}" cat /root/.bashrc
-# $cre run "${img_name}" gcloud --version
 
+echo "=== Test az"
+$cre run "${img_name}" az --version || ( echo "ERROR[$?] wrong or not usable az" ; exit 1 )
+
+echo "=== Test gcloud"
+$cre run "${img_name}" cat /root/.bashrc
+$cre run "${img_name}" /root/google-cloud-sdk/bin/gcloud --version
 


### PR DESCRIPTION
TEAM-10178 change installer binary usr from google, using one without version specific. Change the way gcloud is tested by giving full binary path: somehow the installation method does not add it to the PATH, maybe as we run installation as root user.