### PR TITLE
Add initial testing files

### DIFF
--- a/ansible/playbooks/filter_plugins/sbd.py
+++ b/ansible/playbooks/filter_plugins/sbd.py
@@ -1,0 +1,18 @@
+def calc_sbd_delay(params):
+    sbd_delay_start = str(params.get('sbd_delay_start', 'yes'))
+
+    if sbd_delay_start in ('no', '0'):
+        return 0
+    if sbd_delay_start.isdigit():
+        return int(sbd_delay_start)
+
+    return (
+        int(params.get('corosync_token', 0)) +
+        int(params.get('corosync_consensus', 0)) +
+        int(params.get('pcmk_delay_max', 30)) +
+        int(params.get('sbd_watchdog_timeout', 30)) * 2
+    )
+
+class FilterModule(object):
+    def filters(self):
+        return {'calc_sbd_delay': calc_sbd_delay}

--- a/ansible/playbooks/hana_prevalidate.yaml
+++ b/ansible/playbooks/hana_prevalidate.yaml
@@ -1,0 +1,7 @@
+---
+- name: SAP HANA site failure test
+  hosts: "{{ node_name | default('no_host_provided')}}"
+  gather_facts: false
+  remote_user: cloudadmin
+  roles:
+    - hana_prevalidate

--- a/ansible/playbooks/hana_sr_takeover.yaml
+++ b/ansible/playbooks/hana_sr_takeover.yaml
@@ -1,0 +1,25 @@
+---
+- name: SAP HANA takeover – disruptive node
+  hosts: "{{ node_name | default('no_host_provided')}}"
+  gather_facts: false
+  remote_user: cloudadmin
+  vars_files:
+    - "{{ playbook_dir }}/vars/test_vars.yaml"
+    - "{{ playbook_dir }}/vars/hana_vars.yaml"
+  vars:
+    peer_site: "{{ (groups['hana'] | difference([node_name]))[0] }}"
+  roles:
+    - hana_actions
+
+- name: SAP HANA takeover – cluster validation
+  hosts: hana
+  gather_facts: false
+  remote_user: cloudadmin
+  serial: 1
+  vars_files:
+    - "{{ playbook_dir }}/vars/test_vars.yaml"
+    - "{{ playbook_dir }}/vars/hana_vars.yaml"
+  vars:
+    peer_site: "{{ (groups['hana'] | difference([node_name]))[0] }}"
+  roles:
+    - hana_checks

--- a/ansible/playbooks/hana_sr_test_secondary.yaml
+++ b/ansible/playbooks/hana_sr_test_secondary.yaml
@@ -1,0 +1,12 @@
+---
+- name: SAP HANA secondary-site failure test
+  hosts: "{{ node_name | default('no_host_provided')}}"
+  gather_facts: false
+  remote_user: cloudadmin
+  vars_files:
+    - "{{ playbook_dir }}/vars/test_vars.yaml"
+    - "{{ playbook_dir }}/vars/hana_vars.yaml"
+  vars:
+    peer_site: "{{ (groups['hana'] | difference([node_name]))[0] }}"
+  roles:
+    - hana_secondary_actions

