### PR TITLE
Add ansible-lint test to PR workflows

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -21,9 +21,24 @@ jobs:
       - name: Install all requirements
         run: |
           python3 -m pip install --upgrade -r requirements.txt
+          python3 -m pip install ansible-lint==25.6.1
           ansible-galaxy install -r requirements.yml
 
       - name: Run ansible static tests
         run: |
            make -n static-ansible
            make SHELL='sh -x' static-ansible
+
+      - name: Get all changed Ansible files
+        id: changed-markdown-files
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
+        with:
+          files: |
+            ansible/playbooks/
+
+      - name: Run ansible-lint only on changed files
+        if: steps.changed-markdown-files.outputs.any_changed == 'true'
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-markdown-files.outputs.all_changed_files }}
+        run: |
+          ansible-lint --offline ${ALL_CHANGED_FILES}


### PR DESCRIPTION
Add ansible-lint execution only on ansible files modified by the PR. It does not means it will show and block the merge only about warning introduced by the PR itself, but also about all existing warnings in the file that the PR is editing.


Ticket: https://jira.suse.com/browse/TEAM-7184

Example of PR that is changing an Ansible file https://github.com/SUSE/qe-sap-deployment/pull/372