### PR TITLE
Fix dynamic nvme-sdX disk errors in r5

### DIFF
--- a/ansible/playbooks/vars/aws_hana_storage_profile.yaml
+++ b/ansible/playbooks/vars/aws_hana_storage_profile.yaml
@@ -5,7 +5,7 @@ sap_storage_dict:
     directory: '/hana/data'
     vg: 'hanadatavg'
     lv: 'hanadatalv'
-    pv: ["/dev/nvme1n1", "/dev/nvme2n1"]
+    pv: ["/dev/sdb", "/dev/sdc"]
     numluns: '1'
     stripesize: '256'
   # LVM striped partition
@@ -14,7 +14,7 @@ sap_storage_dict:
     directory: '/hana/log'
     vg: 'hanalogvg'
     lv: 'hanaloglv'
-    pv: ["/dev/nvme3n1", "/dev/nvme4n1"]
+    pv: ["/dev/sdd", "/dev/sde"]
     numluns: '2'
     stripesize: '32'
   hanashared:
@@ -22,7 +22,7 @@ sap_storage_dict:
     directory: '/hana/shared'
     vg: 'hanasharedvg'
     lv: 'hanasharedlv'
-    pv: ["/dev/nvme5n1"]
+    pv: ["/dev/sdf"]
     numluns: '1'
     stripesize: ''
   usrsap:
@@ -30,7 +30,7 @@ sap_storage_dict:
     directory: '/usr/sap'
     vg: 'usrsapvg'
     lv: 'usrsaplv'
-    pv: ["/dev/nvme6n1"]
+    pv: ["/dev/sdg"]
     numluns: '1'
     stripesize: ''
   backup:
@@ -38,6 +38,6 @@ sap_storage_dict:
     directory: '/backup'
     vg: 'backupvg'
     lv: 'backuplv'
-    pv: ["/dev/nvme7n1"]
+    pv: ["/dev/sdh"]
     numluns: '1'
     stripesize: ''

--- a/ansible/roles/qe_sap_storage/tasks/generic_tasks/prepare_storage.yml
+++ b/ansible/roles/qe_sap_storage/tasks/generic_tasks/prepare_storage.yml
@@ -4,28 +4,65 @@
   ansible.builtin.debug:
     msg: "{{ item }} "
 
-- name: Determine the root device
-  ansible.builtin.command: "findmnt -n -o SOURCE /"
-  register: root_device
-  changed_when: false
-
-# Cut any partition suffixes like p1, p2
-- name: Normalize root device name
-  ansible.builtin.set_fact:
-    root_device_name: "{{ root_device.stdout | regex_replace('p[0-9]+$', '') }}"
-
-# If root is not nvme0n1, and it also exists in pv, switch it with nvme0n1 in pv
-# This part of the code only runs if the root_device is not nvme0n1
-# It searches in the item.pv list for the root_device, and if it is found
-# it gets replaced with nvme0n1, which is free to use.
-# This is necessary because nvme1n1-nvme7n1 are given specific roles in aws_hana_storage_profile.yaml
-# and if one of them is root, it needs to be replaced with nvme0n1 (the original root, now free)
-- name: Adjust PV list for storage profile "{{ item.key }}"
-  ansible.builtin.set_fact:
-    adjusted_pv: "{{ item.value.pv | map('regex_replace', '^' ~ root_device_name ~ '$', '/dev/nvme0n1') | list }}"
+# Gather device info (needed to use ansible_facts.devices)
+- name: Gather blockdevice facts (nvmeXn1 sizes)
+  ansible.builtin.setup:
+    gather_subset:
+      - hardware
   when:
