### PR TITLE
Add patterns-cockpit as new requirements for saptune 3.2.3

### DIFF
--- a/ansible/playbooks/tasks/saptune.yaml
+++ b/ansible/playbooks/tasks/saptune.yaml
@@ -11,6 +11,14 @@
   retries: 3
   delay: 60
 
+- name: Install saptune dependency
+  community.general.zypper:
+    name: 'patterns-cockpit'
+    state: present
+  when:
+    - "'saptune' in ansible_facts.packages"
+    - ansible_facts.packages['saptune'][0].version is version('3.2.3', '>=')
+
 - name: Ensure conflicting services are stopped and disabled
   ansible.builtin.systemd:
     name: "{{ item }}"


### PR DESCRIPTION
Saptune 3.2.3 introduced a mandatory check for 'patterns-cockpit'. Since this package is missing from standard cloud images, 'saptune solution verify' fails during deployment. This change adds a task to gather package facts and install 'patterns-cockpit' when saptune version >= 3.2.3 and pacemaker is present, ensuring successful HANA solution verification.

Ticket: [TEAM-11186](https://jira.suse.com/browse/TEAM-11186)

# Verification

- sle-16.0-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE16_0-qesap_gcp_angi_test
http://openqaworker15.qe.prg2.suse.org/tests/364036 :green_circle: package installed at https://openqaworker15.qe.prg2.suse.org/tests/364036/logfile?filename=deploy-ansible.sap-hana-preconfigure.log.txt#line-228 and saptune find it https://openqaworker15.qe.prg2.suse.org/tests/364036/logfile?filename=deploy-ansible.sap-hana-preconfigure.log.txt#line-285

- 15sp7
https://openqaworker15.qe.prg2.suse.org/tests/364065
https://openqaworker15.qe.prg2.suse.org/tests/364068