--- a/ansible/playbooks/roles/hana_actions/tasks/main.yml
+++ b/ansible/playbooks/roles/hana_actions/tasks/main.yml
@@ -1,0 +1,179 @@
+---
+- name: Prepare HANA Action - Dump cluster status (crm status)
+  ansible.builtin.command: crm status
+  become: true
+  register: crm_initial
+  changed_when: false
+
+- name: Prepare HANA Action - Assert this node is currently MASTER
+  ansible.builtin.assert:
+    that:
+      - crm_initial.stdout is search('\* Masters:\s*\[\s*{{ inventory_hostname }}\s*\]')
+    fail_msg: "{{ inventory_hostname }} is NOT the master node – aborting test"
+    success_msg: "{{ inventory_hostname }} is the master node"
+
+- name: Prepare HANA Action - Wait cluster idle
+  ansible.builtin.command: cs_wait_for_idle --sleep 5
+  register: idle
+  retries: "{{ cs_wait_timeout // 5 }}"
+  delay: 5
+  become: true
+  changed_when: false
+  until: idle.rc == 0
+
+# SBD related stuff
+- name: Prepare HANA Action - Configure SBD start-delay
+  become: true
+  ansible.builtin.lineinfile:
+    path: /etc/sysconfig/sbd
+    regexp: '^SBD_DELAY_START='
+    line: "SBD_DELAY_START={{ sbd_delay_start | default('yes') }}"
+  when: action == 'crash' or (action == 'stop' and cloud_platform_name == 'EC2')
+
+- name: Prepare HANA Action - Gather SBD-delay parameters   # noqa: command-instead-of-shell the command variable actually reuires shell
+  become: true
+  ansible.builtin.shell: "{{ item.cmd }}"
+  args:
+    warn: false
+  register: sbddelay
+  changed_when: false
+  failed_when: false
+  loop:
+    - name: corosync_token
+      cmd: "corosync-cmapctl | awk -F ' = ' '/totem.token/ {print int($2/1000)}'"
+    - name: corosync_consensus
+      cmd: "corosync-cmapctl | awk -F ' = ' '/totem.consensus/ {print int($2/1000)}'"
+    - name: pcmk_delay_max
+      cmd: "crm resource param stonith-sbd show pcmk_delay_max | sed 's/[^0-9]*//g'"
+    - name: sbd_watchdog_timeout
+      cmd: "grep -oP '(?<=^SBD_WATCHDOG_TIMEOUT=)[[:digit:]]+' /etc/sysconfig/sbd"
+    - name: sbd_delay_start
+      cmd: "grep -oP '(?<=^SBD_DELAY_START=)([[:digit:]]+|yes|no)+' /etc/sysconfig/sbd"
+  when: action == 'crash' or (action == 'stop' and cloud_platform_name == 'EC2')
+
+- name: Prepare HANA Action - Set SBD delay facts
+  ansible.builtin.set_fact:
+    corosync_token: "{{ sbddelay.results | selectattr('item.name','==','corosync_token')       | map(attribute='stdout') | first | int }}"
+    corosync_consensus: "{{ sbddelay.results | selectattr('item.name','==','corosync_consensus')   | map(attribute='stdout') | first | int }}"
+    pcmk_delay_max: "{{ sbddelay.results | selectattr('item.name','==','pcmk_delay_max')       | map(attribute='stdout') | first | int }}"
+    sbd_watchdog_timeout: "{{ sbddelay.results | selectattr('item.name','==','sbd_watchdog_timeout') | map(attribute='stdout') | first | int }}"
+    sbd_delay_start: "{{ sbddelay.results | selectattr('item.name','==','sbd_delay_start')      | map(attribute='stdout') | first | default('yes') }}"
+  when: action == 'crash' or (action == 'stop' and cloud_platform_name == 'EC2')
+
+- name: Prepare HANA Action - Configure SBD start-delay
+  become: true
+  ansible.builtin.lineinfile:
+    path: /etc/sysconfig/sbd
+    regexp: '^SBD_DELAY_START='
+    line: "SBD_DELAY_START={{ sbd_delay_start }}"
+  when: action == 'crash' or (action == 'stop' and cloud_platform_name == 'EC2')
+
+- name: Prepare HANA Action - Create systemd drop-in for SBD timeout
+  become: true
+  ansible.builtin.file:
+    path: /etc/systemd/system/sbd.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+  when: action == 'crash' or (action == 'stop' and cloud_platform_name == 'EC2')
+
+- name: Prepare HANA Action - Write SBD timeout.conf
+  become: true
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/sbd.service.d/timeout.conf
+    owner: root
+    group: root
+    mode: '0644'
+    content: |
+      [Service]
+      TimeoutSec={{ {
+        'corosync_token'      : corosync_token,
+        'corosync_consensus'  : corosync_consensus,
+        'pcmk_delay_max'      : pcmk_delay_max,
+        'sbd_watchdog_timeout': sbd_watchdog_timeout,
+        'sbd_delay_start'     : sbd_delay_start
+      } | calc_sbd_delay + 30 }}
+  when: action == 'crash' or (action == 'stop' and cloud_platform_name == 'EC2')
+
+# HANA action (stop/kill/crash)
+- name: HANA Action - Stop    # noqa: command-instead-of-shell the command variable actually reuires shell
+  ansible.builtin.shell: "sudo -iu {{ sap_sidadm }} HDB stop"
+  become: true
+  when: action == 'stop'
+  changed_when: true
+
+- name: HANA Action - Kill    # noqa: command-instead-of-shell the command variable actually reuires shell
+  ansible.builtin.shell: "sudo -iu {{ sap_sidadm }} HDB kill -x"
+  become: true
+  when: action == 'kill'
+  changed_when: true
+
+- name: HANA Action - Crash
+  become: true
+  ansible.builtin.shell: echo b > /proc/sysrq-trigger
+  async: 1
+  poll: 0
+  when: action == 'crash'
+  changed_when: true
+
+# Post hana action
+- name: Post HANA Action - Wait SSH back (stop/crash)
+  ansible.builtin.wait_for_connection:
+    delay: 15
+    timeout: 900
+  when: action in ['crash','stop']
+
+- name: Post HANA Action - Pause for calculated SBD delay + 30s
+  ansible.builtin.pause:
+    seconds: "{{ {
+      'corosync_token'      : corosync_token,
+      'corosync_consensus'  : corosync_consensus,
+      'pcmk_delay_max'      : pcmk_delay_max,
+      'sbd_watchdog_timeout': sbd_watchdog_timeout,
+      'sbd_delay_start'     : sbd_delay_start
+    } | calc_sbd_delay + 30 }}"
+  changed_when: false
+  when: action == 'crash' or (action == 'stop' and cloud_platform_name == 'EC2')
+
+- name: Post HANA Action - Wait for Pacemaker to be active    # noqa: command-instead-of-module - we keep systemctl to mimic openqa behaviour
+  become: true
+  ansible.builtin.command: systemctl --no-pager is-active pacemaker
+  register: pm
+  retries: "{{ pacemaker_timeout // 15 }}"
+  delay: 15
+  until: pm.stdout == 'active'
+  changed_when: false
+  when: action == 'crash' or (action == 'stop' and cloud_platform_name == 'EC2')
+
+- name: Post HANA Action - Re-enable system replication
+  ansible.builtin.shell: |
+    sudo -iu {{ sap_sidadm }} \
+      hdbnsutil -sr_register \
+      --online \
+      --name={{ site_name }} \
+      --remoteHost={{ peer_site }} \
+      --remoteInstance={{ sap_hana_install_instance_number }} \
+      --replicationMode=sync \
+      --operationMode=logreplay
+  register: reg
+  retries: 6
+  delay: 10
+  until: reg.rc == 0
+  failed_when: reg.rc != 0
+  changed_when: true
+  become: false
+
+- name: Post HANA Action - crm cleanup (start resources)
+  become: true
+  changed_when: true
+  ansible.builtin.command: crm resource cleanup
+
+- name: Post HANA Action - Wait cluster idle after cleanup
+  become: true
+  ansible.builtin.command: cs_wait_for_idle --sleep 5
+  register: settle
+  retries: "{{ cluster_settle_retries }}"
+  delay: "{{ cluster_settle_delay }}"
+  changed_when: false
+  until: settle.rc == 0

