### PR TITLE
Fix deprecated syntax for AWS ssh keys

### DIFF
--- a/terraform/aws/adminuser.tpl
+++ b/terraform/aws/adminuser.tpl
@@ -7,6 +7,6 @@ users:
     sudo:
       - "ALL=(ALL) NOPASSWD:ALL"
     shell: /bin/bash
-    ssh-authorized-keys: 
+    ssh_authorized_keys: 
     - ${publickey}
 fqdn: ${hostname}.${domain}


### PR DESCRIPTION
This PR aims to replace deprecated syntax `ssh-authorized-keys` with the new syntax `ssh_authorized_keys`.

- Related ticket: https://jira.suse.com/browse/TEAM-11192
- Verification run: https://openqa.suse.de/tests/22022383
12sp5 job for compatibility: https://openqaworker15.qe.prg2.suse.org/tests/364035