### PR TITLE
Improve Pacemaker cluster bootstrap and conditionally use logd

### DIFF
--- a/ansible/playbooks/tasks/aws-cluster-bootstrap.yaml
+++ b/ansible/playbooks/tasks/aws-cluster-bootstrap.yaml
@@ -49,11 +49,19 @@
 # if either of the the above conditions are false the back `Create authkeys` is run.
 # It will shutdown pacemaker on all nodes, write the authfile to the primary node and then copy it the other nodes.
 # Finally, it will notify a handler to start corosync.
+- name: Gather package facts
+  ansible.builtin.package_facts:
+    manager: auto
+
+# ha_logd (logd) is provided by cluster-glue, which has been dropped in SLE 16.
+# Pacemaker >= 2.0.0 no longer uses ha_logd (adopted libqb logging instead),
+# so this is only needed for SLE 12 SP5 with Pacemaker 1.x.
 - name: Ensure logd is enabled and started
   ansible.builtin.systemd:
     name: logd
     state: started
     enabled: true
+  when: ansible_facts.packages['pacemaker'][0].version is version('2.0.0', '<')
 
 - name: Register authkey status
   ansible.builtin.stat:
@@ -142,6 +150,36 @@
 
 - name: Flush handler
   ansible.builtin.meta: flush_handlers
+
+- name: Check pacemaker service status
+  ansible.builtin.service_facts:
+
+- name: Set pacemaker running status
+  ansible.builtin.set_fact:
+    pacemaker_is_running: "{{ ansible_facts.services['pacemaker.service'].state | default('') == 'running' }}"
+
+- name: Collect pacemaker diagnostics on failure
+  ansible.builtin.command: "{{ item }}"  # noqa command-instead-of-module
+  loop:
+    - systemctl status pacemaker.service --no-pager -l
+    - journalctl --no-pager -u pacemaker --lines=50
+  register: pacemaker_diag
+  failed_when: false
+  changed_when: false
+  when: not pacemaker_is_running | bool
+
+- name: Display pacemaker diagnostics
+  ansible.builtin.debug:
+    msg: "{{ item.item }}:\n{{ item.stdout }}"
+  loop: "{{ pacemaker_diag.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+  when: not pacemaker_is_running | bool
+
+- name: Fail if pacemaker is not running
+  ansible.builtin.fail:
+    msg: "Pacemaker is not running after bootstrap. See diagnostics above."
+  when: not pacemaker_is_running | bool
 
 - name: Get DefaultTasksMax value
   ansible.builtin.command:  # noqa command-instead-of-module

--- a/ansible/playbooks/tasks/gcp-cluster-bootstrap.yaml
+++ b/ansible/playbooks/tasks/gcp-cluster-bootstrap.yaml
@@ -30,11 +30,19 @@
 # if either of the the above conditions are false the back `Create authkeys` is run.
 # It will shutdown pacemaker on all nodes, write the authfile to the primary node and then copy it the other nodes.
 # Finally, it will notify a handler to start corosync.
+- name: Gather package facts
+  ansible.builtin.package_facts:
+    manager: auto
+
+# ha_logd (logd) is provided by cluster-glue, which has been dropped in SLE 16.
+# Pacemaker >= 2.0.0 no longer uses ha_logd (adopted libqb logging instead),
+# so this is only needed for SLE 12 SP5 with Pacemaker 1.x.
 - name: Ensure logd is enabled and started
   ansible.builtin.systemd:
     name: logd
     state: started
     enabled: true
+  when: ansible_facts.packages['pacemaker'][0].version is version('2.0.0', '<')
 
 - name: Register authkey status
   ansible.builtin.stat:
@@ -123,6 +131,36 @@
 
 - name: Flush handler
   ansible.builtin.meta: flush_handlers
+
+- name: Check pacemaker service status
+  ansible.builtin.service_facts:
+
+- name: Set pacemaker running status
+  ansible.builtin.set_fact:
+    pacemaker_is_running: "{{ ansible_facts.services['pacemaker.service'].state | default('') == 'running' }}"
+
+- name: Collect pacemaker diagnostics on failure
+  ansible.builtin.command: "{{ item }}"  # noqa command-instead-of-module
+  loop:
+    - systemctl status pacemaker.service --no-pager -l
+    - journalctl --no-pager -u pacemaker --lines=50
+  register: pacemaker_diag
+  failed_when: false
+  changed_when: false
+  when: not pacemaker_is_running | bool
+
+- name: Display pacemaker diagnostics
+  ansible.builtin.debug:
+    msg: "{{ item.item }}:\n{{ item.stdout }}"
+  loop: "{{ pacemaker_diag.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+  when: not pacemaker_is_running | bool
+
+- name: Fail if pacemaker is not running
+  ansible.builtin.fail:
+    msg: "Pacemaker is not running after bootstrap. See diagnostics above."
+  when: not pacemaker_is_running | bool
 
 - name: Get DefaultTasksMax value
   ansible.builtin.command:  # noqa command-instead-of-module


### PR DESCRIPTION
Add conditional logic for the logd service, ensuring it only starts when Pacemaker version is below 2.0.0, to maintain compatibility with SLE 16 where cluster-glue (logd) is deprecated.

Additionally, implement a post-bootstrap health check for the Pacemaker service on AWS and GCP. If the service fails to start, the playbook now automatically collects and displays systemd status and journal logs to simplify troubleshooting.

Ticket: https://jira.suse.com/browse/TEAM-11141

# VR

## qesap regression

### 16.0
sle-16.0-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE16_0-qesap_gcp_angi_test
- http://openqaworker15.qe.prg2.suse.org/tests/363023 :green_circle: deployment fails on the next known issue `pacemaker.service` 

### 12sp5
sle-12-SP5-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE12_5-qesap_aws_saptune_ltss_es_test
- http://openqaworker15.qe.prg2.suse.org/tests/363054 :green_circle:
- http://openqaworker15.qe.prg2.suse.org/tests/363055 :green_circle:

### 15sp4
sle-15-SP4-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE15_4-qesap_gcp_sapconf_test
- http://openqaworker15.qe.prg2.suse.org/tests/363056 :green_circle:

## HanaSR

sle-12-SP5-HanaSr-Gcp-Byos-x86_64-Build12-SP5  hanasr_gcp_test_fencing_native_ltss_es gce_n1_highmem_32
- http://openqaworker15.qe.prg2.suse.org/tests/362910 :green_circle: 

sle-12-SP5-HanaSr-Aws-Payg-x86_64-Build12-SP5  hanasr_aws_test_fencing_native_ltss ec2_r4.8xlarge
 - http://openqaworker15.qe.prg2.suse.org/tests/362911 :green_circle: 
