### PR TITLE
Fix ansible lint in qe_sap_storage role

### DIFF
--- a/ansible/playbooks/sap-hana-storage.yaml
+++ b/ansible/playbooks/sap-hana-storage.yaml
@@ -28,8 +28,7 @@
 
     - name: HANA storage preparation
       vars:
-        sap_storage_cloud_type: 'generic'
-        sap_storage_sap_type: 'sap_hana'
-        sap_storage_action: 'prepare'
+        qe_sap_storage_cloud_type: 'generic'
+        qe_sap_storage_action: 'prepare'
       ansible.builtin.include_role:
         name: ../roles/qe_sap_storage

--- a/ansible/playbooks/tasks/iscsi-server-sbd-prep.yaml
+++ b/ansible/playbooks/tasks/iscsi-server-sbd-prep.yaml
@@ -57,10 +57,9 @@
 
 - name: Prepare iscsi disks
   vars:
-    sap_storage_cloud_type: 'generic'
-    sap_storage_sap_type: 'sap_hana'
-    sap_storage_action: 'prepare'
-  include_role:
+    qe_sap_storage_cloud_type: 'generic'
+    qe_sap_storage_action: 'prepare'
+  ansible.builtin.include_role:
     name: ../roles/qe_sap_storage
 
 - name: Configure HANA SBD target

--- a/ansible/roles/qe_sap_storage/README.md
+++ b/ansible/roles/qe_sap_storage/README.md
@@ -26,8 +26,8 @@ This can be used in 2 ways
 
 | **Variable**           | **Info**                 | **Default** | **Required** |
 | :--------------------- | :----------------------- | :---------- | :----------- |
-| sap_storage_cloud_type | 'generic' / 'az' / 'aws' | 'generic'   | yes          |
-| sap_storage_action     | 'prepare' / 'remove'     | 'prepare'   | yes          |
+| qe_sap_storage_cloud_type | 'generic' / 'az' / 'aws' | 'generic'   | yes          |
+| qe_sap_storage_action     | 'prepare' / 'remove'     | 'prepare'   | yes          |
 
 ### Input
 

--- a/ansible/roles/qe_sap_storage/defaults/main.yml
+++ b/ansible/roles/qe_sap_storage/defaults/main.yml
@@ -2,31 +2,19 @@
 
 # Important variables
 
-sap_storage_cloud_type: 'generic'
+qe_sap_storage_cloud_type: 'generic'
 # generic | az | aws
 
-sap_storage_sap_type: 'sap_onehost'
-# sap_onehost | sap_hana | sap_nw
-
-sap_storage_action: 'prepare'
+qe_sap_storage_action: 'prepare'
 # prepare | remove
 
 
 # Azure variables
 
-sap_storage_az_imds_json:
-sap_storage_az_imds_url: 'http://169.254.169.254/metadata/instance/compute?api-version=2020-09-01'
-sap_storage_az_vmsize_url: 'http://169.254.169.254/metadata/instance/compute/vmSize?api-version=2017-08-01&format=text'
+qe_sap_storage_az_imds_json:
+qe_sap_storage_az_imds_url: 'http://169.254.169.254/metadata/instance/compute?api-version=2020-09-01'
+qe_sap_storage_az_vmsize_url: 'http://169.254.169.254/metadata/instance/compute/vmSize?api-version=2017-08-01&format=text'
 
-sap_storage_az_vmsize:
+qe_sap_storage_az_vmsize:
 
-sap_storage_az_lun: '/dev/disk/azure/scsi1/lun'
-
-# AWS variables
-
-sap_storage_aws_imds_url: 
-sap_storage_aws_vmsize_url: 
-
-sap_storage_aws_vmsize:
-
-# IBM Cloud variables
+qe_sap_storage_az_lun: '/dev/disk/azure/scsi1/lun'

--- a/ansible/roles/qe_sap_storage/tasks/aws_main.yml
+++ b/ansible/roles/qe_sap_storage/tasks/aws_main.yml
@@ -1,7 +1,7 @@
 ---
 
 # AWS