--- a/ansible/playbooks/roles/hana_actions/tasks/main.yml
+++ b/ansible/playbooks/roles/hana_actions/tasks/main.yml
@@ -26,11 +26,11 @@
   become: true
   ansible.builtin.lineinfile:
     path: /etc/sysconfig/sbd
-    regexp: '^SBD_DELAY_START='
+    regexp: "^SBD_DELAY_START="
     line: "SBD_DELAY_START={{ sbd_delay_start | default('yes') }}"
   when: action == 'crash' or (action == 'stop' and cloud_platform_name == 'EC2')
 
-- name: Prepare HANA Action - Gather SBD-delay parameters   # noqa: command-instead-of-shell the command variable actually reuires shell
+- name: Prepare HANA Action - Gather SBD-delay parameters # noqa: command-instead-of-shell the command variable actually reuires shell
   become: true
   ansible.builtin.shell: "{{ item.cmd }}"
   args:
@@ -53,18 +53,18 @@
 
 - name: Prepare HANA Action - Set SBD delay facts
   ansible.builtin.set_fact:
-    corosync_token: "{{ sbddelay.results | selectattr('item.name','==','corosync_token')       | map(attribute='stdout') | first | int }}"
-    corosync_consensus: "{{ sbddelay.results | selectattr('item.name','==','corosync_consensus')   | map(attribute='stdout') | first | int }}"
-    pcmk_delay_max: "{{ sbddelay.results | selectattr('item.name','==','pcmk_delay_max')       | map(attribute='stdout') | first | int }}"
-    sbd_watchdog_timeout: "{{ sbddelay.results | selectattr('item.name','==','sbd_watchdog_timeout') | map(attribute='stdout') | first | int }}"
-    sbd_delay_start: "{{ sbddelay.results | selectattr('item.name','==','sbd_delay_start')      | map(attribute='stdout') | first | default('yes') }}"
+    corosync_token: "{{ sbddelay.results | selectattr('item.name', '==', 'corosync_token') | map(attribute='stdout') | first | int }}"
+    corosync_consensus: "{{ sbddelay.results | selectattr('item.name', '==', 'corosync_consensus') | map(attribute='stdout') | first | int }}"
+    pcmk_delay_max: "{{ sbddelay.results | selectattr('item.name', '==', 'pcmk_delay_max') | map(attribute='stdout') | first | int }}"
+    sbd_watchdog_timeout: "{{ sbddelay.results | selectattr('item.name', '==', 'sbd_watchdog_timeout') | map(attribute='stdout') | first | int }}"
+    sbd_delay_start: "{{ sbddelay.results | selectattr('item.name', '==', 'sbd_delay_start') | map(attribute='stdout') | first | default('yes') }}"
   when: action == 'crash' or (action == 'stop' and cloud_platform_name == 'EC2')
 
 - name: Prepare HANA Action - Configure SBD start-delay
   become: true
   ansible.builtin.lineinfile:
     path: /etc/sysconfig/sbd
-    regexp: '^SBD_DELAY_START='
+    regexp: "^SBD_DELAY_START="
     line: "SBD_DELAY_START={{ sbd_delay_start }}"
   when: action == 'crash' or (action == 'stop' and cloud_platform_name == 'EC2')
 
@@ -75,7 +75,7 @@
     state: directory
     owner: root
     group: root
-    mode: '0755'
+    mode: "0755"
   when: action == 'crash' or (action == 'stop' and cloud_platform_name == 'EC2')
 
 - name: Prepare HANA Action - Write SBD timeout.conf
@@ -84,7 +84,7 @@
     dest: /etc/systemd/system/sbd.service.d/timeout.conf
     owner: root
     group: root
