### PR TITLE
Add optional NCC edge spoke for GCP

### DIFF
--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -751,3 +751,8 @@ variable "ibsm_subnet_region" {
   default     = ""
 }
 
+variable "ibsm_hub_name" {
+  description = "NCC hub name. If empty, no edge spoke will be created."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
This or adds the necessary terraform code to create edge spokes for test VPCs, to enable the new peering method described in https://jira.suse.com/browse/TEAM-10455

- Related ticket: https://jira.suse.com/browse/TEAM-10455
- Verification Runs:
https://openqa.suse.de/tests/19240758
https://openqa.suse.de/tests/19240759
https://openqa.suse.de/tests/19240760
https://openqa.suse.de/tests/19248642 (latest)
Using the old peering: https://openqa.suse.de/tests/19248720

(see  deploy_qesap_terraform-qesap_exec_terraform.log.txt  to verify that in one case the new peering is used, while in the last case the old peering is used)


(This code was used together with https://github.com/BillAnastasiadis/os-autoinst-distri-opensuse/tree/ncc and with the variable IBSM_NCC_HUB in the clone command)