-- name: SAP Storage Preparation - {{ sap_storage_cloud_type | upper }} - AWS
-  shell: |
-    some AWS shit here
-  register: aws_imds_reg
+- name: SAP Storage Preparation - AWS - {{ qe_sap_storage_cloud_type | upper }}
+  ansible.builtin.shell: |
+    some AWS code here
+  changed_when: false

--- a/ansible/roles/qe_sap_storage/tasks/az_main.yml
+++ b/ansible/roles/qe_sap_storage/tasks/az_main.yml
@@ -6,33 +6,36 @@
 
 # Create json format of IMDS
 # Todo: Ansibilize this
-- name: SAP Storage Preparation - {{ sap_storage_cloud_type | upper }} - Create json format of IMDS
-  shell: |
-    curl -H Metadata:true --noproxy "*" "{{ sap_storage_az_imds_url }}" | python3 -mjson.tool
-  register: az_imds_reg
+- name: SAP Storage Preparation - {{ qe_sap_storage_cloud_type | upper }} - Create json format of IMDS
+  ansible.builtin.shell: |
+    curl -H Metadata:true --noproxy "*" "{{ qe_sap_storage_az_imds_url }}" | python3 -mjson.tool
+  register: qe_sap_storage_az_imds_reg
   args:
      executable: /bin/bash
 # If this fails, that means this VM is not Azure?
 
-- set_fact:
-    sap_storage_az_imds_json: "{{ az_imds_reg.stdout }}"
+- name: Store imds json
+  ansible.builtin.set_fact:
+    qe_sap_storage_az_imds_json: "{{ qe_sap_storage_az_imds_reg.stdout }}"
 
 # Pull VMSize
 # Todo: Ansibilize this
-- name: SAP Storage Preparation - {{ sap_storage_cloud_type | upper }} - Pull VMSize
-  shell: |
-    curl -H Metadata:true --noproxy "*" "{{ sap_storage_az_vmsize_url }}"
+- name: SAP Storage Preparation - {{ qe_sap_storage_cloud_type | upper }} - Pull VMSize
+  ansible.builtin.shell: |
+    curl -H Metadata:true --noproxy "*" "{{ qe_sap_storage_az_vmsize_url }}"
   register: az_vmsize_reg
   args:
      executable: /bin/bash
 
-- debug:
+- name: VM size output
+  ansible.builtin.debug:
     msg:
       - "{{ az_vmsize_reg.stdout }}"
 
-- set_fact:
-    sap_storage_az_vmsize: "{{ az_vmsize_reg.stdout }}"
+- name: "Calculate qe_sap_storage_az_vmsize"
+  ansible.builtin.set_fact:
+    qe_sap_storage_az_vmsize: "{{ az_vmsize_reg.stdout }}"
 
 # Include vars depending on VM Size
-- name: SAP Storage Preparation - {{ sap_storage_cloud_type | upper }} - Load Variables for {{ sap_storage_az_vmsize }}
-  include_vars: "{{ sap_storage_cloud_type }}_tasks/vmsizes/{{ sap_storage_az_vmsize }}.yml"
+- name: SAP Storage Preparation - Load Variables for {{ qe_sap_storage_az_vmsize }}
+  ansible.builtin.include_vars: "{{ qe_sap_storage_cloud_type }}_tasks/vmsizes/{{ qe_sap_storage_az_vmsize }}.yml"

--- a/ansible/roles/qe_sap_storage/tasks/az_tasks/prepare_storage.yml
+++ b/ansible/roles/qe_sap_storage/tasks/az_tasks/prepare_storage.yml
@@ -1,20 +1,20 @@
 ---
 
 # Striped volume
-- name: SAP Storage Preparation - {{ sap_storage_cloud_type | upper }} - {{ sap_storage_az_vmsize }} - {{ item.value.name }} - Striped
+- name: SAP Storage Preparation - {{ qe_sap_storage_cloud_type | upper }} - {{ qe_sap_storage_az_vmsize }} - {{ item.value.name }} - Striped
   when:
     - "item.value.numluns != '1'"
   block:
     # Get LUNs from metadata
