### PR TITLE
Add the Libzypp envirtonmet values  - TEAM-10393 

### DIFF
--- a/ansible/playbooks/registration.yaml
+++ b/ansible/playbooks/registration.yaml
@@ -5,7 +5,7 @@
   become: true
   become_user: root
   environment:
-    ZYPP_LOCK_TIMEOUT: 30
+    ZYPP_LOCK_TIMEOUT: 120
 
   vars:
     use_suseconnect: false  # Set to false unless specified

--- a/ansible/playbooks/registration.yaml
+++ b/ansible/playbooks/registration.yaml
@@ -4,6 +4,8 @@
   remote_user: cloudadmin
   become: true
   become_user: root
+  environment:
+    ZYPP_LOCK_TIMEOUT: 30
 
   vars:
     use_suseconnect: false  # Set to false unless specified

--- a/ansible/playbooks/registration.yaml
+++ b/ansible/playbooks/registration.yaml
@@ -5,7 +5,7 @@
   become: true
   become_user: root
   environment:
-    ZYPP_LOCK_TIMEOUT: 120
+    ZYPP_LOCK_TIMEOUT: '120'
 
   vars:
     use_suseconnect: false  # Set to false unless specified
@@ -206,3 +206,4 @@
       ansible.builtin.command: zypper lr -u
       register: repos_after
       failed_when: repos_after.rc != 0
+      changed_when: false


### PR DESCRIPTION
* libzypp environment value `ZYPP_LOCK_TIMEOUT` is now set globally for the `registration.yaml`
* TEAM-10393 

VR: 
* https://openqaworker15.qa.suse.cz/tests/334967 - 30s TIMEOUT
* https://openqaworker15.qa.suse.cz/tests/335103 - 120s TIMEOUT in quotes

VRs fails on missing MU repositories, but successfully pass the SUSE connect registration.

Additianl change: 
* `ansible/playbooks/registration.yaml:205 Task/Handler: Check if repos are added after registration`
   `changed_when: false` added to comply with `ansible_lint`