-    mode: '0644'
+    mode: "0644"
     content: |
       [Service]
       TimeoutSec={{ {
@@ -97,13 +97,13 @@
   when: action == 'crash' or (action == 'stop' and cloud_platform_name == 'EC2')
 
 # HANA action (stop/kill/crash)
-- name: HANA Action - Stop    # noqa: command-instead-of-shell the command variable actually reuires shell
+- name: HANA Action - Stop # noqa: command-instead-of-shell the command variable actually reuires shell
   ansible.builtin.shell: "sudo -iu {{ sap_sidadm }} HDB stop"
   become: true
   when: action == 'stop'
   changed_when: true
 
-- name: HANA Action - Kill    # noqa: command-instead-of-shell the command variable actually reuires shell
+- name: HANA Action - Kill # noqa: command-instead-of-shell the command variable actually reuires shell
   ansible.builtin.shell: "sudo -iu {{ sap_sidadm }} HDB kill -x"
   become: true
   when: action == 'kill'
@@ -126,17 +126,12 @@
 
 - name: Post HANA Action - Pause for calculated SBD delay + 30s
   ansible.builtin.pause:
-    seconds: "{{ {
-      'corosync_token'      : corosync_token,
-      'corosync_consensus'  : corosync_consensus,
-      'pcmk_delay_max'      : pcmk_delay_max,
-      'sbd_watchdog_timeout': sbd_watchdog_timeout,
-      'sbd_delay_start'     : sbd_delay_start
-    } | calc_sbd_delay + 30 }}"
+    seconds: "{{ {'corosync_token': corosync_token, 'corosync_consensus': corosync_consensus, 'pcmk_delay_max': pcmk_delay_max, 'sbd_watchdog_timeout': sbd_watchdog_timeout,
+      'sbd_delay_start': sbd_delay_start} | calc_sbd_delay + 30 }}"
   changed_when: false
   when: action == 'crash' or (action == 'stop' and cloud_platform_name == 'EC2')
 
-- name: Post HANA Action - Wait for Pacemaker to be active    # noqa: command-instead-of-module - we keep systemctl to mimic openqa behaviour
+- name: Post HANA Action - Wait for Pacemaker to be active # noqa: command-instead-of-module - we keep systemctl to mimic openqa behaviour
   become: true
   ansible.builtin.command: systemctl --no-pager is-active pacemaker
   register: pm

--- a/ansible/playbooks/roles/hana_checks/tasks/main.yml
+++ b/ansible/playbooks/roles/hana_checks/tasks/main.yml
@@ -1,0 +1,50 @@
+---
+- name: HANA check - Wait pacemaker up    # noqa: command-instead-of-module - we keep systemctl to mimic openqa behaviour
+  become: true
+  ansible.builtin.command: systemctl --no-pager is-active pacemaker
+  register: pm
+  retries: "{{ pacemaker_timeout // 15 }}"
+  delay: 15
+  until: pm.stdout == 'active'
+  changed_when: false
+
+- name: HANA check - Wait cluster idle again
+  become: true
+  ansible.builtin.command: cs_wait_for_idle --sleep 5
+  register: idle2
+  retries: "{{ cs_wait_timeout // 5 }}"
+  delay: 5
+  until: idle2.rc == 0
+  changed_when: false
+
+- name: HANA check - Gather topology JSON
+  become: true
+  ansible.builtin.command: SAPHanaSR-showAttr --format=script
+  register: topo_raw
+  changed_when: false
+  retries: 6
+  delay: 10
+  until: topo_raw.stdout != ''
+
+- name: HANA check - Parse PRIM / SOK counts
+  ansible.builtin.set_fact:
+      prim_count: "{{ topo_raw.stdout_lines | select('search','sync_state=\"PRIM\"') | list | length }}"
+      sok_count: "{{ topo_raw.stdout_lines | select('search','sync_state=\"SOK\"')  | list | length }}"
+      host_total: "{{ topo_raw.stdout_lines
+                    | select('search','^Hosts/')
+                    | map('regex_replace','^Hosts/([^/]+)/.*','\\1')
+                    | list | unique | length }}"
+
+- name: HANA check - Assert exactly 1 PRIM and the rest SOK
+  ansible.builtin.assert:
+      that:
+          - "{{ prim_count | int == 1 }}"
+          - "{{ sok_count  | int == (host_total | int) - 1 }}"
+      fail_msg: "Topology does not show 1 PRIM and rest SOK — PRIM={{ prim_count }} SOK={{ sok_count }} HOSTS={{ host_total }}"
+      success_msg: "Topology shows 1 PRIM and the rest SOK"
+  changed_when: false
+
+- name: Post HANA check - crm cleanup
+  become: true
+  ansible.builtin.command: crm resource cleanup
+  changed_when: false

--- a/ansible/playbooks/roles/hana_checks/tasks/main.yml
+++ b/ansible/playbooks/roles/hana_checks/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: HANA check - Wait pacemaker up    # noqa: command-instead-of-module - we keep systemctl to mimic openqa behaviour
+- name: HANA check - Wait pacemaker up # noqa: command-instead-of-module - we keep systemctl to mimic openqa behaviour
   become: true
   ansible.builtin.command: systemctl --no-pager is-active pacemaker
   register: pm
@@ -28,20 +28,17 @@
 
 - name: HANA check - Parse PRIM / SOK counts
   ansible.builtin.set_fact:
-      prim_count: "{{ topo_raw.stdout_lines | select('search','sync_state=\"PRIM\"') | list | length }}"
-      sok_count: "{{ topo_raw.stdout_lines | select('search','sync_state=\"SOK\"')  | list | length }}"
-      host_total: "{{ topo_raw.stdout_lines
-                    | select('search','^Hosts/')
-                    | map('regex_replace','^Hosts/([^/]+)/.*','\\1')
-                    | list | unique | length }}"
+    prim_count: "{{ topo_raw.stdout_lines | select('search', 'sync_state=\"PRIM\"') | list | length }}"
+    sok_count: "{{ topo_raw.stdout_lines | select('search', 'sync_state=\"SOK\"') | list | length }}"
+    host_total: "{{ topo_raw.stdout_lines | select('search', '^Hosts/') | map('regex_replace', '^Hosts/([^/]+)/.*', '\\1') | list | unique | length }}"
 
 - name: HANA check - Assert exactly 1 PRIM and the rest SOK
   ansible.builtin.assert:
-      that:
-          - "{{ prim_count | int == 1 }}"
-          - "{{ sok_count  | int == (host_total | int) - 1 }}"
-      fail_msg: "Topology does not show 1 PRIM and rest SOK — PRIM={{ prim_count }} SOK={{ sok_count }} HOSTS={{ host_total }}"
-      success_msg: "Topology shows 1 PRIM and the rest SOK"
+    that:
+      - "{{ prim_count | int == 1 }}"
+      - "{{ sok_count | int == (host_total | int) - 1 }}"
+    fail_msg: "Topology does not show 1 PRIM and rest SOK — PRIM={{ prim_count }} SOK={{ sok_count }} HOSTS={{ host_total }}"
+    success_msg: "Topology shows 1 PRIM and the rest SOK"
   changed_when: false
 
 - name: Post HANA check - crm cleanup

--- a/ansible/playbooks/roles/hana_prevalidate/tasks/main.yaml
+++ b/ansible/playbooks/roles/hana_prevalidate/tasks/main.yaml
@@ -12,7 +12,7 @@
   become: true
   failed_when: showattr_path.rc != 0
 
-- name: Query RPM owning SAPHanaSR-showAttr   # noqa: command-instead-of-module - we keep rpm cli command to mimic openqa behaviour
+- name: Query RPM owning SAPHanaSR-showAttr # noqa: command-instead-of-module - we keep rpm cli command to mimic openqa behaviour
   ansible.builtin.command: rpm -qf {{ showattr_path.stdout }}
   register: showattr_rpm
   changed_when: false

--- a/ansible/playbooks/roles/hana_prevalidate/tasks/main.yaml
+++ b/ansible/playbooks/roles/hana_prevalidate/tasks/main.yaml
@@ -1,0 +1,39 @@
+---
+- name: Wait until SSH is reachable
+  ansible.builtin.wait_for_connection:
+    timeout: 300
+    delay: 5
+
+# Show SAPHanaSR-showAttr version and package
+- name: Locate SAPHanaSR-showAttr binary
+  ansible.builtin.command: which SAPHanaSR-showAttr
+  register: showattr_path
+  changed_when: false
+  become: true
+  failed_when: showattr_path.rc != 0
+
+- name: Query RPM owning SAPHanaSR-showAttr   # noqa: command-instead-of-module - we keep rpm cli command to mimic openqa behaviour
+  ansible.builtin.command: rpm -qf {{ showattr_path.stdout }}
+  register: showattr_rpm
+  changed_when: false
+
+- name: Display SAPHanaSR-showAttr info
+  ansible.builtin.debug:
+    msg: "showAttr path={{ showattr_path.stdout }}  package={{ showattr_rpm.stdout }}"
+
+# Wait for sync and healthy cluster
+- name: Wait for cluster idle
+  ansible.builtin.command: cs_wait_for_idle --sleep 5
+  retries: 48
+  register: cs_idle
+  until: cs_idle.rc == 0
+  become: true
+  changed_when: false
+
+# No failed resources check
+- name: Check cluster for failed resources
+  ansible.builtin.command: crm status
+  register: crm_status
+  changed_when: false
+  failed_when: crm_status.stdout is search('Failed Resource Actions')
+  become: true

