### PR TITLE
Tune ansible lint configuration

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,3 +3,5 @@ exclude_paths:
   - ansible/playbooks/registration_role.yaml
   - ansible/playbooks/vars/hana_media.yaml
   - ansible/playbooks/vars/hana_vars.yaml
+warn_list:
+  - role-name[path]

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -21,7 +21,8 @@ jobs:
       - name: Install all requirements
         run: |
           python3 -m pip install --upgrade -r requirements.txt
-          python3 -m pip install ansible-lint==25.6.1
+          # 25.1.3 is the newest version that support ansible-core 2.16.8 we are using right now
+          python3 -m pip install ansible-lint==25.1.3
           ansible-galaxy install -r requirements.yml
 
       - name: Run ansible static tests

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -2,3 +2,12 @@ extends: default
 
 rules:
   line-length: disable
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: false
+  braces:
+    max-spaces-inside: 1
+  octal-values:
+    forbid-implicit-octal: false
+    forbid-explicit-octal: true
+


### PR DESCRIPTION
Let's run the github workflow to use a version of ansible-lint that is compatible to the official ansible-core version used by the project. Adjust yamllint configuration to what used by ansible. Lower fatal ansible-lint rules about roles path: it is something about the qe-sap-deployment structure that needs more works to be addressed.

Ticket: https://jira.suse.com/browse/TEAM-7184

