### PR TITLE
Fix dryrun output for Ansible

### DIFF
--- a/scripts/qesap/lib/process_manager.py
+++ b/scripts/qesap/lib/process_manager.py
@@ -3,6 +3,7 @@ All tools needed to manage external executable and processes
 '''
 
 import subprocess
+import shlex
 import logging
 
 log = logging.getLogger('QESAP')
@@ -11,7 +12,8 @@ log = logging.getLogger('QESAP')
 def subprocess_run(cmd, env=None):
     """Tiny wrapper around subprocess
     Args:
-        cmd (list of string): directly used as input for subprocess.run
+        cmd (string): properly splitted in list of string internally by shlex.plit
+                      before to be used as input for subprocess.run
     Returns:
         (int, list of string): exit code and list of stdout
     """
@@ -19,11 +21,11 @@ def subprocess_run(cmd, env=None):
         log.error("Empty command")
         return (1, [])
 
-    log.info("Run:       '%s'", ' '.join(cmd))
+    log.info("Run:       '%s'", cmd)
     if env is not None:
         log.info("with env %s", env)
 
-    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False, env=env)
+    proc = subprocess.run(shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False, env=env)
 
     ret_stdout = list(proc.stdout.decode('UTF-8').splitlines())
     if proc.returncode != 0:

--- a/scripts/qesap/test/conftest.py
+++ b/scripts/qesap/test/conftest.py
@@ -201,16 +201,7 @@ ANSIBLEPB_EXE = FAKE_BIN_PATH + "ansible-playbook"
 @pytest.fixture()
 def ansible_exe_call():
     def _callback(inventory):
-        return [
-            ANSIBLE_EXE,
-            "-vv",
-            "-i",
-            inventory,
-            "all",
-            "-a",
-            "true",
-            '--ssh-extra-args=-l cloudadmin -o UpdateHostKeys=yes -o StrictHostKeyChecking=accept-new',
-        ]
+        return f"{ANSIBLE_EXE} -vv -i {inventory} all -a true --ssh-extra-args=\"-l cloudadmin -o UpdateHostKeys=yes -o StrictHostKeyChecking=accept-new\""
 
     return _callback
 
@@ -220,7 +211,7 @@ def mock_call_ansibleplaybook():
     """
     create a mock.call with some default elements
     ```
-    mock.call(['ansible-playbook', '-i', inventory, playbook], env={'ANSIBLE_PIPELINING', 'True'})
+    mock.call('ansible-playbook -i inventory, playbook', env={'ANSIBLE_PIPELINING', 'True'})
     ```
     """
 
@@ -233,7 +224,7 @@ def mock_call_ansibleplaybook():
             original_env["ANSIBLE_PIPELINING"] = "True"
         else:
             original_env = env
-        return mock.call(cmd=playbook_cmd, env=original_env)
+        return mock.call(cmd=' '.join(playbook_cmd), env=original_env)
 
     return _callback
 

--- a/scripts/qesap/test/e2e/test.sh
+++ b/scripts/qesap/test/e2e/test.sh
@@ -431,7 +431,7 @@ qesap.py --verbose -b ${QESAPROOT} -c ${QESAP_CFG} --dryrun ansible || test_die 
 test_split
 echo "Run the script again collecting the output"
 qesap.py -b ${QESAPROOT} -c ${QESAP_CFG} --dryrun ansible |& tee "${THIS_LOG}"
-grep -E "ansible.*-i.*${PROVIDER}/inventory.yaml.*all.*ssh-extra-args=.*" \
+grep -E "ansible.*-i.*${PROVIDER}/inventory.yaml.*all.*ssh-extra-args=\".*\"" \
     "${THIS_LOG}" || test_die "${QESAP_CFG} dryrun fails in ansible command"
 grep -E "ansible-playbook.*-i.*${PROVIDER}/inventory.yaml.*ansible/playbooks/sambuconero.yaml" \
     "${THIS_LOG}" || test_die "${QESAP_CFG} dryrun fails in ansible-playbook command"

--- a/scripts/qesap/test/unit/test_qesap_lib_cmd_ansible.py
+++ b/scripts/qesap/test/unit/test_qesap_lib_cmd_ansible.py
@@ -18,21 +18,13 @@ def test_export_ansible_output():
     """
     Utility function that get the ansible command line and the command output.
     Function calculate the log name by extracting the ansible playbook name from the command line.
-    Function take the content of out and write it to a file in the current directory
+    Function take the content of stdout and write it to a file in the current directory
     """
 
     test_dir = os.getcwd()
     test_file = os.path.join(test_dir, "ansible.testAll.log.txt")
 
-    command_to_sent = [
-        "/tmp/exec_venv/bin/ansible-playbok",
-        "-vvvv",
-        "-i",
-        "/root/qe-sap-deployment/terraform/aws/inventory.yaml",
-        "/some/immaginary/path/ansible/playbooks/testAll.yaml",
-        "-e",
-        "something=somevalue",
-    ]
+    command_to_sent = "/tmp/exec_venv/bin/ansible-playbok -vvvv -i /root/qe-sap-deployment/terraform/aws/inventory.yaml /some/immaginary/path/ansible/playbooks/testAll.yaml -e something=somevalue"
     ansible_output = """whatever multiline string
     produced by Ansible"""
 
@@ -89,9 +81,7 @@ ansible:
         ["This is the ansible output", "Two lines of that"],
     )
 
-    # Set expectation
-    calls = []
-    calls.append(mock.call(cmd=ansible_exe_call(inventory)))
+    calls = [mock.call(cmd=ansible_exe_call(inventory))]
     calls.append(mock_call_ansibleplaybook(inventory, playbook[0]))
 
     ret = cmd_ansible(data, tmpdir, False, False)

--- a/scripts/qesap/test/unit/test_qesap_lib_cmd_terraform.py
+++ b/scripts/qesap/test/unit/test_qesap_lib_cmd_terraform.py
@@ -176,16 +176,8 @@ terraform:
         ["This is the terraform output", "Two lines of that"],
     )
 
-    # Set expectation
-    calls = []
-    terraform_cmd = ["terraform", f"-chdir={provider_folder}"]
-    # Just test one of them
-    terraform_cmd.append("init")
-    terraform_cmd.append("-no-color")
-    calls.append(mock.call(terraform_cmd))
-
     ret = cmd_terraform(data, tmpdir, False)
 
     assert ret == 0
-
-    subprocess_run.assert_has_calls(calls)
+    # init just test one of them
+    subprocess_run.assert_has_calls([mock.call(f"terraform -chdir={provider_folder} init -no-color")])

--- a/scripts/qesap/test/unit/test_subprocess_run.py
+++ b/scripts/qesap/test/unit/test_subprocess_run.py
@@ -13,10 +13,12 @@ def test_no_command():
 
 def test_echo():
     '''