--- a/ansible/playbooks/roles/hana_secondary_actions/tasks/main.yml
+++ b/ansible/playbooks/roles/hana_secondary_actions/tasks/main.yml
@@ -1,0 +1,199 @@
+---
+- name: Prepare secondary Action - Dump cluster status
+  ansible.builtin.command: crm status
+  become: true
+  register: crm_initial
+  changed_when: false
+
+- name: Prepare secondary Action - Assert this node is not master
+  ansible.builtin.assert:
+    that:
+      - crm_initial.stdout is not search('\* Masters:\s*\[\s*{{ inventory_hostname }}\s*\]')
+    fail_msg: "{{ inventory_hostname }} is MASTER – expected replica"
+    success_msg: "{{ inventory_hostname }} is in replica mode"
+
+- name: Prepare secondary Action - Wait cluster idle (pre-action)
+  ansible.builtin.command: cs_wait_for_idle --sleep 5
+  become: true
+  register: idle_pre
+  retries: "{{ cs_wait_timeout // 5 }}"
+  delay: 5
+  until: idle_pre.rc == 0
+  changed_when: false
+
+# SBD-related stuff
+- name: Prepare secondary Action - Gather SBD-delay parameters    # noqa: command-instead-of-shell the command variable actually reuires shell
+  become: true
+  ansible.builtin.shell: "{{ item.cmd }}"
+  args:
+    warn: false
+  register: sbddelay
+  changed_when: false
+  failed_when: false
+  loop:
+    - name: corosync_token
+      cmd: "corosync-cmapctl | awk -F ' = ' '/totem.token/ {print int($2/1000)}'"
+    - name: corosync_consensus
+      cmd: "corosync-cmapctl | awk -F ' = ' '/totem.consensus/ {print int($2/1000)}'"
+    - name: pcmk_delay_max
+      cmd: "crm resource param stonith-sbd show pcmk_delay_max | sed 's/[^0-9]*//g'"
+    - name: sbd_watchdog_timeout
+      cmd: "grep -oP '(?<=^SBD_WATCHDOG_TIMEOUT=)[[:digit:]]+' /etc/sysconfig/sbd"
+    - name: sbd_delay_start
+      cmd: "grep -oP '(?<=^SBD_DELAY_START=)([[:digit:]]+|yes|no)+' /etc/sysconfig/sbd"
+  when: action == 'crash'
+
+- name: Prepare secondary Action - Set SBD delay facts
+  ansible.builtin.set_fact:
+    corosync_token: "{{ sbddelay.results
+                        | selectattr('item.name','==','corosync_token')
+                        | map(attribute='stdout') | first | int }}"
+    corosync_consensus: "{{ sbddelay.results
+                            | selectattr('item.name','==','corosync_consensus')
+                            | map(attribute='stdout') | first | int }}"
+    pcmk_delay_max: "{{ sbddelay.results
+                        | selectattr('item.name','==','pcmk_delay_max')
+                        | map(attribute='stdout') | first | int }}"
+    sbd_watchdog_timeout: "{{ sbddelay.results
+                              | selectattr('item.name','==','sbd_watchdog_timeout')
+                              | map(attribute='stdout') | first | int }}"
+    sbd_delay_start: "{{ sbddelay.results
+                        | selectattr('item.name','==','sbd_delay_start')
+                        | map(attribute='stdout') | first | default('yes') }}"
+  when: action == 'crash'
+
+- name: Prepare secondary Action - Configure SBD start-delay
+  ansible.builtin.lineinfile:
+    path: /etc/sysconfig/sbd
+    regexp: '^SBD_DELAY_START='
+    line: "SBD_DELAY_START={{ sbd_delay_start }}"
+  become: true
+  when: action == 'crash'
+
+- name: Prepare secondary Action - Create systemd drop-in dir for sbd
+  ansible.builtin.file:
+    path: /etc/systemd/system/sbd.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+  become: true
+  when: action == 'crash'
+
+- name: Prepare secondary Action - Write SBD service timeout override
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/sbd.service.d/timeout.conf
+    owner: root
+    group: root
+    mode: '0644'
+    content: |
+      [Service]
+      TimeoutSec={{ {
+        'corosync_token'      : corosync_token,
+        'corosync_consensus'  : corosync_consensus,
+        'pcmk_delay_max'      : pcmk_delay_max,
+        'sbd_watchdog_timeout': sbd_watchdog_timeout,
+        'sbd_delay_start'     : sbd_delay_start
+      } | calc_sbd_delay + 30 }}
+  become: true
+  when: action == 'crash'
+
+- name: Prepare secondary Action - Pause for calculated SBD delay + 30s
+  ansible.builtin.pause:
+    seconds: "{{ {
+      'corosync_token'      : corosync_token,
+      'corosync_consensus'  : corosync_consensus,
+      'pcmk_delay_max'      : pcmk_delay_max,
+      'sbd_watchdog_timeout': sbd_watchdog_timeout,
+      'sbd_delay_start'     : sbd_delay_start
+    } | calc_sbd_delay + 30 }}"
+  become: true
+  when: action == 'crash'
+  changed_when: false
+
+- name: Prepare secondary Action - Wait for Pacemaker to be active    # noqa: command-instead-of-module - we keep systemctl to mimic openqa behaviour
+  ansible.builtin.command: systemctl --no-pager is-active pacemaker
+  register: pm_active
+  retries: "{{ pacemaker_timeout // 15 }}"
+  delay: 15
+  until: pm_active.stdout == 'active'
+  become: true
+  changed_when: false
+  when: action == 'crash'
+
+# Secondary action
+- name: Secondary Action – Stop HANA
+  ansible.builtin.shell: "sudo -iu {{ sap_sidadm }} HDB stop"   # noqa: command-instead-of-shell the command variable actually reuires shell
+  become: true
+  when: action == 'stop'
+  changed_when: true
+
+- name: Secondary Action – Kill HANA
+  ansible.builtin.shell: "sudo -iu {{ sap_sidadm }} HDB kill -x"    # noqa: command-instead-of-shell the command variable actually reuires shell
+  become: true
+  when: action == 'kill'
+  changed_when: true
+
+- name: Secondary Action – Crash OS
+  ansible.builtin.shell: echo b > /proc/sysrq-trigger
+  async: 1
+  poll: 0
+  become: true
+  when: action == 'crash'
+  changed_when: true
+
+# Post secondary action
+- name: Post secondary Action - Wait for SSH back
+  ansible.builtin.wait_for_connection:
+    delay: 15
+    timeout: 900
+  when: action in ['crash','stop']
+  changed_when: false
+
+- name: Post secondary Action - Wait cluster idle (post-action)
+  ansible.builtin.command: cs_wait_for_idle --sleep 5
+  become: true
+  register: idle_post
+  retries: "{{ cs_wait_timeout // 5 }}"
+  delay: 5
+  until: idle_post.rc == 0
+  changed_when: false
+
+- name: Post secondary Action - Compute HANA resource prefix
+  ansible.builtin.set_fact:
+    use_angi: "{{ use_angi | default(false) | bool }}"
+    master_resource_type: "{{ use_angi | default(false) | bool | ternary('mst','msl') }}"
+
+- name: Post secondary Action - Compute HANA resource name
+  ansible.builtin.set_fact:
+    resource_name: "{{ master_resource_type }}_SAPHanaCtl_{{ sap_hana_install_sid }}_HDB{{ sap_hana_install_instance_number }}"
+
+- name: Post secondary Action - Wait for HANA resource to be running on this node
+  ansible.builtin.command: crm resource status "{{ resource_name }}"
+  register: res_stat
+  become: true
+  retries: "{{ hana_sync_timeout // 30 }}"
+  delay: 30
+  until: 'res_stat.stdout is search("is running on: " ~ inventory_hostname)'
+  changed_when: false
+
+- name: Post secondary Action - Assert this node did not become MASTER    # noqa: command-instead-of-shell the command variable actually reuires shell
+  become: true
+  ansible.builtin.shell: crm resource status "{{ resource_name }}"
+  register: master_out
+  changed_when: false
+  failed_when: 'master_out.stdout is search("is running on: " ~ inventory_hostname ~ " Master")'
+
+- name: Post secondary Action - Cleanup HANA resource
+  ansible.builtin.command: crm resource cleanup
+  become: true
+  changed_when: false
+
+- name: Post secondary Action - Wait cluster idle after cleanup
+  ansible.builtin.command: cs_wait_for_idle --sleep 5
+  become: true
+  register: idle_cleanup
+  retries: "{{ cluster_settle_retries }}"
+  delay: "{{ cluster_settle_delay }}"
+  until: idle_cleanup.rc == 0
+  changed_when: false

