### PR TITLE
Bump disk attachment timeout on Azure

### DIFF
--- a/terraform/azure/modules/hana_node/main.tf
+++ b/terraform/azure/modules/hana_node/main.tf
@@ -380,6 +380,9 @@ resource "azurerm_virtual_machine_data_disk_attachment" "hana_data_disk_attachme
   virtual_machine_id = azurerm_linux_virtual_machine.hana[floor(count.index / local.disks_number)].id
   lun                = count.index % local.disks_number
   caching            = element(local.disks_caching, count.index % local.disks_number)
+  timeouts {
+    read = "30m"
+  }
 }
 
 resource "azurerm_linux_virtual_machine" "hana" {


### PR DESCRIPTION
Reference Ticket: https://jira.suse.com/browse/TEAM-8865

When trying to attach a large number of disks (12) at the same time, the provider may take more time than the default 10 minutes.

verification runs:
- http://openqaworker15.qa.suse.cz/tests/319379
- http://openqaworker15.qa.suse.cz/tests/319380
- http://openqaworker15.qa.suse.cz/tests/319381
- http://openqaworker15.qa.suse.cz/tests/319382
- http://openqaworker15.qa.suse.cz/tests/319383