### PR TITLE
Qesap ansible sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,23 +154,31 @@ Refer to the qe-sap-deployment Ansible documentation or `ansible/playbooks/vars/
 
 ###### Playbooks sequence
 
-The `qesap.py ... ansible` sub-command calls a sequence of playbooks execution. The sequence has to be defined in the `ansible::create` section of the config.yaml. The `ansible::destroy` sequence is used by `qesap.py ... ansible -d`
+The `qesap.py ... ansible` sub-command calls a sequence of playbooks execution.
+By default the sequence is from the `ansible::sequences::create` section of the config.yaml.
+The `ansible::sequences::destroy` sequence is used by `qesap.py ... ansible -d`
+It is also possible to request the execution of a specific sequence using
+`qesap.py ... ansible -s somethingelse`.
 
 ```yaml
+apiver: 4
 ansible:
-  create:
-    - registration.yaml -e reg_code=******* -e email_address=your@email.some
-    - pre-cluster.yaml
-    - sap-hana-preconfigure.yaml -e use_sapconf=true
-    - cluster_sbd_prep.yaml
-    - sap-hana-storage.yaml
-    - sap-hana-download-media.yaml
-    - sap-hana-install.yaml
-    - sap-hana-system-replication.yaml
-    - sap-hana-system-replication-hooks.yaml
-    - sap-hana-cluster.yaml
-  destroy:
-    - deregister.yaml
+  sequences:
+    create:
+      - registration.yaml -e reg_code=******* -e email_address=your@email.some
+      - pre-cluster.yaml
+      - sap-hana-preconfigure.yaml -e use_sapconf=true
+      - cluster_sbd_prep.yaml
+      - sap-hana-storage.yaml
+      - sap-hana-download-media.yaml
+      - sap-hana-install.yaml
+      - sap-hana-system-replication.yaml
+      - sap-hana-system-replication-hooks.yaml
+      - sap-hana-cluster.yaml
+    somethingelse:
+      - some-other-playbook.yaml
+    destroy:
+      - deregister.yaml
 ```
 
 * In case of Azure deployment using native fencing, there are additional parameters to be added for `sap-hana-cluster.yaml` playbook.
@@ -181,9 +189,15 @@ ansible:
 Terraform and Ansible deployment steps can be executed like:
 
 ```shell
+(venv) python3 scripts/qesap/qesap.py --verbose -c config.yaml -b <FOLDER_OF_YOUR_CLONED_REPO> deploy
+````
+
+That is equivalent to
+
+```shell
 (venv) python3 scripts/qesap/qesap.py --verbose -c config.yaml -b <FOLDER_OF_YOUR_CLONED_REPO> terraform
 
-(venv) python3 scripts/qesap/qesap.py --verbose -c config.yaml -b <FOLDER_OF_YOUR_CLONED_REPO> ansible
+(venv) python3 scripts/qesap/qesap.py --verbose -c config.yaml -b <FOLDER_OF_YOUR_CLONED_REPO> ansible -s create
 ```
 
 The terraform sub command has a partial support for Terraform workspace
@@ -195,6 +209,12 @@ The terraform sub command has a partial support for Terraform workspace
 #### Destroy
 
 The destruction of the infrastructure, including the de-registration of SLES, can be conducted with:
