### PR TITLE
Add retry to SUSEConnect -s

### DIFF
--- a/ansible/playbooks/registration.yaml
+++ b/ansible/playbooks/registration.yaml
@@ -19,7 +19,10 @@
     - name: Check for registration
       ansible.builtin.command: SUSEConnect -s
       register: repos
-      failed_when: false
+      until: repos.rc == 0
+      retries: 10
+      delay: 60
+      failed_when: repos.rc != 0
       changed_when: false
 
     # Check if there are instances of `Not Registered` in it


### PR DESCRIPTION
Add retry and fails if exit code is not zero. This prevent a failure to be confused to a system that does not registration.

Ticket : https://jira.suse.com/browse/TEAM-10225

# Verification
Not in a single VR I managed to get the retry mechanism to be used, all of the time SUSEConnect worked at the first try

## PAYG
http://openqaworker15.qa.suse.cz/tests/320120
http://openqaworker15.qa.suse.cz/tests/320300
http://openqaworker15.qa.suse.cz/tests/320292

## BYOS
 http://openqaworker15.qa.suse.cz/tests/320293