### PR TITLE
Increase delete timeout for AWS hana instances

### DIFF
--- a/terraform/aws/modules/hana_node/main.tf
+++ b/terraform/aws/modules/hana_node/main.tf
@@ -84,6 +84,10 @@ resource "aws_instance" "hana" {
   #  auto_recovery = "disabled" # see https://docs.aws.amazon.com/sap/latest/sap-hana/sap-hana-on-aws-cluster-configuration.html
   #}
 
+  timeouts {
+    delete = "60m"
+  }
+
   tags = {
     name                        = "${var.common_variables["deployment_name"]}-${var.name}${format("%02d", count.index + 1)}"
     workspace                   = var.common_variables["deployment_name"]


### PR DESCRIPTION
This PR increases the `destroy` timeout for the AWS hana resources, as baremetal instances take slightly longer than 20m (the default timeout) to be destroyed.

- Related ticket: https://jira.suse.com/browse/TEAM-10517
- Verification run: https://openqaworker15.qa.suse.cz/tests/335266/logfile?filename=destroy-qesap_exec_terraform_destroy.log.txt#line-1330

(see how the previous error about hana iming out is gone - the other error will be tackled in a different pr)