### PR TITLE
Add saptune 3.2.3 softfail for patterns-cockpit and TSX diagnostics

### DIFF
--- a/ansible/playbooks/tasks/saptune.yaml
+++ b/ansible/playbooks/tasks/saptune.yaml
@@ -23,6 +23,46 @@
     - ansible_facts.packages['saptune'][0].version is version('3.2.3', '>=')
     - ansible_distribution_major_version == '16'
 
+# patterns-cockpit is a dependency introduced in saptune 3.2.3 on SLES 16
+# and is expected to be eventually dropped.
+# https://bugzilla.suse.com/show_bug.cgi?id=1262794#c4 and https://bugzilla.suse.com/show_bug.cgi?id=1262794#c5
+- name: Softfail for patterns-cockpit saptune dependency
+  ansible.builtin.debug:
+    msg:
+      - "[OSADO][softfail] bsc#1262794 patterns-cockpit saptune dependency will be eventually removed"
+  when:
+    - ansible_facts.packages['saptune'][0].version is version('3.2.3', '>=')
+    - ansible_distribution_major_version == '16'
+
+- name: Collect TSX diagnostic information
+  ansible.builtin.shell: |
+    set -o pipefail
+    printf '=== CPU: model / hypervisor / virt-type ===\n'
+    lscpu | grep -iE 'Model name|Hypervisor|Virtualization type'
+    printf '=== Kernel config: CONFIG_X86_INTEL_TSX ===\n'
+    grep CONFIG_X86_INTEL_TSX "/boot/config-$(uname -r)" 2>/dev/null || echo '(not found)'
+    printf '=== TAA mitigation ===\n'
+    cat /sys/devices/system/cpu/vulnerabilities/tsx_async_abort 2>/dev/null || echo '(not found)'
+    printf '=== saptune grub:tsx note sections ===\n'
+    for n in 3577842 2684254; do
+      f="/usr/share/saptune/notes/$n"
+      [ -f "$f" ] && grep -E '^\[grub|^tsx=' "$f"
+    done
+    true
+  register: tsx_diag
+  changed_when: false
+  failed_when: false
+  when:
+    - ansible_facts.packages['saptune'][0].version is version('3.2.3', '>=')
+    - ansible_distribution_major_version == '16'
+
+- name: Show TSX diagnostic information
+  ansible.builtin.debug:
+    var: tsx_diag.stdout_lines
+  when:
+    - ansible_facts.packages['saptune'][0].version is version('3.2.3', '>=')
+    - ansible_distribution_major_version == '16'
+
 # WORKAROUND for SAP Note 3577842 grub:tsx on cloud VMs (TEAM-11186, bsc#1263100).
 #
 # saptune >= 3.2.3 on SLES 16 checks that tsx=auto appears in /proc/cmdline.


### PR DESCRIPTION
Introduce a softfail debug message for the patterns-cockpit dependency to indicate it is a temporary workaround (bsc#1262794). Add diagnostic tasks to collect TSX-related information (CPU, kernel config, TAA mitigation, and saptune notes) to troubleshoot grub:tsx compliance issues on cloud platforms.

Ticket: https://jira.suse.com/browse/TEAM-11186

# Verifications

 - sle-16.0-Qesap-Gcp-Payg-x86_64-BuildLATEST_GCE_SLE16_0-qesap_gcp_angi_test@64bit -> http://openqaworker15.qe.prg2.suse.org/tests/367220 :green_circle: softfail http://openqaworker15.qe.prg2.suse.org/tests/367220/logfile?filename=deploy-ansible.sap-hana-preconfigure.log.txt#line-239  and http://openqaworker15.qe.prg2.suse.org/tests/367220#step/deploy/114 

 - sle-16.0-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE16_0-qesap_aws_saptune_angi_test@64bit -> http://openqaworker15.qe.prg2.suse.org/tests/367222 :green_circle: softfail is there but deployment fails later. Failure is present also without this PR

 - sle-16.0-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE16_0-qesap_azure_saptune_test_msi@64bit -> http://openqaworker15.qe.prg2.suse.org/tests/367223 :green_circle: 

 - sle-15-SP7-Qesap-Gcp-Byos-x86_64-BuildLATEST_GCE_SLE15_7-qesap_gcp_angi_test@64bit -> http://openqaworker15.qe.prg2.suse.org/tests/367221 :green_circle:  no task as expected