--- a/ansible/playbooks/roles/hana_secondary_actions/tasks/main.yml
+++ b/ansible/playbooks/roles/hana_secondary_actions/tasks/main.yml
@@ -22,7 +22,7 @@
   changed_when: false
 
 # SBD-related stuff
-- name: Prepare secondary Action - Gather SBD-delay parameters    # noqa: command-instead-of-shell the command variable actually reuires shell
+- name: Prepare secondary Action - Gather SBD-delay parameters # noqa: command-instead-of-shell the command variable actually reuires shell
   become: true
   ansible.builtin.shell: "{{ item.cmd }}"
   args:
@@ -45,27 +45,17 @@
 
 - name: Prepare secondary Action - Set SBD delay facts
   ansible.builtin.set_fact:
-    corosync_token: "{{ sbddelay.results
-                        | selectattr('item.name','==','corosync_token')
-                        | map(attribute='stdout') | first | int }}"
-    corosync_consensus: "{{ sbddelay.results
-                            | selectattr('item.name','==','corosync_consensus')
-                            | map(attribute='stdout') | first | int }}"
-    pcmk_delay_max: "{{ sbddelay.results
-                        | selectattr('item.name','==','pcmk_delay_max')
-                        | map(attribute='stdout') | first | int }}"
-    sbd_watchdog_timeout: "{{ sbddelay.results
-                              | selectattr('item.name','==','sbd_watchdog_timeout')
-                              | map(attribute='stdout') | first | int }}"
-    sbd_delay_start: "{{ sbddelay.results
-                        | selectattr('item.name','==','sbd_delay_start')
-                        | map(attribute='stdout') | first | default('yes') }}"
+    corosync_token: "{{ sbddelay.results | selectattr('item.name', '==', 'corosync_token') | map(attribute='stdout') | first | int }}"
+    corosync_consensus: "{{ sbddelay.results | selectattr('item.name', '==', 'corosync_consensus') | map(attribute='stdout') | first | int }}"
+    pcmk_delay_max: "{{ sbddelay.results | selectattr('item.name', '==', 'pcmk_delay_max') | map(attribute='stdout') | first | int }}"
+    sbd_watchdog_timeout: "{{ sbddelay.results | selectattr('item.name', '==', 'sbd_watchdog_timeout') | map(attribute='stdout') | first | int }}"
+    sbd_delay_start: "{{ sbddelay.results | selectattr('item.name', '==', 'sbd_delay_start') | map(attribute='stdout') | first | default('yes') }}"
   when: action == 'crash'
 
 - name: Prepare secondary Action - Configure SBD start-delay
   ansible.builtin.lineinfile:
     path: /etc/sysconfig/sbd