+
+```shell
+(venv) python3 scripts/qesap/qesap.py --verbose -c config.yaml -b <FOLDER_OF_YOUR_CLONED_REPO> destroy
+```
+
+That is equivalent to
 
 ```shell
 (venv) python3 scripts/qesap/qesap.py --verbose -c config.yaml -b <FOLDER_OF_YOUR_CLONED_REPO> ansible -d

--- a/scripts/qesap/qesap.py
+++ b/scripts/qesap/qesap.py
@@ -18,13 +18,13 @@ logging.basicConfig(format="%(levelname)-8s %(message)s")
 log = logging.getLogger('QESAP')
 
 
-VERSION = '0.5'
+VERSION = '1.0'
 
 DESCRIBE = '''qe-sap-deployment helper script'''
 
 
 def load_yaml(path):
-    """ argparser validator for YAML files and convert the file to a python data structure
+    """argparser validator for YAML files and convert the file to a python data structure
 
     Args:
         path (str)): path of the file to validate
@@ -38,18 +38,20 @@ def load_yaml(path):
     """
     if not os.path.isfile(path):
         # raise SystemExit
-        raise argparse.ArgumentTypeError("load_yaml:" + path + " is not a file")
+        raise argparse.ArgumentTypeError(f"load_yaml:{path} is not a file")
 
     with open(path, 'r', encoding='utf-8') as file:
         try:
             data = yaml.load(file, Loader=yaml.FullLoader)
         except (ScannerError, ParserError) as exc:
-            raise argparse.ArgumentTypeError("load_yaml:" + path + " is not a valid YAML file") from exc
+            raise argparse.ArgumentTypeError(
+                f"load_yaml:{path} is not a valid YAML file"
+            ) from exc
     return data
 
 
 def is_dir(path):
-    """ argparser validator for directory
+    """argparser validator for directory
 
     Args:
         path (str)): path to validate
@@ -63,7 +65,7 @@ def is_dir(path):
     if os.path.isdir(path):
         return path
     # raise SystemExit
-    raise argparse.ArgumentTypeError("is_dir:" + path + " is not a folder")
+    raise argparse.ArgumentTypeError(f"is_dir:{path} is not a folder")
 
 
 def cli(command_line=None):
@@ -73,17 +75,24 @@ def cli(command_line=None):
     parser = argparse.ArgumentParser(description=DESCRIBE)
 
     parser.add_argument('--version', action='version', version=VERSION)
-    parser.add_argument('--verbose', action='store_true', help="Increases log verbosity")
-    parser.add_argument('--dryrun', action='store_true', help="Dry run execution mode")
+    parser.add_argument(
+        '--verbose', action='store_true', help='Increases log verbosity'
+    )
+    parser.add_argument('--dryrun', action='store_true', help='Dry run execution mode')
 
     parser.add_argument(
-        '-c', '--config-file', dest='configdata',
+        '-c',
+        '--config-file',
+        dest='configdata',
         type=load_yaml,
         required=True,
-        help="""Input global configuration .yaml file""")
+        help="""Input global configuration .yaml file""",
+    )
 
     parser.add_argument(
-        '-b', '--base-dir', dest='basedir',
+        '-b',
+        '--base-dir',
+        dest='basedir',
         type=is_dir,
         required=True,
         help="""Base project folder, used to figure out
@@ -93,47 +102,111 @@ def cli(command_line=None):
     Files created there:
     - terraform/{CLOUDPROVIDER}/terraform.tfvars
     - ...
-    """)
+    """,
+    )
     # Sub-commands
     subparsers = parser.add_subparsers(
-        description='''List of qesap subcommands, each of them is usually associated to a specific procedure''',
-        dest='command')
+        description="""List of qesap subcommands, each of them is usually associated to a specific procedure""",
+        dest='command',
+    )
 
-    subparsers.add_parser('configure',
-                          help="""Generate all Terraform, Ansible configuration file
-                                  starting from the main global YAML configuration file""")
-    subparsers.add_parser('deploy', help="Run, in sequence, the Terraform and Ansible deployment steps")
-    subparsers.add_parser('destroy', help="Run, in sequence, the Ansible and Terraform destroy steps")
-    parser_terraform = subparsers.add_parser('terraform', help="Only run the Terraform part of the deployment")
-    parser_terraform.add_argument('-d',
-                                  '--destroy',
-                                  action='store_true',
-                                  help='Call terraform destroy')
-    parser_terraform.add_argument('-w',
-                                  '--workspace',
-                                  dest='workspace',
-                                  default='default',
-                                  help="""Workspace to use in terraform commands. Defaults to 'default'""")
-    parser_terraform.add_argument('-p',
-                                  '--parallel',
-                                  type=int,
-                                  dest='parallel',
-                                  help="""Set value for -parallelism for plan and apply""")
-    parser_ansible = subparsers.add_parser('ansible', help="Run the Ansible part of the deployment")
-    parser_ansible.add_argument('-d',
-                                '--destroy',
-                                action='store_true',
-                                help='Play ansible deregister playoooks')
+    subparsers.add_parser(
+        'configure',
+        help="""Generate all Terraform, Ansible configuration file
+                                  starting from the main global YAML configuration file""",
+    )
+    subparsers.add_parser(
+        'deploy', help="Run, in sequence, the Terraform and Ansible deployment steps"
+    )
+    subparsers.add_parser(
+        'destroy', help="Run, in sequence, the Ansible and Terraform destroy steps"
+    )
+    parser_terraform = subparsers.add_parser(
+        'terraform', help="Only run the Terraform part of the deployment"
+    )
+    parser_terraform.add_argument(
+        '-d', '--destroy', action='store_true', help='Call terraform destroy'
+    )
+    parser_terraform.add_argument(
+        '-w',
+        '--workspace',
+        dest='workspace',
+        default='default',
+        help="""Workspace to use in terraform commands. Defaults to 'default'""",
+    )
+    parser_terraform.add_argument(
+        '-p',
+        '--parallel',
+        type=int,
+        dest='parallel',
+        help="""Set value for -parallelism for plan and apply""",
+    )
+    parser_ansible = subparsers.add_parser(
+        'ansible', help="Run the Ansible part of the deployment"
+    )
+    parser_ansible.add_argument(
+        '-d',
+        '--destroy',
+        action='store_true',
+        help='Play ansible deregister playoooks. It is equivalent of ``-s deregister`',
+    )
 
