### PR TITLE
Add timeouts for azure disk attachments

### DIFF
--- a/terraform/azure/modules/hana_node/main.tf
+++ b/terraform/azure/modules/hana_node/main.tf
@@ -382,7 +382,10 @@ resource "azurerm_virtual_machine_data_disk_attachment" "hana_data_disk_attachme
   lun                = count.index % local.disks_number
   caching            = element(local.disks_caching, count.index % local.disks_number)
   timeouts {
-    read = "30m"
+    read   = "30m"
+    create = "30m"
+    update = "30m"
+    delete = "30m"
   }
 }
 


### PR DESCRIPTION
Adding timeouts in create/update/delete operations in `hana_data_disk_attachment`s, to try and mitigate sporadic concurrent operation errors. This is, in essense, an extension of https://github.com/SUSE/qe-sap-deployment/pull/342/changes, that did the same for read operations.

- Related ticket: https://jira.suse.com/browse/TEAM-11065
- Verification run: (manual runs - did not hit the problem with it enabled, worth a try)