### PR TITLE
Change retry timing for SUSEConnect

### DIFF
--- a/ansible/playbooks/registration.yaml
+++ b/ansible/playbooks/registration.yaml
@@ -20,8 +20,8 @@
       ansible.builtin.command: SUSEConnect -s
       register: repos
       until: repos.rc == 0
-      retries: 10
-      delay: 60
+      retries: 5
+      delay: 120
       failed_when: repos.rc != 0
       changed_when: false
 


### PR DESCRIPTION
Retry less time but wait double the time between each retry. Without this change, the retry is orking properly in detecting the error and run the command again, in particular zypper error 7.
Problem is, in PAYG images, the first retry that does not fails for a collision with another zypper process, report some modules as not Registered: it is something not expected for a PAYG image. Waiting more time can give time to the image itself (cloudregister) to register all modules.

Ticket https://jira.suse.com/browse/TEAM-10225

Verification :  http://openqaworker15.qa.suse.cz/tests/321224