-    parser_ansible.add_argument('--profile',
-                                action='store_true',
-                                help='Run Ansible with ansible.posix.profile_tasks')
+    parser_ansible.add_argument(
+        '--profile',
+        action='store_true',
+        help='Run Ansible with ansible.posix.profile_tasks',
+    )
 
-    parser_ansible.add_argument('--junit',
-                                help='Enable Ansible junit report and store it in provided folder')
+    parser_ansible.add_argument(
+        '--junit', help='Enable Ansible junit report and store it in provided folder'
+    )
+
+    parser_ansible.add_argument(
+        '-s',
+        '--sequence',
+        help='Only execute a playbook sequence from a specific Ansible `sequence` section',
+    )
 
     parsed_args = parser.parse_args(command_line)
     return parsed_args
+
+
+def run_subcommand(args):
+    """
+    Helper functio to run subcomand and return result
+    """
+    if args.command == 'configure':
+        log.info('Configuring...')
+        return cmd_configure(args.configdata, args.basedir, args.dryrun)
+    if args.command == 'deploy':
+        log.info('Deploying...')
+        return cmd_deploy(args.configdata, args.basedir, args.dryrun, args.verbose)
+    if args.command == 'destroy':
+        log.info('Destroying...')
+        return cmd_destroy(args.configdata, args.basedir, args.dryrun, args.verbose)
+    if args.command == 'terraform':
+        log.info('Running Terraform...')
+        return cmd_terraform(
+            args.configdata,
+            args.basedir,
+            args.dryrun,
+            workspace=args.workspace,
+            destroy=args.destroy,
+            parallel=args.parallel,
+        )
+    if args.command == 'ansible':
+        log.info('Running Ansible...')
+        return cmd_ansible(
+            args.configdata,
+            args.basedir,
+            args.dryrun,
+            args.verbose,
+            destroy=args.destroy,
+            profile=args.profile,
+            junit=args.junit,
+            sequence=args.sequence,
+        )
+    return Status(f"Unknown command: {args.command}")
 
 
 def main(command_line=None):  # pylint: disable=too-many-return-statements
@@ -146,7 +219,7 @@ def main(command_line=None):  # pylint: disable=too-many-return-statements
         log.setLevel(logging.getLevelName('DEBUG'))
 
     if not parsed_args.command:
-        log.debug("No command")
+        log.debug('No command')
         return 0
 
     sim_message = os.getenv('QESAP_SIM_MSG')
@@ -154,62 +227,19 @@ def main(command_line=None):  # pylint: disable=too-many-return-statements
         log.error("This is a -- %s -- simulation.", sim_message)
     sim_rc = os.getenv('QESAP_SIM_RC')
     if sim_rc:
-        res = Status(int(sim_rc))
-        return res
+        return Status(int(sim_rc))
 
-    if parsed_args.command == "configure":
-        log.info("Configuring...")
-        res = cmd_configure(
-            parsed_args.configdata,
-            parsed_args.basedir,
-            parsed_args.dryrun
-        )
-    elif parsed_args.command == "deploy":
-        log.info("Deploying...")
-        res = cmd_deploy(
-            parsed_args.configdata,
-            parsed_args.basedir,
-            parsed_args.dryrun,
-            parsed_args.verbose
-        )
-    elif parsed_args.command == "destroy":
-        log.info("Destroying...")
-        res = cmd_destroy(
-            parsed_args.configdata,
-            parsed_args.basedir,
-            parsed_args.dryrun,
-            parsed_args.verbose
-        )
-    elif parsed_args.command == "terraform":
-        log.info("Running Terraform...")
-        res = cmd_terraform(
-            parsed_args.configdata,
-            parsed_args.basedir,
-            parsed_args.dryrun,
-            workspace=parsed_args.workspace,
-            destroy=parsed_args.destroy,
-            parallel=parsed_args.parallel
-        )
-        if res != 0:
-            print(res.msg)  # should we use file=sys.stderr here?
-        return res
-    elif parsed_args.command == "ansible":
-        log.info("Running Ansible...")
-        res = cmd_ansible(
-            parsed_args.configdata,
-            parsed_args.basedir,
-            parsed_args.dryrun,
-            parsed_args.verbose,
-            destroy=parsed_args.destroy,
-            profile=parsed_args.profile,
-            junit=parsed_args.junit
-        )
-    else:
-        res = Status(f"Unknown command: {parsed_args.command}")
+    if (
+        parsed_args.command == 'ansible'
+        and parsed_args.destroy
+        and parsed_args.sequence
+    ):
+        log.error('Ansible subcommand do not support --sequence and -d at same time.')
+        return Status(1)
 
