### PR TITLE
Remove explicit installation of python-httplib2

### DIFF
--- a/ansible/playbooks/tasks/aws-cluster-bootstrap.yaml
+++ b/ansible/playbooks/tasks/aws-cluster-bootstrap.yaml
@@ -35,16 +35,6 @@
   retries: 3
   delay: 60
 
-# This is a workaround for https://bugzilla.suse.com/show_bug.cgi?id=1231153
-# If it is fixed, this task will no longer be needed
-- name: Install python-httplib2 via zypper
-  community.general.zypper:
-    name: python-httplib2
-    state: present
-  when: ansible_distribution_major_version == '12'
-  register: httplib2_zypper
-  ignore_errors: true
-
 # The following tasks check that the file /etc/corosync/authkey exists on each node and that all nodes have an identical copy
 # if either of the the above conditions are false the back `Create authkeys` is run.
 # It will shutdown pacemaker on all nodes, write the authfile to the primary node and then copy it the other nodes.

--- a/ansible/playbooks/tasks/gcp-cluster-bootstrap.yaml
+++ b/ansible/playbooks/tasks/gcp-cluster-bootstrap.yaml
@@ -16,16 +16,6 @@
   retries: 3
   delay: 60
 
-# This is a workaround for https://bugzilla.suse.com/show_bug.cgi?id=1231153
-# If it is fixed, this task will no longer be needed
-- name: Install python-httplib2 via zypper
-  community.general.zypper:
-    name: python-httplib2
-    state: present
-  when: ansible_distribution_major_version == '12'
-  register: httplib2_zypper
-  ignore_errors: true
-
 # The following tasks check that the file /etc/corosync/authkey exists on each node and that all nodes have an identical copy
 # if either of the the above conditions are false the back `Create authkeys` is run.
 # It will shutdown pacemaker on all nodes, write the authfile to the primary node and then copy it the other nodes.


### PR DESCRIPTION
TEAM-9693 added an ansible task to explicitly install the gce_fence dependency python-httplib2, that should have been pulled in automatically but wasn't due to bsc#1231153.

The bug has since been resolved and the new task should no longer be needed so we remove it with this commit.

Related Ticket: TEAM-11094
Verification Runs: 
GCP: https://openqaworker15.qe.prg2.suse.org/tests/363266/logfile?filename=Cleanup_resources-hana0-rpm-qa.txt&filter=python-httplib2
AWS: https://openqaworker15.qe.prg2.suse.org/tests/363110/logfile?filename=Crash_site_a-primary-hana0-rpm-qa.txt&filter=python-httplib2 
It is not there in AWS but is not necessary, so we did need to install it.