### PR TITLE
Add optional priority argument to ibsm

### DIFF
--- a/ansible/playbooks/ibsm.yaml
+++ b/ansible/playbooks/ibsm.yaml
@@ -30,6 +30,7 @@
         name: "TEST_{{ repo_id }}"
         disable_gpg_check: true
         autorefresh: true
+        priority: "{{ priority | default(omit) }}"
       loop: "{{ repos.split(',') }}"
       loop_control:
         index_var: repo_id


### PR DESCRIPTION
Add an optional argument to the playbook about IBS Mirror. If configured it allows to specify a priority when adding a repo to the zypper list.

This mimics https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/19658

Ticket: https://jira.suse.com/browse/TEAM-9887

# Verification
 sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_ibsmirror_peering_test

 -  http://openqaworker15.qa.suse.cz/tests/328264 :green_circle: this executions is using the changed playbook but it is without repos http://openqaworker15.qa.suse.cz/tests/328264/logfile?filename=serial_terminal.txt#line-4127
 - http://openqaworker15.qa.suse.cz/tests/328273 this has one repos but no priority


