### PR TITLE
Set ZYPP_LOCK_TIMEOUT when running zypper patch

### DIFF
--- a/ansible/playbooks/fully-patch-system.yaml
+++ b/ansible/playbooks/fully-patch-system.yaml
@@ -17,6 +17,8 @@
         name: '*'
         state: latest
         type: patch
+      environment:
+        ZYPP_LOCK_TIMEOUT: 120
       notify: Reboot after patch
 
   handlers:


### PR DESCRIPTION
Allow zypper to wait more time, 2 minutes for the moment, before to give up.
It can help to reduce rick of failure for collisions with zypper called at boot and by the registration framework.

# Verification
 - sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_angi_test@64bit -> http://openqaworker15.qa.suse.cz/tests/319389