+    res = run_subcommand(parsed_args)
     if res != 0:
         log.error(res.msg)
-
     return res
 
 

--- a/scripts/qesap/test/conftest.py
+++ b/scripts/qesap/test/conftest.py
@@ -175,9 +175,9 @@ def create_playbooks(playbooks_dir):
 
 @pytest.fixture
 def ansible_config():
-    def _callback(provider, playbooks):
+    def _callback(provider, playbooks, apiver=3):
         config_content = f"""---
-apiver: 3
+apiver: {apiver}
 provider: {provider}
 ansible:
     az_container_name: pippo
@@ -186,11 +186,17 @@ ansible:
     hana_media:
     - pippo"""
 
-        for seq in ["create", "destroy"]:
-            if seq in playbooks:
+        if apiver < 4:
+            for seq in playbooks:
                 config_content += f"\n    {seq}:"
                 for play in playbooks[seq]:
                     config_content += f"\n        - {play}.yaml"
+        else:
+            config_content += "\n    sequences:"
+            for seq in playbooks:
+                config_content += f"\n        {seq}:"
+                for play in playbooks[seq]:
+                    config_content += f"\n            - {play}.yaml"
         return config_content
 
     return _callback

--- a/scripts/qesap/test/e2e/test_9.yaml
+++ b/scripts/qesap/test/e2e/test_9.yaml
@@ -1,0 +1,29 @@
+---
+apiver: 4
+provider: fragola
+terraform:
+  variables:
+    fruit: lampone
+ansible:
+  hana_media:
+    - mora
+    - corniolo
+  az_storage_account_name: ribes
+  az_container_name: uvaspina
+  az_key_name: '***'
+  hana_vars:
+    juice: mirtillo
+    sap_hana_install_software_directory: /a
+    sap_hana_install_master_password: ''
+    sap_hana_install_sid: 'ABC'
+    sap_hana_install_instance_number: '42'
+    sap_domain: 123
+    primary_site: 456
+    secondary_site: 789
+  sequences:
+    create:
+      - goji.yaml
+    test:
+      - test.yaml
+    destroy:
+      - ribes_nero.yaml

--- a/scripts/qesap/test/unit/test_hy_conf.py
+++ b/scripts/qesap/test/unit/test_hy_conf.py
@@ -1,12 +1,14 @@
 import os
 import pytest
-from hypothesis import given
+from hypothesis import given, example
 from hypothesis.strategies import dictionaries, text
 from lib.config import CONF
 
 
 @pytest.mark.skipif("FUZZYTEST" not in os.environ, reason="Fuzzy test disabled by default")
-@given(dictionaries(text(), text()))
+@example({})
+@example({'apiver': '3', 'terraform': ''})
+@given(dictionaries(text(), text()).filter(lambda x: 'ansible' not in x))
 def test_conf_has_not_ansible(conf_dict):
     conf = CONF(conf_dict)
     assert conf.has_ansible() is False


### PR DESCRIPTION
Add --sequence to ansible subcommand
Propose a new conf.yaml structure under apiver:4, the new structure move all the sequences of playbooks:
- from `ansible::create` and `ansible:destroy`
- to a dedicated key `ansible::sequences::create` and `ansible::sequences::destroy`.

There's an example in the README

This allow to add more than these two sequences of playbooks and give them a name (e.g.  ansible::sequences::something).

Also add an argument to the ansible subcommand of the glue script to allow which sequence of playbooks to run
  `qesap.py ... ansible --sequence something`

# Verification

## Using existing apiver:3 OSADO conf.yaml
sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_angi_test
- http://openqaworker15.qa.suse.cz/tests/328271 :green_circle: 

sle-15-SP6-HanaSr-Aws-Payg-x86_64-Build15-SP6_2025-06-05T02:03:19Z-hanasr_aws_test_peering ec2_r4.8xlarge 
- http://openqaworker15.qa.suse.cz/tests/328274 :green_circle: 

## Using conf.yaml with apiver:4
sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_angi_test
- http://openqaworker15.qa.suse.cz/tests/328279 :green_circle: 