-    - root_device_name != '/dev/nvme0n1'
-    - root_device_name in item.value.pv
+    - cloud_platform_is_aws and not aws_machine_type_is_r4
+
+# Get a list of all nvme device names
+- name: Build list of nvme devices and their sizes
+  ansible.builtin.set_fact:
+    nvme_device_list: >-
+      {{
+        ansible_facts.devices |
+        dict2items |
+        selectattr('key', 'match', '^nvme[0-9]+n1$')|
+        list
+      }}
+  when:
+    - cloud_platform_is_aws and not aws_machine_type_is_r4
+
+- name: Convert ebs_id_to_device_name list to a dictionary
+  ansible.builtin.set_fact:
+    ebs_id_to_device_name_map: >-
+      {{
+        ebs_id_to_device_name
+        | map('dict2items')
+        | flatten
+        | items2dict
+      }}
+  when:
+    - cloud_platform_is_aws and not aws_machine_type_is_r4
+
+# Using data exported by terraform in ebs_id_to_device_name, create a
+# sdX -> nvmeXn1 map, based on the device serial
+- name: Build /dev/sdX to nvme device mapping for attached volumes
+  ansible.builtin.set_fact:
+    sd_to_nvme_map: "{{ sd_to_nvme_map | default({}) | combine({ device_name: '/dev/' ~ nvme_dev.key }) }}"
+  loop: "{{ nvme_device_list }}"
+  loop_control:
+    loop_var: nvme_dev
+  vars:
+    # terraform (aws) exports the serial as "vol-xxx" while the system sees it as "volxxx", so we need to omit the '-'
+    volume_id: "{{ nvme_dev.value.serial | regex_replace('^vol(?!-)', 'vol-') }}"
+    device_name: "{{ ebs_id_to_device_name_map.get(volume_id, '') }}"
+  when:
+    - cloud_platform_is_aws and not aws_machine_type_is_r4
+    - device_name != ''  # only map if the serial id exists in the exported serial ids from terraform
+
+- name: Adjust PV list for storage profile {{ item.key }}
+  ansible.builtin.set_fact:
+    adjusted_pv: >-
+      {{
+        item.value.pv
+        | map('extract', sd_to_nvme_map)
+        | list
+      }}
+  when:
+    - cloud_platform_is_aws and not aws_machine_type_is_r4
 
 - name: Physical Volume list that will be used
   ansible.builtin.debug:

--- a/terraform/aws/inventory.tmpl
+++ b/terraform/aws/inventory.tmpl
@@ -14,6 +14,10 @@ all:
           ansible_host: ${value}
           ansible_python_interpreter: ${hana_remote_python}
           hana_machinetype: ${hana_machinetype}
+          ebs_id_to_device_name:
+%{ for ebs_map_key, ebs_map_value in ebs_map[index] ~}
+          - ${ebs_map_key}: ${ebs_map_value}
+%{ endfor ~}
 %{ endfor ~}
 %{ if iscsi_enabled }
     iscsi:

--- a/terraform/aws/modules/hana_node/outputs.tf
+++ b/terraform/aws/modules/hana_node/outputs.tf
@@ -29,3 +29,13 @@ output "subnets_by_az" {
     s.availability_zone => s.id
   }
 }
+
+output "volume_id_to_device_name" {
+  value = [
+    for inst in aws_instance.hana :
+    { for bd in inst.ebs_block_device :
+      bd.volume_id => bd.device_name
+    }
+  ]
+  description = "EBS volume‑ID -> /dev/sdX"
+}

--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -117,6 +117,7 @@ resource "local_file" "ansible_inventory" {
       cluster_ip          = local.hana_cluster_vip,
       stonith_tag         = module.hana_node.stonith_tag,
       region              = var.aws_region
+      ebs_map             = module.hana_node.volume_id_to_device_name
   })
   filename = "inventory.yaml"
 }


### PR DESCRIPTION
There is a problem with the displayed device names in r5 instances. While the volumes are described and named in https://github.com/SUSE/qe-sap-deployment/blob/581256196a2c235300c15a20e85248fa55d03a52/terraform/aws/modules/hana_node/variables.tf#L95, their names are assigned on boot time as `nvmeXn1`, where X is and integer from 0 to 7.

The nvmeXn1 displayed device names in r5 instances are assigned randomly: there is no guarantee that nvme0n1 will be the root, or that nvme1n1 will be the first entry in the `hana_data_disks_configuration` (from the hana node's variables.tf). This becomes a problem, because we explicitly set roles for volumes using their nvme names [in a dedicated file ](https://github.com/SUSE/qe-sap-deployment/blob/main/ansible/playbooks/vars/aws_hana_storage_profile.yaml).

This pr exports the volume serials from terraform and uses those serials to pair the original sdX names (as defined [here](https://github.com/jankohoutek/qe-sap-deployment/blob/74b7c043be894bad3ec5415ba26e2f4c25c3f2af/terraform/aws/modules/hana_node/variables.tf#L95)) to their nvmeXn1 counterparts.

- Related ticket: https://jira.suse.com/browse/TEAM-10362
- Verification Runs:
https://openqaworker15.qa.suse.cz/tests/324508
https://openqaworker15.qa.suse.cz/tests/324417
(they fail due to timeout, unrelated to pr)
r4 instance: https://openqa.suse.de/tests/17710895 (fails diue to peering trouble which will be solved by https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/22104)
