### PR TITLE
Add azure peering to terraform

### DIFF
--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -881,3 +881,16 @@ variable "iscsi_remote_python" {
   default     = "/usr/bin/python3"
 }
 
+# Network peering variables
+variable "ibsm_vnet_name" {
+  description = "Name of the IBSM vnet"
+  type        = string
+  default     = ""
+}
+
+variable "ibsm_rg" {
+  description = "Name of the IBSM resource group"
+  type        = string
+  default     = ""
+}
+


### PR DESCRIPTION
Following the enablement of direct terraform network peering for GCP IBSM, this ticket adds terraform network peering for Azure.

**How to test:** run a manual deployment for azure and add these variables to config.yaml, in the terraform section:

```
ibsm_vnet_name: <ibsm_vnet_name>
enable_az_vnet_peering: true
```
`ibsm_rg: <ibsm_rg>` is also needed, but already provided in current azure jobs.

Simply run terraform using a yaml with the above added in config.yaml, then ssh to one of the nodes and ping the IBSM private ip.

Related ticket: https://jira.suse.com/browse/TEAM-9885
- Verification runs: 

https://openqa.suse.de/tests/17187386 (using the new way - check the CASEDIR and the new variable `IBSM_VNET`, those changes are enough to trigger the new peering)

https://openqa.suse.de/tests/17187371 (using the old way - no CASEDIR and no `IBSM_VNET` variable provided)