### PR TITLE
Add optional IBSM peering (TGW) to terraform

### DIFF
--- a/terraform/aws/modules/drbd_node/outputs.tf
+++ b/terraform/aws/modules/drbd_node/outputs.tf
@@ -18,3 +18,10 @@ output "drbd_name" {
 output "drbd_public_name" {
   value = data.aws_instance.drbd.*.public_dns
 }
+
+output "subnets_by_az" {
+  value = {
+    for s in aws_subnet.drbd-subnet :
+    s.availability_zone => s.id
+  }
+}

--- a/terraform/aws/modules/hana_node/outputs.tf
+++ b/terraform/aws/modules/hana_node/outputs.tf
@@ -23,3 +23,9 @@ output "stonith_tag" {
   value = local.hana_stonith_tag
 }
 
+output "subnets_by_az" {
+  value = {
+    for s in aws_subnet.hana-subnet :
+    s.availability_zone => s.id
+  }
+}

--- a/terraform/aws/modules/netweaver_node/outputs.tf
+++ b/terraform/aws/modules/netweaver_node/outputs.tf
@@ -18,3 +18,10 @@ output "netweaver_name" {
 output "netweaver_public_name" {
   value = data.aws_instance.netweaver.*.public_dns
 }
+
+output "subnets_by_az" {
+  value = {
+    for s in aws_subnet.netweaver-subnet :
+    s.availability_zone => s.id
+  }
+}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -746,3 +746,8 @@ variable "iscsi_remote_python" {
   default     = "/usr/bin/python3"
 }
 
+variable "ibsm_project_tag" {
+  description = "IBSM tgw 'Project' tag - leave empty to disable terraform peering."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
This ticket optionally adds the resources/logic necessary for AWS IBSM peering in qe-sap-deployment (terraform).

Verified manually, only add

ibsm_vpc_id: 'vpc-...'
ibsm_tgw_project_tag: "<ibsm-Project-tag>"

and after terraform, peering will be enabled.


**WORK IN PROGRESS - DO NOT MERGE!**