### PR TITLE
Fix warnings in sap download playbook

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -8,6 +8,6 @@ rules:
   braces:
     max-spaces-inside: 1
   octal-values:
-    forbid-implicit-octal: false
+    forbid-implicit-octal: true
     forbid-explicit-octal: true
 

--- a/ansible/playbooks/sap-hana-download-media.yaml
+++ b/ansible/playbooks/sap-hana-download-media.yaml
@@ -21,15 +21,17 @@
         -o tsv
       delegate_to: 127.0.0.1
       no_log: true
-      run_once: true
+      run_once: true  # noqa: run-once[task] fine to ignore as not using strategy:free
       register: az_account_key
+      changed_when: az_account_key.rc == 0
       when: az_sas_token is not defined or az_sas_token == ""
 
     - name: "Set expiry"
       ansible.builtin.command: "date -u +'%Y-%m-%dT%H:%MZ' -d '+3 hours'"
       delegate_to: 127.0.0.1
-      run_once: true
+      run_once: true  # noqa: run-once[task] fine to ignore as not using strategy:free
       register: expiry
+      changed_when: true
       when: az_sas_token is not defined or az_sas_token == ""
 
     - name: Generate SAS token
@@ -44,7 +46,7 @@
       delegate_to: 127.0.0.1
       changed_when: false
       no_log: true
-      run_once: true
+      run_once: true  # noqa: run-once[task] fine to ignore as not using strategy:free
       register: az_sas_token_output
       when: az_sas_token is not defined or az_sas_token == ""
 
@@ -52,7 +54,7 @@
       ansible.builtin.set_fact:
         az_sas_token: "{{ az_sas_token_output.stdout }}"
       delegate_to: 127.0.0.1
-      run_once: true
+      run_once: true  # noqa: run-once[task] fine to ignore as not using strategy:free
       when: az_sas_token is not defined or az_sas_token == ""
 
     - name: Create software directory
@@ -61,7 +63,7 @@
         state: directory
         owner: root
         group: root
-        mode: 0755
+        mode: "0755"
       become: true
       become_user: root
 
@@ -71,7 +73,7 @@
         dest: "{{ hana_download_path + '/' + item | split('/') | last }}"
         owner: root
         group: root
-        mode: 0600
+        mode: "0600"
         timeout: "{{ url_timeout }}"
       register: result
       until: result is succeeded


### PR DESCRIPTION
Fix warnings about yamllint octal and others about run_once.

Ticket https://jira.suse.com/browse/TEAM-7184

# Verification

sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_angi_test 
 -  http://openqaworker15.qa.suse.cz/tests/331494 :yellow_circle: the download playbook execution is fine, but jobs fails for a failure in a later ansible playbook. I prefer to run a second VR
 -  http://openqaworker15.qa.suse.cz/tests/331498 :green_circle: 