-    Run subprocess_run using the true subprocess
+    Run subprocess_run using the true subprocess.
+    Test is really running an echo command
+    and check the stdout.
     '''
-    test_text = '"Banana"'
-    exit_code, stdout_list = subprocess_run(['echo', test_text])
+    test_text = 'Banana'
+    exit_code, stdout_list = subprocess_run(f"echo \"{test_text}\"")
     assert exit_code == 0
     assert stdout_list == [test_text]
 
@@ -29,7 +31,7 @@ def test_multilines():
     test_text = ''
     for string in str_list:
         test_text += (string * 10) + "\n"
-    _, stdout_list = subprocess_run(['echo', test_text])
+    _, stdout_list = subprocess_run(f"echo \"{test_text}\"")
     assert len(stdout_list) == len(str_list) + 1
     for i, line in enumerate(str_list):
         assert line * 10 == stdout_list[i].strip()
@@ -39,8 +41,8 @@ def test_stderr():
     '''
     Run subprocess_run redirect the stderr to stdout
     '''
-    test_text = '"Banana"'
-    exit_code, stdout_list = subprocess_run(['logger', '-s', test_text])
+    test_text = 'Banana'
+    exit_code, stdout_list = subprocess_run(f"logger -s {test_text}")
     assert exit_code == 0
     assert len(stdout_list) > 0
 
@@ -49,9 +51,9 @@ def test_err():
     '''
     Run subprocess_run with a command that fails
     '''
-    not_existing_file = '"Banana"'
+    not_existing_file = 'Banana'
 
-    exit_code, stdout_list = subprocess_run(['cat', not_existing_file])
+    exit_code, stdout_list = subprocess_run(f"cat {not_existing_file}")
     assert exit_code == 1
     assert len(stdout_list) > 0
 
@@ -60,8 +62,8 @@ def test_env():
     '''
     Check that env variable are controllable
     '''
-    _, stdout_list = subprocess_run(['printenv'])
+    _, stdout_list = subprocess_run('printenv')
     assert 'BANANA_VALUE' not in stdout_list
-    exit_code, stdout_list = subprocess_run(['printenv'], env={'BANANA_VALUE': '1234'})
+    exit_code, stdout_list = subprocess_run('printenv', env={'BANANA_VALUE': '1234'})
     assert exit_code == 0
     assert 'BANANA_VALUE=1234' in stdout_list


### PR DESCRIPTION
Dryrun is mind to print Terraform and Ansible commands that a user can
directly run. The first Ansible command produced an invalid command due
to missing quotation. This commit is about fixing this issue. The
approach is to change the internal rappresentation for the commands,
from a list of list of string (subprocess expect a list of strings for a
single command), to a list of strings: each command is just rappresented
with a single space separated string. This format can be directly used
for the dryrun mode. When not in dryrun mode, process_manager is using
shlex.split to produce the input subproces needs.