### PR TITLE
Add timestamp to TF output

### DIFF
--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -4,6 +4,11 @@
 # - Private node name
 # - Public node name
 
+# Timestamp of apply
+output "Timestamp" {
+  value = timestamp()
+}
+
 # iSCSI server
 
 output "iscsisrv_ip" {

--- a/terraform/azure/outputs.tf
+++ b/terraform/azure/outputs.tf
@@ -4,6 +4,11 @@
 # - Private node name
 # - Public node name
 
+# Timestamp of apply
+output "Timestamp" {
+  value = timestamp()
+}
+
 # iSCSI server
 
 output "iscsisrv_ip" {

--- a/terraform/gcp/outputs.tf
+++ b/terraform/gcp/outputs.tf
@@ -4,6 +4,11 @@
 # - Private node name
 # - Public node name
 
+# Timestamp of apply
+output "Timestamp" {
+  value = timestamp()
+}
+
 # iSCSI server
 
 output "iscsisrv_ip" {


### PR DESCRIPTION
In any evenience of provisioning errors, this will make debugging easier by time correlation with the provider's event log.

related ticket: https://jira.suse.com/browse/TEAM-10213

VRs:
  - http://openqaworker15.qa.suse.cz/tests/318972/logfile?filename=deploy-qesap_exec_terraform.log.txt#line-914
  - http://openqaworker15.qa.suse.cz/tests/318973/logfile?filename=deploy-qesap_exec_terraform.log.txt#line-907
  - http://openqaworker15.qa.suse.cz/tests/318976/logfile?filename=deploy-qesap_exec_terraform.log.txt#line-1764
