### PR TITLE
Increase IGW delete timeout

### DIFF
--- a/terraform/aws/infrastructure.tf
+++ b/terraform/aws/infrastructure.tf
@@ -49,6 +49,10 @@ resource "aws_internet_gateway" "igw" {
   count  = var.vpc_id == "" ? 1 : 0
   vpc_id = local.vpc_id
 
+  timeouts {
+    delete = "${var.hana_destroy_timeout + 10}m"
+  }
+
   tags = {
     name      = "${local.deployment_name}-igw"
     workspace = local.deployment_name

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -160,6 +160,7 @@ module "hana_node" {
   hana_data_disk_type  = var.hana_data_disk_type
   hana_data_disk_size  = var.hana_data_disk_size
   iscsi_srv_ip         = join("", module.iscsi_server.iscsisrv_ip)
+  destroy_timeout      = var.hana_destroy_timeout
 }
 
 module "monitoring" {

--- a/terraform/aws/modules/hana_node/main.tf
+++ b/terraform/aws/modules/hana_node/main.tf
@@ -85,7 +85,7 @@ resource "aws_instance" "hana" {
   #}
 
   timeouts {
-    delete = "60m"
+    delete = "${var.destroy_timeout}m"
   }
 
   tags = {

--- a/terraform/aws/modules/hana_node/variables.tf
+++ b/terraform/aws/modules/hana_node/variables.tf
@@ -134,3 +134,8 @@ variable "iscsi_srv_ip" {
   description = "iscsi server address"
   type        = string
 }
+
+variable "destroy_timeout" {
+  type        = number
+  description = "Delete-timeout in minutes."
+}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -733,3 +733,9 @@ variable "ibsm_project_tag" {
   type        = string
   default     = ""
 }
+
+variable "hana_destroy_timeout" {
+  type        = number
+  description = "How long Terraform should wait (in minutes) before giving up on a resource deletion."
+  default     = 60
+}


### PR DESCRIPTION
Increases delete timeout of IGW to the timeout for HANA resources +10m, in order to let terraform destroy it after the HANA resources to avoid dependency issues.

- Related ticket: https://jira.suse.com/browse/TEAM-10517
- Verification Run: https://openqaworker15.qa.suse.cz/tests/335682#details
https://openqaworker15.qa.suse.cz/tests/335689#