### PR TITLE
Fix typos : "manadatory" -> "mandatory"

### DIFF
--- a/scripts/qesap/test/conftest.py
+++ b/scripts/qesap/test/conftest.py
@@ -373,7 +373,7 @@ def check_duplicate():
 
 
 @pytest.fixture
-def check_manadatory_args(capsys, tmpdir):
+def check_mandatory_args(capsys, tmpdir):
     """
     Given a cli to test and a subcommand string,
     check that both -c and -b are mandatory

--- a/scripts/qesap/test/unit/test_qesap_cli.py
+++ b/scripts/qesap/test/unit/test_qesap_cli.py
@@ -20,13 +20,13 @@ def test_cli_help(capsys):
     assert "usage:" in result
 
 
-def test_cli_configure_noargs(check_manadatory_args):
+def test_cli_configure_noargs(check_mandatory_args):
     '''
     configure subcommand at least needs:
     -b to know where to write the terraform.tfvars
     -c to know what to write in the terraform.tfvars
     '''
-    assert check_manadatory_args(cli, 'configure')
+    assert check_mandatory_args(cli, 'configure')
 
 
 def test_cli_configure_b_notexist(capsys, tmpdir):
@@ -110,13 +110,13 @@ def test_cli_destroy(base_args):
     cli(args)
 
 
-def test_cli_terraform_noargs(check_manadatory_args):
+def test_cli_terraform_noargs(check_mandatory_args):
     '''
     terraform subcommand at least needs:
     -b to know where to look for the Terraform files to run
     -c to know the Cloud Provider subfolder to use
     '''
-    assert check_manadatory_args(cli, 'terraform')
+    assert check_mandatory_args(cli, 'terraform')
 
 
 def test_cli_terraform(base_args):
@@ -149,7 +149,7 @@ def test_cli_terraform_workspace(base_args):
     cli(args)
 
 
-def test_cli_ansible_noargs(check_manadatory_args):
+def test_cli_ansible_noargs(check_mandatory_args):
     '''
     ansible subcommand at least needs:
     -b to know where to look for the Ansible playbooks
@@ -157,7 +157,7 @@ def test_cli_ansible_noargs(check_manadatory_args):
     -c to know the list of Ansible Playbooks
        to play and other setting for them (like the SCC reg code)
     '''
-    assert check_manadatory_args(cli, 'ansible')
+    assert check_mandatory_args(cli, 'ansible')
 
 
 def test_cli_ansible(base_args):

--- a/scripts/qesap/test/unit/test_qesap_configure_ansible.py
+++ b/scripts/qesap/test/unit/test_qesap_configure_ansible.py
@@ -275,7 +275,7 @@ ansible:
 
 def test_configure_ansible_hana(configure_helper):
     """
-    Test that 'configure' fails if manadatory params are missing
+    Test that 'configure' fails if mandatory params are missing
     """
     provider = "pinocchio"
     conf = f"""---


### PR DESCRIPTION
Yes, I know, I know. It's just typos.

I tried to ignore them, I really did. I tried to focus on the actual logic. But they whispered to me in the dead of night, mocking my commitment to quality.

This PR contains strictly typo fixes. No logic changes were smuggled in, I promise (mostly). 
