### PR TITLE
Add parallel argument to terraform gluescript command

### DIFF
--- a/scripts/qesap/lib/cmds.py
+++ b/scripts/qesap/lib/cmds.py
@@ -165,15 +165,17 @@ def cmd_destroy(configure_data, base_project, dryrun=False, verbose=False):
     return cmd_terraform(configure_data, base_project, dryrun, workspace='default', destroy=True)
 
 
-def cmd_terraform(configure_data, base_project, dryrun, workspace='default', destroy=False):
+def cmd_terraform(configure_data, base_project, dryrun, workspace='default', destroy=False, parallel=None):
     """ Main executor for the deploy sub-command
 
     Args:
         configure_data (obj): configuration structure
         base_project (str): base project path where to
                       look for the Terraform files
-        destroy (bool): destroy
         dryrun (bool): enable dryrun execution mode
+        workspace (str): name of the workspace to activate before running the deployment
+        destroy (bool): destroy
+        parallel (int): value to use for argument --parallelism=n when call terraform plan and apply
 
     Returns:
         Status: execution result, 0 means OK. It is mind to be used as script exit code
@@ -199,8 +201,11 @@ def cmd_terraform(configure_data, base_project, dryrun, workspace='default', des
         cmds.append(f"{terraform_common_cmd} init")
         if workspace != 'default':
             cmds.append(f"{terraform_common_cmd} workspace new {workspace}")
-        cmds.append(f"{terraform_common_cmd} plan -out=plan.zip")
-        cmds.append(f"{terraform_common_cmd} apply -auto-approve plan.zip")
+        parallel_str = ''
+        if parallel:
+            parallel_str = f"-parallelism={parallel} "
+        cmds.append(f"{terraform_common_cmd} plan {parallel_str}-out=plan.zip")
+        cmds.append(f"{terraform_common_cmd} apply {parallel_str}-auto-approve plan.zip")
 
     for command in cmds:
         command += ' -no-color'

--- a/scripts/qesap/qesap.py
+++ b/scripts/qesap/qesap.py
@@ -114,6 +114,11 @@ def cli(command_line=None):
                                   dest='workspace',
                                   default='default',
                                   help="""Workspace to use in terraform commands. Defaults to 'default'""")
+    parser_terraform.add_argument('-p',
+                                  '--parallel',
+                                  type=int,
+                                  dest='parallel',
+                                  help="""Set value for -parallelism for plan and apply""")
     parser_ansible = subparsers.add_parser('ansible', help="Run the Ansible part of the deployment")
     parser_ansible.add_argument('-d',
                                 '--destroy',
@@ -182,7 +187,8 @@ def main(command_line=None):  # pylint: disable=too-many-return-statements
             parsed_args.basedir,
             parsed_args.dryrun,
             workspace=parsed_args.workspace,
-            destroy=parsed_args.destroy
+            destroy=parsed_args.destroy,
+            parallel=parsed_args.parallel
         )
         if res != 0:
             print(res.msg)  # should we use file=sys.stderr here?

--- a/scripts/qesap/test/e2e/main_local_many.tf
+++ b/scripts/qesap/test/e2e/main_local_many.tf
@@ -1,0 +1,10 @@
+resource "local_file" "foo" {
+  # 10 is the default parallel level in terraform when not using -parallelism=N
+  # so use it to maximise the difference in using or not using the argument
+  count    = 10
+  content  = "@${timestamp()} foo@"
+  filename = "${path.module}/foo.${count.index}.bar"
+  provisioner "local-exec" {
+    command = "sleep 2 ; date +'%T %N'"
+  }
+}

--- a/scripts/qesap/test/unit/test_qesap_terraform.py
+++ b/scripts/qesap/test/unit/test_qesap_terraform.py
@@ -252,3 +252,24 @@ def test_terraform_call_terraform_workspace_destroy(subprocess_run, args_helper,
     calls.append(mock.call(f"terraform -chdir={terraform_dir} workspace delete lucignolo -no-color"))
 
     subprocess_run.assert_has_calls(calls)
+
+
+@mock.patch("lib.process_manager.subprocess_run")
+def test_terraform_call_terraform_parallel(subprocess_run, args_helper, config_yaml_sample):
+    """
+    Command terraform calls 'terraform plan' and 'terraform apply' with -parallelism=n
+    """
+    provider = 'mangiafuoco'
+    conf = config_yaml_sample(provider)
+
+    args, terraform_dir, *_ = args_helper(provider, conf)
+    args.extend(['terraform', '-p', '5'])
+    subprocess_run.return_value = (0, [])
+    assert main(args) == 0
+    subprocess_run.assert_called()
+
+    calls = []
+    calls.append(mock.call(f"terraform -chdir={terraform_dir} plan -parallelism=5 -out=plan.zip -no-color"))
+    calls.append(mock.call(f"terraform -chdir={terraform_dir} apply -parallelism=5 -auto-approve plan.zip -no-color"))
+
+    subprocess_run.assert_has_calls(calls)


### PR DESCRIPTION
Add --parallel to be able to control inner terraform -parallelism=N in plan and apply


Ticket: https://jira.suse.com/browse/TEAM-10214

# Verification

https://openqaworker15.qa.suse.cz/tests/321203 :green_apple:  deployment part is fine

e2e test has an example of how the --parallel feature works:
- https://github.com/SUSE/qe-sap-deployment/actions/runs/14411886450/job/40421466983?pr=346#step:10:779

It is using this new `.tf` file https://github.com/SUSE/qe-sap-deployment/pull/346/files#diff-23b7f123238e99116b1db37bd902b2b36a0503f8a63da1aa6e9ff4968c168b47R1

The file is about creating 10 files and write in them the timestamp of the time they has been created.

The deployment is executed two times: with and without `--parallel`

Without `--parallel` https://github.com/SUSE/qe-sap-deployment/actions/runs/14411886450/job/40421466983?pr=346#step:10:975

File content is in https://github.com/SUSE/qe-sap-deployment/actions/runs/14411886450/job/40421466983?pr=346#step:10:1060
```
#./test_repo/terraform/fragola/foo.0.bar --> 2025-04-11T20:57:45Z foo!#
#./test_repo/terraform/fragola/foo.1.bar --> 2025-04-11T20:57:45Z foo!#
#./test_repo/terraform/fragola/foo.2.bar --> 2025-04-11T20:57:45Z foo!#
#./test_repo/terraform/fragola/foo.3.bar --> 2025-04-11T20:57:45Z foo!#
#./test_repo/terraform/fragola/foo.4.bar --> 2025-04-11T20:57:45Z foo!#
#./test_repo/terraform/fragola/foo.5.bar --> 2025-04-11T20:57:45Z foo!#
#./test_repo/terraform/fragola/foo.6.bar --> 2025-04-11T20:57:45Z foo!#
#./test_repo/terraform/fragola/foo.7.bar --> 2025-04-11T20:57:45Z foo!#
#./test_repo/terraform/fragola/foo.8.bar --> 2025-04-11T20:57:45Z foo!#
#./test_repo/terraform/fragola/foo.9.bar --> 2025-04-11T20:57:45Z foo!#
```
All of them has been created at the same time as Terraform default parallelization level is 10

Here is a second deployment with `--parallel 1` https://github.com/SUSE/qe-sap-deployment/actions/runs/14411886450/job/40421466983?pr=346#step:10:1460

Each file has a different timestamp
```
#./test_repo/terraform/fragola/foo.0.bar --> 2025-04-11T20:58:00Z foo!#
#./test_repo/terraform/fragola/foo.1.bar --> 2025-04-11T20:58:02Z foo!#
#./test_repo/terraform/fragola/foo.2.bar --> 2025-04-11T20:57:54Z foo!#
#./test_repo/terraform/fragola/foo.3.bar --> 2025-04-11T20:57:58Z foo!#
#./test_repo/terraform/fragola/foo.4.bar --> 2025-04-11T20:57:56Z foo!#
#./test_repo/terraform/fragola/foo.5.bar --> 2025-04-11T20:57:48Z foo!#
#./test_repo/terraform/fragola/foo.6.bar --> 2025-04-11T20:57:50Z foo!#
#./test_repo/terraform/fragola/foo.7.bar --> 2025-04-11T20:58:06Z foo!#
#./test_repo/terraform/fragola/foo.8.bar --> 2025-04-11T20:57:52Z foo!#
#./test_repo/terraform/fragola/foo.9.bar --> 2025-04-11T20:58:04Z foo!#
```