-    - name: SAP Storage Preparation - {{ sap_storage_cloud_type | upper }} - {{ sap_storage_az_vmsize }} - {{ item.value.name }} Get LUNs from metadata
+    - name: SAP Storage Preparation - {{ qe_sap_storage_cloud_type | upper }} - {{ qe_sap_storage_az_vmsize }} - {{ item.value.name }} Get LUNs from metadata
       ansible.builtin.shell: |
         for i in {1..{{ item.value.numluns }}}
         do
-          {{ item.value.vg }}${i}lun="{{ sap_storage_az_lun }} \
+          {{ item.value.vg }}${i}lun="{{ qe_sap_storage_az_lun }} \
             `awk '/caching/ { r=""; f=1 } f { r = (r ? r ORS : "") $0 } \
             /writeAcceleratorEnabled/ \
             { if (f && r ~ /{{ item.value.name }}${i}/) print r; f=0 }' \
-            {{ sap_storage_az_imds_json }} \
+            {{ qe_sap_storage_az_imds_json }} \
             | grep lun | sed 's/[^0-9]*//g'`"
           echo ${{ item.value.vg }}${i}lun
         done
@@ -27,14 +27,14 @@
         pvs_list: "{{ pvs_reg.stdout.split() }}"
 
     # Create Volume Group
-    - name: SAP Storage Preparation - {{ sap_storage_cloud_type | upper }} - {{ sap_storage_az_vmsize }} - {{ item.value.name }} Volume Group Striped
+    - name: SAP Storage Preparation - {{ qe_sap_storage_cloud_type | upper }} - {{ qe_sap_storage_az_vmsize }} - {{ item.value.name }} Volume Group Striped
       community.general.lvg:
         vg: "{{ item.value.vg }}"
         pvs: "{{ pvs_list | join(',') }}"
         force: true
 
     # Create Logical Group
-    - name: SAP Storage Preparation - {{ sap_storage_cloud_type | upper }} - {{ sap_storage_az_vmsize }} - {{ item.value.name }} Logical Volume - Striped
+    - name: SAP Storage Preparation - {{ qe_sap_storage_cloud_type | upper }} - {{ qe_sap_storage_az_vmsize }} - {{ item.value.name }} Logical Volume - Striped
       community.general.lvol:
         vg: "{{ item.value.vg }}"
         lv: "{{ item.value.lv }}"
@@ -43,19 +43,19 @@
 
 
 # Single volume
-- name: SAP Storage Preparation - {{ sap_storage_cloud_type | upper }} - {{ sap_storage_az_vmsize }} - {{ item.value.name }} - Single Volume
+- name: SAP Storage Preparation - {{ qe_sap_storage_cloud_type | upper }} - {{ qe_sap_storage_az_vmsize }} - {{ item.value.name }} - Single Volume
   when:
     - "item.value.numluns == '1'"
   block:
 
     # Get LUNs from metadata
-    - name: SAP Storage Preparation - {{ sap_storage_cloud_type | upper }} - {{ sap_storage_az_vmsize }} - {{ item.value.name }} Get LUNs from metadata
+    - name: SAP Storage Preparation - {{ qe_sap_storage_cloud_type | upper }} - {{ qe_sap_storage_az_vmsize }} - {{ item.value.name }} Get LUNs from metadata
       ansible.builtin.shell: |
-        {{ item.value.vg }}lun="{{ sap_storage_az_lun }} \
+        {{ item.value.vg }}lun="{{ qe_sap_storage_az_lun }} \
           `awk '/caching/ { r=""; f=1 } f { r = (r ? r ORS : "") $0 } \
           /writeAcceleratorEnabled/ \
           { if (f && r ~ /{{ item.value.name }}/) print r; f=0 }' \
-          {{ sap_storage_az_imds_json }} \
+          {{ qe_sap_storage_az_imds_json }} \
           | grep lun | sed 's/[^0-9]*//g'`"
         echo ${{ item.value.vg }}lun
       args:
@@ -67,14 +67,14 @@
         pvs_one: "{{ pvs_reg.stdout }}"
 
     # Create Volume Group
