### PR TITLE
GCE: remove unnecessary disk "hana-software"

### DIFF
--- a/ansible/playbooks/vars/gcp_hana_storage_profile.yaml
+++ b/ansible/playbooks/vars/gcp_hana_storage_profile.yaml
@@ -41,11 +41,3 @@ sap_storage_dict:
     pv: ["/dev/disk/by-id/google-{{ prefix }}-hana-backup"]
     numluns: '1'
     stripesize: ''
-  install:
-    name: 'install'
-    directory: '/hana/install'
-    vg: 'installvg'
-    lv: 'installlv'
-    pv: ["/dev/disk/by-id/google-{{ prefix }}-hana-software"]
-    numluns: '1'
-    stripesize: ''

--- a/terraform/gcp/modules/hana_node/main.tf
+++ b/terraform/gcp/modules/hana_node/main.tf
@@ -49,14 +49,6 @@ resource "google_compute_disk" "usr_sap" {
   zone  = element(var.compute_zones, count.index)
 }
 
-resource "google_compute_disk" "hana-software" {
-  count = var.hana_count
-  name  = "${var.common_variables["deployment_name"]}-hana-software"
-  type  = "pd-standard"
-  size  = "20"
-  zone  = element(var.compute_zones, count.index)
-}
-
 # Don't remove the routes! Even though the RA gcp-vpc-move-route creates them, if they are not created here, the terraform destroy cannot work as it will find new route names
 resource "google_compute_route" "hana-route" {
   name                   = "${var.common_variables["deployment_name"]}-hana-route"
@@ -178,12 +170,6 @@ resource "google_compute_instance" "clusternodes" {
   attached_disk {
     source      = element(google_compute_disk.usr_sap.*.self_link, count.index)
     device_name = element(google_compute_disk.usr_sap.*.name, count.index)
-    mode        = "READ_WRITE"
-  }
-
-  attached_disk {
-    source      = element(google_compute_disk.hana-software.*.self_link, count.index)
-    device_name = element(google_compute_disk.hana-software.*.name, count.index)
     mode        = "READ_WRITE"
   }
 


### PR DESCRIPTION
The `hana-software` disk which mounts to directory `/hana/install`, this disk is unnecessary because it is only used temporarily during installation of HANA, and this disk is not used in other cloud configurations.

https://jira.suse.com/browse/TEAM-10265
VR: https://openqaworker15.qa.suse.cz/tests/328372