### PR TITLE
Add retry to azure fencing configuration

### DIFF
--- a/ansible/playbooks/tasks/azure-cluster-bootstrap.yaml
+++ b/ansible/playbooks/tasks/azure-cluster-bootstrap.yaml
@@ -275,6 +275,7 @@
       pcmk_reboot_timeout=900
       pcmk_delay_max=15
       op monitor interval=3600 timeout=120
+  retries: 3  # Retry in case of transient issues on metadata endpoint
   register: __crm_cfg_fence_azure_arm_msi
   changed_when: __crm_cfg_fence_azure_arm_msi.rc == 0
   when:
@@ -299,6 +300,7 @@
       power_timeout=240
       pcmk_reboot_timeout=900
       op monitor interval=3600 timeout=120
+  retries: 3  # Retry in case of transient issues on metadata endpoint
   register: __crm_cfg_fence_azure_arm_spn
   changed_when: __crm_cfg_fence_azure_arm_spn.rc == 0
   when:


### PR DESCRIPTION
reference ticket: https://jira.suse.com/browse/TEAM-10323

when Azure metadata endpoint (default at
http://169.254.169.254/metadata/instance ) is not available, the call to retrieve fencing agent attributes may fail. We introduce a retry to cope with any transient error.

VRs:
  - http://openqaworker15.qa.suse.cz/tests/325384
  - http://openqaworker15.qa.suse.cz/tests/325385
  - http://openqaworker15.qa.suse.cz/tests/325386
  - http://openqaworker15.qa.suse.cz/tests/325387
  - http://openqaworker15.qa.suse.cz/tests/325388
  - http://openqaworker15.qa.suse.cz/tests/325389
  - http://openqaworker15.qa.suse.cz/tests/325401
  - http://openqaworker15.qa.suse.cz/tests/325402
  - http://openqaworker15.qa.suse.cz/tests/325421
  - http://openqaworker15.qa.suse.cz/tests/325422
  - http://openqaworker15.qa.suse.cz/tests/325454
  - http://openqaworker15.qa.suse.cz/tests/325483
  - http://openqaworker15.qa.suse.cz/tests/325485
  - http://openqaworker15.qa.suse.cz/tests/325486
  - http://openqaworker15.qa.suse.cz/tests/325487
  - http://openqaworker15.qa.suse.cz/tests/325493
  - http://openqaworker15.qa.suse.cz/tests/325494
  - http://openqaworker15.qa.suse.cz/tests/325495
  - http://openqaworker15.qa.suse.cz/tests/325497
  - http://openqaworker15.qa.suse.cz/tests/325498
  - http://openqaworker15.qa.suse.cz/tests/325499
  - http://openqaworker15.qa.suse.cz/tests/325500
  - http://openqaworker15.qa.suse.cz/tests/325501
  - http://openqaworker15.qa.suse.cz/tests/325502
  - http://openqaworker15.qa.suse.cz/tests/325503
  - http://openqaworker15.qa.suse.cz/tests/325504


