### PR TITLE
Fix corosync 3.x startup failure on SLE 16.0

### DIFF
--- a/ansible/playbooks/templates/aws_corosync.conf.j2
+++ b/ansible/playbooks/templates/aws_corosync.conf.j2
@@ -3,10 +3,14 @@ totem {
         token: 30000
         consensus: 36000
         token_retransmits_before_loss_const: 6
+{% if ansible_facts.packages['corosync'][0].version is version('3.0.0', '<') %}
         crypto_cipher: {{ crypto_cipher }}
         crypto_hash: {{ crypto_hash }}
+{% endif %}
         clear_node_high_bit: yes
+{% if ansible_facts.packages['corosync'][0].version is version('3.0.0', '<') %}
         rrp_mode: passive
+{% endif %}
 
         interface {
                 ringnumber: 0

--- a/ansible/playbooks/templates/corosync.conf.j2
+++ b/ansible/playbooks/templates/corosync.conf.j2
@@ -3,10 +3,14 @@ totem {
         token: 30000
         consensus: 36000
         token_retransmits_before_loss_const: 6
+{% if ansible_facts.packages['corosync'][0].version is version('3.0.0', '<') %}
         crypto_cipher: {{ crypto_cipher }}
         crypto_hash: {{ crypto_hash }}
+{% endif %}
         clear_node_high_bit: yes
+{% if ansible_facts.packages['corosync'][0].version is version('3.0.0', '<') %}
         rrp_mode: passive
+{% endif %}
 
         interface {
                 ringnumber: 0

--- a/ansible/playbooks/templates/gcp_corosync.conf.j2
+++ b/ansible/playbooks/templates/gcp_corosync.conf.j2
@@ -1,8 +1,10 @@
 totem {
         version: 2
+{% if ansible_facts.packages['corosync'][0].version is version('3.0.0', '<') %}
         secauth: off
         crypto_hash: sha1
         crypto_cipher: aes256
+{% endif %}
         cluster_name: hacluster
         clear_node_high_bit: yes
         token: 20000


### PR DESCRIPTION
Fix corosync by omitting invalid config options.
Corosync 3.x (shipped in SLE 16.0) rejects crypto_cipher, crypto_hash, and secauth when transport is udpu, causing corosync to exit with code 8 and pacemaker to fail on its dependency.
These options are safe to omit because they were never functional with udpu transport — corosync 2.x silently accepted them but only supported encryption on multicast (UDP) transport. Cluster traffic was never encrypted with udpu, so removing these options changes no runtime behavior. Similarly, rrp_mode (removed in corosync 3.x) had no effect with a single interface.
The version conditional preserves the existing config for corosync 2.x (SLE 12 SP5, SLE 15 SP4/SP5) and only omits the options on 3.x+.

Ticket: https://jira.suse.com/browse/TEAM-11163

# Verification:

## 16.0
sle-16.0-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE16_0-qesap_gcp_angi_test
-  http://openqaworker15.qe.prg2.suse.org/tests/363644 :green_circle: fail in destroy, I do not think it is related to this change
- https://openqaworker15.qe.prg2.suse.org/tests/363736

sle-16.0-HanaSr-Aws-Payg-x86_64-Build16.0_2026-04-22T02:03:26Z-hanasr_aws_test_fencing_native_stop_kill ec2_r4.8xlarge
 - http://openqaworker15.qe.prg2.suse.org/tests/363733 :green_circle: 

sle-16.0-HanaSr-Azure-Byos-x86_64-Build16.0_2026-04-22T02:03:26Z-hanasr_azure_test_msi az_Standard_E4s_v3
- http://openqaworker15.qe.prg2.suse.org/tests/363734 :red_circle: fail due to TEAM-11186

sle-16.0-HanaSr-Gcp-Byos-x86_64-Build16.0_2026-04-22T02:03:26Z-hanasr_gcp_test_fencing_native_stop_kill gce_n1_highmem_32 
- http://openqaworker15.qe.prg2.suse.org/tests/363735

 
## Not 16.0
sle-12-SP5-Qesap-Aws-Payg-x86_64-BuildLATEST_AWS_SLE12_5-qesap_aws_saptune_ltss_test
 - http://openqaworker15.qe.prg2.suse.org/tests/363643 :green_circle: `corosync: release:"9.22.1" version:"2.3.6"
`