### PR TITLE
Reduce storage usage on GCP HanaSR testing

### DIFF
--- a/terraform/gcp/modules/hana_node/variables.tf
+++ b/terraform/gcp/modules/hana_node/variables.tf
@@ -62,7 +62,7 @@ variable "hana_data_disk_type" {
 variable "hana_data_disk_size" {
   description = "Disk size of the data volume"
   type        = string
-  default     = "350"
+  default     = "128"
 }
 
 variable "hana_log_disk_type" {
@@ -98,7 +98,7 @@ variable "hana_backup_disk_type" {
 variable "hana_backup_disk_size" {
   description = "Disk size of the disk used for /hana/backup"
   type        = string
-  default     = "256"
+  default     = "128"
 }
 
 variable "hana_usr_sap_disk_type" {
@@ -108,7 +108,7 @@ variable "hana_usr_sap_disk_type" {
 }
 
 variable "hana_usr_sap_disk_size" {
-  description = "Disk size of the disk used for /hana/backup"
+  description = "Disk size of the disk used for /usr/sap"
   type        = string
-  default     = "64"
+  default     = "32"
 }


### PR DESCRIPTION
From our discussion in Slack, we reduce the maximum disk size to 128GB for the `n1-highmem-32` machine.

As for the `/usr/sap` partition, Google documentation says 32GB is enough.

VR:  https://openqaworker15.qa.suse.cz/tests/331944

https://jira.suse.com/browse/TEAM-10265