-    - name: SAP Storage Preparation - {{ sap_storage_cloud_type | upper }} - {{ sap_storage_az_vmsize }} - {{ item.value.name }} Volume Group One
+    - name: SAP Storage Preparation - {{ qe_sap_storage_cloud_type | upper }} - {{ qe_sap_storage_az_vmsize }} - {{ item.value.name }} Volume Group One
       community.general.lvg:
         vg: "{{ item.value.vg }}"
         pvs: "{{ pvs_one }}"
         force: true
 
     # Create Logical Group
-    - name: SAP Storage Preparation - {{ sap_storage_cloud_type | upper }} - {{ sap_storage_az_vmsize }} - {{ item.value.name }} Logical Volume - One
+    - name: SAP Storage Preparation - {{ qe_sap_storage_cloud_type | upper }} - {{ qe_sap_storage_az_vmsize }} - {{ item.value.name }} Logical Volume - One
       community.general.lvol:
         vg: "{{ item.value.vg }}"
         lv: "{{ item.value.lv }}"
@@ -82,13 +82,13 @@
 
 
 # Create Filesystem
-- name: SAP Storage Preparation - {{ sap_storage_cloud_type | upper }} - {{ sap_storage_az_vmsize }} - {{ item.value.name }} Filesystem
+- name: SAP Storage Preparation - {{ qe_sap_storage_cloud_type | upper }} - {{ qe_sap_storage_az_vmsize }} - {{ item.value.name }} Filesystem
   community.general.filesystem:
     fstype: xfs
     dev: "/dev/{{ item.value.vg }}/{{ item.value.lv }}"
 
 # Mount Filesystem
-- name: SAP Storage Preparation - {{ sap_storage_cloud_type | upper }} - {{ sap_storage_az_vmsize }} - {{ item.value.name }} Mount
+- name: SAP Storage Preparation - {{ qe_sap_storage_cloud_type | upper }} - {{ qe_sap_storage_az_vmsize }} - {{ item.value.name }} Mount
   ansible.posix.mount:
     path: "{{ item.value.directory }}"
     fstype: xfs

--- a/ansible/roles/qe_sap_storage/tasks/az_tasks/remove_storage.yml
+++ b/ansible/roles/qe_sap_storage/tasks/az_tasks/remove_storage.yml
@@ -1,27 +1,27 @@
 ---
 
 # Unmount Filesystem
-- name: SAP Storage Preparation - {{ sap_storage_cloud_type | upper }} - {{ item.value.name }} Unmount Filesystem
+- name: SAP Storage Preparation - {{ qe_sap_storage_cloud_type | upper }} - {{ item.value.name }} Unmount Filesystem
   ansible.posix.mount:
     path: "{{ item.value.directory }}"
     state: absent
 
 # Remove Filesystem
-- name: SAP Storage Preparation - {{ sap_storage_cloud_type | upper }} - {{ item.value.name }} Remove Filesystem
+- name: SAP Storage Preparation - {{ qe_sap_storage_cloud_type | upper }} - {{ item.value.name }} Remove Filesystem
   ansible.builtin.shell: |
     /sbin/wipefs --all -f /dev/mapper/{{ item.value.vg }}-{{ item.value.lv }}
 
 # Remove Logical Volume
-- name: SAP Storage Preparation - {{ sap_storage_cloud_type | upper }} - {{ item.value.name }} Remove Logical Volume
+- name: SAP Storage Preparation - {{ qe_sap_storage_cloud_type | upper }} - {{ item.value.name }} Remove Logical Volume
   community.general.lvol:
     lv: "{{ item.value.lv }}"
     vg: "{{ item.value.vg }}"
     state: absent
-    force: yes
+    force: true
 
 # Remove Volume Group
-- name: SAP Storage Preparation - {{ sap_storage_cloud_type | upper }} - {{ item.value.name }} Remove Volume Group
+- name: SAP Storage Preparation - {{ qe_sap_storage_cloud_type | upper }} - {{ item.value.name }} Remove Volume Group
   community.general.lvg:
     vg: "{{ item.value.vg }}"
     state: absent
-    force: yes
+    force: true

--- a/ansible/roles/qe_sap_storage/tasks/generic_main.yml
+++ b/ansible/roles/qe_sap_storage/tasks/generic_main.yml
@@ -5,5 +5,5 @@
 ################
 
 - name: SAP Storage Preparation - Generic Pretasks
