### PR TITLE
Stop pinning azure-core

### DIFF
--- a/ansible/playbooks/tasks/azure-cluster-bootstrap.yaml
+++ b/ansible/playbooks/tasks/azure-cluster-bootstrap.yaml
@@ -30,22 +30,6 @@
       ansible_distribution_version is version('15.5', '==') or
       ansible_distribution_version is version('12.5', '==')
 
-# For SLES 12 a we need to force a downgrade of python-azure-core see https://www.suse.com/support/kb/doc/?id=000020716
-- name: Ensure Azure Python SDK and Azure Identity python modules are installed [12sp5]
-  community.general.zypper:
-    name: "{{ item }}"
-    state: present
-  loop:
-    - 'python-azure-mgmt-compute'
-    - 'python-azure-identity'
-    - 'python-azure-core==1.9.0-2.3.4'
-  when:
-    - ansible_distribution_version is version('12.5', '==')
-  register: result
-  until: result is succeeded
-  retries: 3
-  delay: 60
-
 - name: Ensure Azure Python SDK and Azure Identity python modules are installed [15 sp<4]
   community.general.zypper:
     name: "{{ item }}"


### PR DESCRIPTION
For SLES 12, we needed to force a downgrade of python-azure-core according to https://www.suse.com/support/kb/doc/?id=000020716. But a fix has since been released and we are still using the old package.

This removes the pinning.

Related Ticket: TEAM-11103
VR: https://openqaworker15.qe.prg2.suse.org/tests/363111