### PR TITLE
Fix usage of register and changed_when in iscsi client

### DIFF
--- a/ansible/playbooks/tasks/iscsi-client-sbd-prep.yaml
+++ b/ansible/playbooks/tasks/iscsi-client-sbd-prep.yaml
@@ -47,7 +47,7 @@
 - name: Set LUNs to automatic
   ansible.builtin.command:
     cmd: "iscsiadm -m node -p {{ item.item.stdout | split(':') | first }}:3260 -T {{ srv_iqn }} --op=update --name=node.startup --value=automatic"
-    register: iscsiadm_result
-    changed_when: iscsiadm_result.rc == 0
+  register: iscsiadm_result
+  changed_when: iscsiadm_result.rc == 0
   when: item.changed
   loop: "{{ login.results }}"


### PR DESCRIPTION
Fix the indentation of register and changed_when in a command task in iscsi client file.

Fix regression introduced in https://github.com/SUSE/qe-sap-deployment/pull/368


Ticket: https://jira.suse.com/browse/TEAM-10410

# Verification

http://openqaworker15.qa.suse.cz/tests/329722