-  debug:
+  ansible.builtin.debug:
     msg: "No pre task"

--- a/ansible/roles/qe_sap_storage/tasks/generic_tasks/prepare_storage.yml
+++ b/ansible/roles/qe_sap_storage/tasks/generic_tasks/prepare_storage.yml
@@ -69,7 +69,7 @@
     msg: "Using PV list: {{ (adjusted_pv is defined and (adjusted_pv | length) > 0) | ternary(adjusted_pv, item.value.pv) }}"
 
 # Create Volume Group
-- name: SAP Storage Preparation - Volume Group One - {{ sap_storage_cloud_type | upper }} - {{ item.value.name }}
+- name: SAP Storage Preparation - Volume Group One - {{ qe_sap_storage_cloud_type | upper }} - {{ item.value.name }}
   community.general.lvg:
     vg: "{{ item.value.vg }}"
     pvs: "{{ (adjusted_pv is defined and (adjusted_pv | length) > 0) | ternary(adjusted_pv, item.value.pv) }}"
@@ -85,7 +85,7 @@
   when: adjusted_pv is defined
 
 # Create Logical Group - One
-- name: SAP Storage Preparation - {{ sap_storage_cloud_type | upper }} - {{ item.value.name }} Logical Volume - One
+- name: SAP Storage Preparation - {{ qe_sap_storage_cloud_type | upper }} - {{ item.value.name }} Logical Volume - One
   community.general.lvol:
     vg: "{{ item.value.vg }}"
     lv: "{{ item.value.lv }}"
@@ -94,7 +94,7 @@
     - "item.value.numluns == '1'"
 
 # Create Logical Group - Striped
-- name: SAP Storage Preparation - {{ sap_storage_cloud_type | upper }} - {{ item.value.name }} Logical Volume - Striped
+- name: SAP Storage Preparation - {{ qe_sap_storage_cloud_type | upper }} - {{ item.value.name }} Logical Volume - Striped
   community.general.lvol:
     vg: "{{ item.value.vg }}"
     lv: "{{ item.value.lv }}"
@@ -104,13 +104,13 @@
     - "item.value.numluns != '1'"
 
 # Create Filesystem
-- name: SAP Storage Preparation - {{ sap_storage_cloud_type | upper }} - {{ item.value.name }} Filesystem
+- name: SAP Storage Preparation - {{ qe_sap_storage_cloud_type | upper }} - {{ item.value.name }} Filesystem
   community.general.filesystem:
     fstype: xfs
     dev: "/dev/{{ item.value.vg }}/{{ item.value.lv }}"
 
 # Mount Filesystem
-- name: SAP Storage Preparation - {{ sap_storage_cloud_type | upper }} - {{ item.value.name }} Mount
+- name: SAP Storage Preparation - {{ qe_sap_storage_cloud_type | upper }} - {{ item.value.name }} Mount
   ansible.posix.mount:
     path: "{{ item.value.directory }}"
     fstype: xfs

--- a/ansible/roles/qe_sap_storage/tasks/generic_tasks/remove_storage.yml
+++ b/ansible/roles/qe_sap_storage/tasks/generic_tasks/remove_storage.yml
@@ -1,7 +1,7 @@
 ---
 
 # Unmount Filesystem
-- name: SAP Storage Preparation - {{ sap_storage_cloud_type | upper }} - {{ item.value.name }} Unmount Filesystem
+- name: SAP Storage Preparation - {{ qe_sap_storage_cloud_type | upper }} - {{ item.value.name }} Unmount Filesystem
   mount:
     path: "{{ item.value.directory }}"
     state: absent
@@ -9,19 +9,19 @@
 # INFO:
 # this only works right using community Ansible Galaxy filesystem module
 # only interested with native Ansible modules for now
-# - name: SAP Storage Preparation - {{ sap_storage_cloud_type | upper }} - {{ item.value.name }} Filesystem
+# - name: SAP Storage Preparation - {{ qe_sap_storage_cloud_type | upper }} - {{ item.value.name }} Filesystem
 #   filesystem:
 #     dev: "/dev/mapper/{{ item.value.vg }}/{{ item.value.lv }}"
 #     state: absent
 
 # Remove Filesystem
