### PR TITLE
Increase ControlPersist for ansible ssh

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,3 @@
 [ssh_connection]
 pipelining = True
+ssh_args = -C -o ControlMaster=auto -o ControlPersist=86400s


### PR DESCRIPTION
This pr increases the `ControlPersist` ssh opt in qe-sap-deployment ansible, as a possible workarond to the `rc: -13` sporadic issue we are seeing in Azure SAPHanaSR-PerfOpt jobs.

It seems to be a problem with openssh, fixed in newer versions of the package, but we still use an older (<9) version, at least up to 15sp5.
Looking at some ansible issues that discuss the subject, like https://github.com/ansible/ansible/issues/78344 , a workaround working for some seems to be increasing the `ControlPersist` ssh option.

- Related ticket: https://jira.suse.com/browse/TEAM-10318
- Verification runs: 
https://openqa.suse.de/tests/17918592
https://openqa.suse.de/tests/17918635
https://openqa.suse.de/tests/17918637 (aws one, just to make sure)