### PR TITLE
Remove not needed AWS terraform variables

### DIFF
--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -59,25 +59,9 @@ For detailed information and deployment options have a look at `terraform.tfvars
 
     * AWS credentials
 
-    There are 2 ways of using the AWS credentials. Using the access key id and
-    the secret access key or using an already existing credentials file,
-    being both options self exclusive (the first option has preference).
-
-    To use the first option basically set the values `aws_access_key_id` and
-    `aws_secret_access_key` in the `terraform.tfvars`.
-
-    To use the credentials file, configure the values for the access key and
-    the secret key in a credentials file located in `$HOME/.aws/credentials`.
-    The syntax of the file is:
-
-    ``` shell
-    [default]
-    aws_access_key_id = <HERE_GOES_THE_ACCESS_KEY>
-    aws_secret_access_key = <HERE_GOES_THE_SECRET_KEY>
-    ```
-
-    This file is also used by the `aws` command line tool, so it can be created
-    with the command: `aws configure`.
+    Refer to terraform AWS provider documentation.
+    Same configuration needed to use `aws` command line tool applies to terraform too.
+    So it can be created with the command: `aws configure`.
 
     **Note**: All tests so far with this configuration have been done with only the keys stored in the credentials files, and the region being passed as a variable.
 

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -99,79 +99,70 @@ module "common_variables" {
 }
 
 module "drbd_node" {
-  source                = "./modules/drbd_node"
-  common_variables      = module.common_variables.configuration
-  name                  = var.drbd_name
-  network_domain        = var.drbd_network_domain == "" ? var.network_domain : var.drbd_network_domain
-  drbd_count            = var.drbd_enabled == true ? 2 : 0
-  vm_size               = var.drbd_instancetype
-  availability_zones    = data.aws_availability_zones.available.names
-  os_image              = local.drbd_os_image
-  os_owner              = local.drbd_os_owner
-  vpc_id                = local.vpc_id
-  subnet_address_range  = local.drbd_subnet_address_range
-  key_name              = aws_key_pair.key-pair.key_name
-  security_group_id     = local.security_group_id
-  route_table_id        = aws_route_table.route-table.id
-  aws_credentials       = var.aws_credentials
-  aws_access_key_id     = var.aws_access_key_id
-  aws_secret_access_key = var.aws_secret_access_key
-  host_ips              = local.drbd_ips
-  drbd_data_disk_size   = var.drbd_data_disk_size
-  drbd_data_disk_type   = var.drbd_data_disk_type
-  iscsi_srv_ip          = join("", module.iscsi_server.iscsisrv_ip)
-  nfs_mounting_point    = var.drbd_nfs_mounting_point
-  nfs_export_name       = var.netweaver_sid
+  source               = "./modules/drbd_node"
+  common_variables     = module.common_variables.configuration
+  name                 = var.drbd_name
+  network_domain       = var.drbd_network_domain == "" ? var.network_domain : var.drbd_network_domain
+  drbd_count           = var.drbd_enabled == true ? 2 : 0
+  vm_size              = var.drbd_instancetype
+  availability_zones   = data.aws_availability_zones.available.names
+  os_image             = local.drbd_os_image
+  os_owner             = local.drbd_os_owner
+  vpc_id               = local.vpc_id
+  subnet_address_range = local.drbd_subnet_address_range
+  key_name             = aws_key_pair.key-pair.key_name
+  security_group_id    = local.security_group_id
+  route_table_id       = aws_route_table.route-table.id
+  host_ips             = local.drbd_ips
+  drbd_data_disk_size  = var.drbd_data_disk_size
+  drbd_data_disk_type  = var.drbd_data_disk_type
+  iscsi_srv_ip         = join("", module.iscsi_server.iscsisrv_ip)
+  nfs_mounting_point   = var.drbd_nfs_mounting_point
+  nfs_export_name      = var.netweaver_sid
 }
 
 module "netweaver_node" {
-  source                = "./modules/netweaver_node"
-  common_variables      = module.common_variables.configuration
-  name                  = var.netweaver_name
-  network_domain        = var.netweaver_network_domain == "" ? var.network_domain : var.netweaver_network_domain
-  xscs_server_count     = local.netweaver_xscs_server_count
-  app_server_count      = var.netweaver_enabled ? var.netweaver_app_server_count : 0
-  vm_size               = var.netweaver_instancetype
-  availability_zones    = data.aws_availability_zones.available.names
-  os_image              = local.netweaver_os_image
-  os_owner              = local.netweaver_os_owner
-  vpc_id                = local.vpc_id
-  subnet_address_range  = local.netweaver_subnet_address_range
-  key_name              = aws_key_pair.key-pair.key_name
-  security_group_id     = local.security_group_id
-  route_table_id        = aws_route_table.route-table.id
-  efs_performance_mode  = var.netweaver_efs_performance_mode
-  aws_credentials       = var.aws_credentials
-  aws_access_key_id     = var.aws_access_key_id
-  aws_secret_access_key = var.aws_secret_access_key
-  s3_bucket             = var.netweaver_s3_bucket
-  host_ips              = local.netweaver_ips
-  virtual_host_ips      = local.netweaver_virtual_ips
-  iscsi_srv_ip          = join("", module.iscsi_server.iscsisrv_ip)
+  source               = "./modules/netweaver_node"
+  common_variables     = module.common_variables.configuration
+  name                 = var.netweaver_name
+  network_domain       = var.netweaver_network_domain == "" ? var.network_domain : var.netweaver_network_domain
+  xscs_server_count    = local.netweaver_xscs_server_count
+  app_server_count     = var.netweaver_enabled ? var.netweaver_app_server_count : 0
+  vm_size              = var.netweaver_instancetype
+  availability_zones   = data.aws_availability_zones.available.names
+  os_image             = local.netweaver_os_image
+  os_owner             = local.netweaver_os_owner
+  vpc_id               = local.vpc_id
+  subnet_address_range = local.netweaver_subnet_address_range
+  key_name             = aws_key_pair.key-pair.key_name
+  security_group_id    = local.security_group_id
+  route_table_id       = aws_route_table.route-table.id
+  efs_performance_mode = var.netweaver_efs_performance_mode
+  s3_bucket            = var.netweaver_s3_bucket
+  host_ips             = local.netweaver_ips
+  virtual_host_ips     = local.netweaver_virtual_ips
+  iscsi_srv_ip         = join("", module.iscsi_server.iscsisrv_ip)
 }
 
 module "hana_node" {
-  source                = "./modules/hana_node"
-  common_variables      = module.common_variables.configuration
-  name                  = var.hana_name
-  network_domain        = var.hana_network_domain == "" ? var.network_domain : var.hana_network_domain
-  hana_count            = var.hana_count
-  vm_size               = var.hana_instancetype
-  availability_zones    = data.aws_availability_zones.available.names
-  os_image              = local.hana_os_image
-  os_owner              = local.hana_os_owner
-  vpc_id                = local.vpc_id
-  subnet_address_range  = local.hana_subnet_address_range
-  key_name              = aws_key_pair.key-pair.key_name
-  security_group_id     = local.security_group_id
-  route_table_id        = aws_route_table.route-table.id
-  aws_credentials       = var.aws_credentials
-  aws_access_key_id     = var.aws_access_key_id
-  aws_secret_access_key = var.aws_secret_access_key
-  host_ips              = local.hana_ips
-  hana_data_disk_type   = var.hana_data_disk_type
-  hana_data_disk_size   = var.hana_data_disk_size
-  iscsi_srv_ip          = join("", module.iscsi_server.iscsisrv_ip)
+  source               = "./modules/hana_node"
+  common_variables     = module.common_variables.configuration
+  name                 = var.hana_name
+  network_domain       = var.hana_network_domain == "" ? var.network_domain : var.hana_network_domain
+  hana_count           = var.hana_count
+  vm_size              = var.hana_instancetype
+  availability_zones   = data.aws_availability_zones.available.names
+  os_image             = local.hana_os_image
+  os_owner             = local.hana_os_owner
+  vpc_id               = local.vpc_id
+  subnet_address_range = local.hana_subnet_address_range
+  key_name             = aws_key_pair.key-pair.key_name
+  security_group_id    = local.security_group_id
+  route_table_id       = aws_route_table.route-table.id
+  host_ips             = local.hana_ips
+  hana_data_disk_type  = var.hana_data_disk_type
+  hana_data_disk_size  = var.hana_data_disk_size
+  iscsi_srv_ip         = join("", module.iscsi_server.iscsisrv_ip)
 }
 
 module "monitoring" {

--- a/terraform/aws/modules/drbd_node/variables.tf
+++ b/terraform/aws/modules/drbd_node/variables.tf
@@ -63,20 +63,6 @@ variable "route_table_id" {
   type        = string
 }
 
-variable "aws_credentials" {
-  description = "AWS credentials file path in local machine"
-  type        = string
-  default     = "~/.aws/credentials"
-}
-
-variable "aws_access_key_id" {
-  type = string
-}
-
-variable "aws_secret_access_key" {
-  type = string
-}
-
 variable "host_ips" {
   description = "ip addresses to set to the nodes"
   type        = list(string)

--- a/terraform/aws/modules/hana_node/variables.tf
+++ b/terraform/aws/modules/hana_node/variables.tf
@@ -63,20 +63,6 @@ variable "route_table_id" {
   type        = string
 }
 
-variable "aws_credentials" {
-  description = "AWS credentials file path in local machine"
-  type        = string
-  default     = "~/.aws/credentials"
-}
-
-variable "aws_access_key_id" {
-  type = string
-}
-
-variable "aws_secret_access_key" {
-  type = string
-}
-
 variable "host_ips" {
   description = "ip addresses to set to the nodes. The first ip must be in 10.0.0.0/24 subnet and the second in 10.0.1.0/24 subnet"
   type        = list(string)

--- a/terraform/aws/modules/netweaver_node/variables.tf
+++ b/terraform/aws/modules/netweaver_node/variables.tf
@@ -74,20 +74,6 @@ variable "efs_performance_mode" {
   default     = "generalPurpose"
 }
 
-variable "aws_credentials" {
-  description = "AWS credentials file path in local machine"
-  type        = string
-  default     = "~/.aws/credentials"
-}
-
-variable "aws_access_key_id" {
-  type = string
-}
-
-variable "aws_secret_access_key" {
-  type = string
-}
-
 variable "s3_bucket" {
   description = "S3 bucket where Netwaever installation files are stored"
   type        = string

--- a/terraform/aws/terraform.tfvars.example
+++ b/terraform/aws/terraform.tfvars.example
@@ -32,13 +32,6 @@ deployment_name = "mydeployment"
 # Add the "deployment_name" as a prefix to the hostname.
 #deployment_name_in_hostname = true
 
-# aws-cli credentials data
-# access keys parameters have preference over the credentials file (they are self exclusive)
-#aws_access_key_id = my-access-key-id
-#aws_secret_access_key = my-secret-access-key
-# aws-cli credentials file. Located on ~/.aws/credentials on Linux, MacOS or Unix or at C:\Users\USERNAME\.aws\credentials on Windows
-#aws_credentials = "~/.aws/credentials"
-
 # Default os_image and os_owner. These values are not used if the specific values are set (e.g.: hana_os_image)
 # BYOS example with sles4sap 15 sp3 (this value is a pattern, it will select the latest version that matches this name)
 #os_image = "suse-sles-sap-15-sp3-byos"

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -5,24 +5,6 @@ variable "aws_region" {
   type        = string
 }
 
-variable "aws_access_key_id" {
-  description = "AWS access key id"
-  type        = string
-  default     = ""
-}
-
-variable "aws_secret_access_key" {
-  description = "AWS secret access key"
-  type        = string
-  default     = ""
-}
-
-variable "aws_credentials" {
-  description = "AWS credentials file path in local machine. This file will be used it `aws_access_key_id` and `aws_secret_access_key` are not provided"
-  type        = string
-  default     = "~/.aws/credentials"
-}
-
 variable "vpc_id" {
   description = "Id of a currently existing vpc to use in the deployment. It must have an internet gateway attached. If not provided a new one will be created."
   type        = string


### PR DESCRIPTION
Remove terraform variable about AWS credentials. Terraform needs some credentials to work but they are not provided via terraform variables. This commit remove not used terraform variables.

Ticket: https://jira.suse.com/browse/TEAM-10407

# Verification
 - sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6_BYOS-qesap_aws_angi_test@64bit -> http://openqaworker15.qa.suse.cz/tests/328415 :green_circle: 