-- name: SAP Storage Preparation - {{ sap_storage_cloud_type | upper }} - {{ item.value.name }} Remove Filesystem
+- name: SAP Storage Preparation - {{ qe_sap_storage_cloud_type | upper }} - {{ item.value.name }} Remove Filesystem
   shell: |
     /sbin/wipefs --all -f /dev/mapper/{{ item.value.vg }}-{{ item.value.lv }}
   ignore_errors: yes
 
 # Remove Logical Volume
-- name: SAP Storage Preparation - {{ sap_storage_cloud_type | upper }} - {{ item.value.name }} Remove Logical Volume
+- name: SAP Storage Preparation - {{ qe_sap_storage_cloud_type | upper }} - {{ item.value.name }} Remove Logical Volume
   community.general.lvol:
     lv: "{{ item.value.lv }}"
     vg: "{{ item.value.vg }}"
@@ -29,7 +29,7 @@
     force: yes
 
 # Remove Volume Group
-- name: SAP Storage Preparation - {{ sap_storage_cloud_type | upper }} - {{ item.value.name }} Remove Volume Group
+- name: SAP Storage Preparation - {{ qe_sap_storage_cloud_type | upper }} - {{ item.value.name }} Remove Volume Group
   community.general.lvg:
     vg: "{{ item.value.vg }}"
     state: absent

--- a/ansible/roles/qe_sap_storage/tasks/main.yml
+++ b/ansible/roles/qe_sap_storage/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
 
 ################
-# Cloud Specific Pre-Tasks - call cloud specific pre tasks thru {{ sap_storage_cloud_type }}_main.yml
+# Cloud Specific Pre-Tasks - call cloud specific pre tasks thru {{ qe_sap_storage_cloud_type }}_main.yml
 ################
 
-- name: SAP Storage Preparation - {{ sap_storage_cloud_type }}
-  include_tasks: "{{ sap_storage_cloud_type }}_main.yml"
+- name: SAP Storage Preparation - {{ qe_sap_storage_cloud_type }}
+  ansible.builtin.include_tasks: "{{ qe_sap_storage_cloud_type }}_main.yml"
 
 ################
-# Main Run - call cloud specific tasks thru {{ sap_storage_cloud_type }}_tasks/prep_storage.yml
+# Main Run - call cloud specific tasks thru {{ qe_sap_storage_cloud_type }}_tasks/prep_storage.yml
 ################
 
-- name: SAP Storage Preparation - {{ sap_storage_action | capitalize }} Volume Groups and Logical Volumes
-  include_tasks: "{{ sap_storage_cloud_type }}_tasks/{{ sap_storage_action }}_storage.yml"
-  loop: "{{ lookup('dict', sap_storage_dict,  wantlist=True) }}"
+- name: SAP Storage Preparation - Volume Groups and Logical Volumes - {{ qe_sap_storage_action | capitalize }}
+  ansible.builtin.include_tasks: "{{ qe_sap_storage_cloud_type }}_tasks/{{ qe_sap_storage_action }}_storage.yml"
+  loop: "{{ lookup('dict', sap_storage_dict, wantlist=True) }}"


### PR DESCRIPTION
Preparation for ticket: https://jira.suse.com/browse/TEAM-10423

This fix warnings like
```
var-naming[no-role-prefix]: Variables names from within roles should use qe_sap_storage_ as a prefix. (vars: sap_storage_az_lun)
```

or
```
fqcn[action-core]: Use FQCN for builtin module actions (include_vars).
```

# Verification
sle-15-SP7-Qesap-Azure-Byos-x86_64-BuildLATEST_AZURE_SLE15_7_BYOS-qesap_azure_saptune_test_msi
 - http://openqaworker15.qa.suse.cz/tests/338002 :green_circle: 

sle-15-SP6-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_6_PAYG-qesap_azure_saptune_test
- http://openqaworker15.qa.suse.cz/tests/338006 :green_circle: 
