### PR TITLE
Remove unused package ha-cluster-bootstrap from deployment

### DIFF
--- a/ansible/playbooks/tasks/aws-cluster-bootstrap.yaml
+++ b/ansible/playbooks/tasks/aws-cluster-bootstrap.yaml
@@ -26,18 +26,9 @@
     - credentials
     - config
 
-- name: Define base package dependencies list
-  ansible.builtin.set_fact:
-    pkg_dependencies: ['corosync', 'crmsh', 'fence-agents', 'pacemaker', 'patterns-ha-ha_sles', 'resource-agents', 'rsyslog', 'socat']
-
-- name: Add extra packages for SLES versions below 16
-  ansible.builtin.set_fact:
-    pkg_dependencies: "{{ pkg_dependencies + ['ha-cluster-bootstrap'] }}"
-  when: ansible_distribution_major_version != '16'
-
 - name: Ensure cluster dependencies are installed
-  community.general.zypper:
-    name: "{{ pkg_dependencies }}"
+  ansible.builtin.package:
+    name: ['corosync', 'crmsh', 'fence-agents', 'pacemaker', 'patterns-ha-ha_sles', 'resource-agents', 'rsyslog', 'socat']
     state: present
   register: result
   until: result is succeeded

--- a/ansible/playbooks/tasks/gcp-cluster-bootstrap.yaml
+++ b/ansible/playbooks/tasks/gcp-cluster-bootstrap.yaml
@@ -7,18 +7,9 @@
   ansible.builtin.set_fact:
     corosync_template: "../templates/gcp_corosync.conf.j2"
 
-- name: Define base package dependencies list
-  ansible.builtin.set_fact:
-    pkg_dependencies: ['corosync', 'crmsh', 'fence-agents', 'pacemaker', 'patterns-ha-ha_sles', 'resource-agents', 'rsyslog', 'socat']
-
-- name: Add extra packages for SLES versions below 16
-  ansible.builtin.set_fact:
-    pkg_dependencies: "{{ pkg_dependencies + ['ha-cluster-bootstrap'] }}"
-  when: ansible_distribution_major_version != '16'
-
 - name: Ensure cluster dependencies are installed
-  community.general.zypper:
-    name: "{{ pkg_dependencies }}"
+  ansible.builtin.package:
+    name: ['corosync', 'crmsh', 'fence-agents', 'pacemaker', 'patterns-ha-ha_sles', 'resource-agents', 'rsyslog', 'socat']
     state: present
   register: result
   until: result is succeeded


### PR DESCRIPTION
While working on TEAM-11037, we noticed that we are not using the scripts in the ha-cluster-bootstrap package on any CSP and any SLE version, so the deployment should not have it as a dependency.

This removes it and makes use of the builtin package management task for ansible instead of the community one.

Related Ticket: TEAM-11105
Verification Runs: https://openqaworker15.qe.prg2.suse.org/tests/overview?build=apappas&distri=sle