### PR TITLE
Add python3 module registration in 15_sp4

### DIFF
--- a/ansible/playbooks/registration.yaml
+++ b/ansible/playbooks/registration.yaml
@@ -162,7 +162,6 @@
       when:
         - ansible_facts['distribution_major_version'] == "12"
         - to_be_registered
-        - "(is_registercloudguest_bin.rc != 0) or (use_suseconnect | bool)"
 
     - name: Add SLES 12 public cloud module
       ansible.builtin.command: SUSEConnect -p sle-module-public-cloud/12/{{ ansible_facts['architecture'] }}
@@ -174,7 +173,6 @@
       when:
         - ansible_facts['distribution_major_version'] == "12"
         - to_be_registered
-        - "(is_registercloudguest_bin.rc != 0) or (use_suseconnect | bool)"
 
     - name: Add SLES 15 public cloud module
       ansible.builtin.command: SUSEConnect -p sle-module-public-cloud/{{ ansible_facts['distribution_version'] }}/{{ ansible_facts['architecture'] }}
@@ -186,7 +184,6 @@
       when:
         - ansible_facts['distribution_major_version'] == "15"
         - to_be_registered
-        - "(is_registercloudguest_bin.rc != 0) or (use_suseconnect | bool)"
 
     - name: Add python3 module in 15_SP4
       ansible.builtin.command: SUSEConnect -p sle-module-python3/{{ ansible_facts['distribution_version'] }}/{{ ansible_facts['architecture'] }}
@@ -198,7 +195,6 @@
       when:
         - ansible_facts['distribution_version'] == '15.4'
         - to_be_registered
-        - "(is_registercloudguest_bin.rc != 0) or (use_suseconnect | bool)"
 
     # Latest version of cloud-regionsrv-client is needed in PAYG, and image
     # needs to be registered in order for zypper up to work.

--- a/ansible/playbooks/registration.yaml
+++ b/ansible/playbooks/registration.yaml
@@ -188,6 +188,18 @@
         - to_be_registered
         - "(is_registercloudguest_bin.rc != 0) or (use_suseconnect | bool)"
 
+    - name: Add python3 module in 15_SP4
+      ansible.builtin.command: SUSEConnect -p sle-module-python3/{{ ansible_facts['distribution_version'] }}/{{ ansible_facts['architecture'] }}
+      register: result
+      changed_when: result.rc == 0
+      until: result is succeeded
+      retries: 10
+      delay: 60
+      when:
+        - ansible_facts['distribution_version'] == '15.4'
+        - to_be_registered
+        - "(is_registercloudguest_bin.rc != 0) or (use_suseconnect | bool)"
+
     # Latest version of cloud-regionsrv-client is needed in PAYG, and image
     # needs to be registered in order for zypper up to work.
     # see https://www.suse.com/c/long-term-service-pack-support-for-payg-instances-simplified/


### PR DESCRIPTION
Module is recommended but not installed by default

Ticket: https://jira.suse.com/browse/TEAM-11057

# Verification 

## 15sp4
### GCP
sle-15-SP4-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE15_4-qesap_gcp_sapconf_test
- http://openqaworker15.qe.prg2.suse.org/tests/360698 at first commit
- http://openqaworker15.qe.prg2.suse.org/tests/360794 at first commit
- http://openqaworker15.qe.prg2.suse.org/tests/361139 :green_circle: module is implicitly registered as image is PAYG https://openqaworker15.qe.prg2.suse.org/tests/361139/logfile?filename=deploy-ansible.registration.log.txt#line-166 **SLE-Module-Python3-15-SP4-Updates**

sle-15-SP4-HanaSr-Gcp-Byos-x86_64-Build15-SP4 hanasr_gcp_test_fencing_native
- http://openqaworker15.qe.prg2.suse.org/tests/360703  at first commit
- http://openqaworker15.qe.prg2.suse.org/tests/361140
- http://openqaworker15.qe.prg2.suse.org/tests/361142 :green_circle: Python3 module registered here https://openqaworker15.qe.prg2.suse.org/tests/361142/logfile?filename=deploy_qesap_ansible-ansible.registration.log.txt#line-867

### AWS
sle-15-SP4-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_4-qesap_aws_saptune_test
 - http://openqaworker15.qe.prg2.suse.org/tests/360699  at first commit
 - http://openqaworker15.qe.prg2.suse.org/tests/361141 :green_circle: here the Python3 module registered https://openqaworker15.qe.prg2.suse.org/tests/361141/logfile?filename=deploy-ansible.registration.log.txt#line-143

sle-15-SP4-HanaSr-Aws-Payg-x86_64-Build15-SP4_2026-03-26T03:03:26Z-hanasr_aws_test_fencing_native ec2_r4.8xlarge
 - http://openqaworker15.qe.prg2.suse.org/tests/360701  at first commit
 - http://openqaworker15.qe.prg2.suse.org/tests/361143 :green_circle: explicit register of python3 is not performed as image is PAYG but module is there https://openqaworker15.qe.prg2.suse.org/tests/361143/logfile?filename=deploy_qesap_ansible-ansible.registration.log.txt#line-805

### Azure
sle-15-SP4-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE15_4-qesap_azure_saptune_test 
- http://openqaworker15.qe.prg2.suse.org/tests/360700  at first commit
- http://openqaworker15.qe.prg2.suse.org/tests/361206 :green_circle: 

sle-15-SP4-HanaSr-Azure-Byos-x86_64-Build15-SP4_2026-03-26T03:03:26Z-hanasr_azure_test_msi az_Standard_E4s_v3
- http://openqaworker15.qe.prg2.suse.org/tests/360702  at first commit
-  http://openqaworker15.qe.prg2.suse.org/tests/361207 :green_circle: https://openqaworker15.qe.prg2.suse.org/tests/361207/logfile?filename=deploy_qesap_ansible-ansible.registration.log.txt#line-1041


## 12sp5

### GCP
sle-12-SP5-Qesap-Gcp-Byos-x86_64-BuildLATEST_GCE_SLE12_5-qesap_gcp_saptune_ltss_es_test
- http://openqaworker15.qe.prg2.suse.org/tests/361144
- http://openqaworker15.qe.prg2.suse.org/tests/361238

sle-12-SP5-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE12_5-qesap_gcp_saptune_ltss_test
- http://openqaworker15.qe.prg2.suse.org/tests/361145 :green_circle: LTSS registration remain ok https://openqaworker15.qe.prg2.suse.org/tests/361145/logfile?filename=deploy-ansible.registration.log.txt#line-162
 
### AWS
sle-12-SP5-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE12_5-qesap_aws_saptune_ltss_es_test
 - http://openqaworker15.qe.prg2.suse.org/tests/361239

sle-12-SP5-Qesap-Aws-Payg-x86_64-BuildLATEST_AWS_SLE12_5-qesap_aws_saptune_ltss_test
 - http://openqaworker15.qe.prg2.suse.org/tests/361240
 
