### PR TITLE
Wait for sudo enablement in GCP

### DIFF
--- a/ansible/playbooks/registration.yaml
+++ b/ansible/playbooks/registration.yaml
@@ -4,6 +4,7 @@
   remote_user: cloudadmin
   become: true
   become_user: root
+  gather_facts: false
   environment:
     ZYPP_LOCK_TIMEOUT: '120'
 
@@ -13,6 +14,20 @@
   tasks:
 
     # Pre flight checks
+    - name: Wait until passwordless sudo works in GCP
+      become: false # This task is to check sudo is ready
+      ansible.builtin.command: sudo -n true
+      register: sudo_test
+      retries: 30
+      delay: 5
+      until: sudo_test.rc == 0
+      changed_when: false
+      failed_when: sudo_test.rc != 0
+
+    - name: Gather facts (manually, after sudo is ready)
+      ansible.builtin.setup:
+      changed_when: false
+
     - name: Check for instance-flavor-check presence
       ansible.builtin.command: which instance-flavor-check
       register: ifc_bin


### PR DESCRIPTION
This pr adds a task to wait for paswordless sudo to be available before moving forward with the rest of the ansible execution. It also disables automatic fact-gathering, and moves it aftair the above task.

- Related ticket:
- Verification runs:
https://openqaworker15.qa.suse.cz/tests/349582
https://openqaworker15.qa.suse.cz/tests/349583
https://openqaworker15.qa.suse.cz/tests/349584