-    regexp: '^SBD_DELAY_START='
+    regexp: "^SBD_DELAY_START="
     line: "SBD_DELAY_START={{ sbd_delay_start }}"
   become: true
   when: action == 'crash'
@@ -76,7 +66,7 @@
     state: directory
     owner: root
     group: root
-    mode: '0755'
+    mode: "0755"
   become: true
   when: action == 'crash'
 
@@ -85,7 +75,7 @@
     dest: /etc/systemd/system/sbd.service.d/timeout.conf
     owner: root
     group: root
-    mode: '0644'
+    mode: "0644"
     content: |
       [Service]
       TimeoutSec={{ {
@@ -100,18 +90,13 @@
 
 - name: Prepare secondary Action - Pause for calculated SBD delay + 30s
   ansible.builtin.pause:
-    seconds: "{{ {
-      'corosync_token'      : corosync_token,
-      'corosync_consensus'  : corosync_consensus,
-      'pcmk_delay_max'      : pcmk_delay_max,
-      'sbd_watchdog_timeout': sbd_watchdog_timeout,
-      'sbd_delay_start'     : sbd_delay_start
-    } | calc_sbd_delay + 30 }}"
+    seconds: "{{ {'corosync_token': corosync_token, 'corosync_consensus': corosync_consensus, 'pcmk_delay_max': pcmk_delay_max, 'sbd_watchdog_timeout': sbd_watchdog_timeout,
+      'sbd_delay_start': sbd_delay_start} | calc_sbd_delay + 30 }}"
   become: true
   when: action == 'crash'
   changed_when: false
 
-- name: Prepare secondary Action - Wait for Pacemaker to be active    # noqa: command-instead-of-module - we keep systemctl to mimic openqa behaviour
+- name: Prepare secondary Action - Wait for Pacemaker to be active # noqa: command-instead-of-module - we keep systemctl to mimic openqa behaviour
   ansible.builtin.command: systemctl --no-pager is-active pacemaker
   register: pm_active
   retries: "{{ pacemaker_timeout // 15 }}"
@@ -123,13 +108,13 @@
 
 # Secondary action
 - name: Secondary Action – Stop HANA
-  ansible.builtin.shell: "sudo -iu {{ sap_sidadm }} HDB stop"   # noqa: command-instead-of-shell the command variable actually reuires shell
+  ansible.builtin.shell: "sudo -iu {{ sap_sidadm }} HDB stop" # noqa: command-instead-of-shell the command variable actually reuires shell
   become: true
   when: action == 'stop'
   changed_when: true
 
 - name: Secondary Action – Kill HANA
-  ansible.builtin.shell: "sudo -iu {{ sap_sidadm }} HDB kill -x"    # noqa: command-instead-of-shell the command variable actually reuires shell
+  ansible.builtin.shell: "sudo -iu {{ sap_sidadm }} HDB kill -x" # noqa: command-instead-of-shell the command variable actually reuires shell
   become: true
   when: action == 'kill'
   changed_when: true
@@ -162,7 +147,7 @@
 - name: Post secondary Action - Compute HANA resource prefix
   ansible.builtin.set_fact:
     use_angi: "{{ use_angi | default(false) | bool }}"
-    master_resource_type: "{{ use_angi | default(false) | bool | ternary('mst','msl') }}"
+    master_resource_type: "{{ use_angi | default(false) | bool | ternary('mst', 'msl') }}"
 
 - name: Post secondary Action - Compute HANA resource name
   ansible.builtin.set_fact:
@@ -177,7 +162,7 @@
   until: 'res_stat.stdout is search("is running on: " ~ inventory_hostname)'
   changed_when: false
 
-- name: Post secondary Action - Assert this node did not become MASTER    # noqa: command-instead-of-shell the command variable actually reuires shell
+- name: Post secondary Action - Assert this node did not become MASTER # noqa: command-instead-of-shell the command variable actually reuires shell
   become: true
   ansible.builtin.shell: crm resource status "{{ resource_name }}"
   register: master_out

--- a/ansible/playbooks/vars/test_vars.yaml
+++ b/ansible/playbooks/vars/test_vars.yaml
@@ -1,0 +1,8 @@
+---
+cs_wait_timeout: 240
+hana_sync_timeout: 900
+pacemaker_timeout: 300
+cluster_settle_retries: 10
+cluster_settle_delay: 60
+crm_mon_cmd: "crm_mon -R -r -n -1"
+sap_sidadm: "{{ sap_hana_install_sid | lower }}adm"


### PR DESCRIPTION
This pr adds the necessary playbooks, roles and support files in qe-sap-deployment to enable testing functionality (specifically the openQA Modules `hana_sr_takeover, `hana_sr_test_secondary` and `qesap_prevalidate`).

Ticket: TEAM-10427