### PR TITLE
Add optional custom tags functionality to Azure

### DIFF
--- a/terraform/azure/infrastructure.tf
+++ b/terraform/azure/infrastructure.tf
@@ -53,6 +53,11 @@ locals {
     for s in split(",", var.allowed_ssh_cidr_csv) : trimspace(s)
     if trimspace(s) != ""
   ]
+
+  base_tags = {
+    workspace = local.deployment_name
+  }
+  tags = merge(local.base_tags, var.custom_tags)
 }
 
 # Azure resource group and storage account resources. Create one here
@@ -61,6 +66,7 @@ resource "azurerm_resource_group" "myrg" {
   count    = var.resource_group_name == "" ? 1 : 0
   name     = "rg-ha-sap-${local.deployment_name}"
   location = var.az_region
+  tags     = local.tags
 }
 
 resource "azurerm_storage_account" "mytfstorageacc" {
@@ -69,10 +75,7 @@ resource "azurerm_storage_account" "mytfstorageacc" {
   location                 = var.az_region
   account_replication_type = "LRS"
   account_tier             = "Standard"
-
-  tags = {
-    workspace = local.deployment_name
-  }
+  tags                     = local.tags
 }
 
 # Network resources: Virtual Network, Subnet, Netapp Subnet
@@ -82,10 +85,7 @@ resource "azurerm_virtual_network" "mynet" {
   address_space       = [local.vnet_address_range]
   location            = var.az_region
   resource_group_name = local.resource_group_name
-
-  tags = {
-    workspace = local.deployment_name
-  }
+  tags                = local.tags
 }
 
 resource "azurerm_subnet" "mysubnet" {
@@ -119,9 +119,7 @@ resource "azurerm_route_table" "myroutes" {
     next_hop_type  = "VnetLocal"
   }
 
-  tags = {
-    workspace = local.deployment_name
-  }
+  tags = local.tags
 }
 
 # Azure Netapp Files resources (see README for ANF setup)
@@ -155,6 +153,7 @@ resource "azurerm_netapp_account" "mynetapp-acc" {
   name                = "netapp-acc-${lower(local.deployment_name)}"
   resource_group_name = local.resource_group_name
   location            = var.az_region
+  tags                = local.tags
 }
 
 resource "azurerm_netapp_pool" "mynetapp-pool" {
@@ -165,6 +164,7 @@ resource "azurerm_netapp_pool" "mynetapp-pool" {
   resource_group_name = local.resource_group_name
   service_level       = var.anf_pool_service_level
   size_in_tb          = var.anf_pool_size
+  tags                = local.tags
 }
 
 # Security group
@@ -315,9 +315,7 @@ resource "azurerm_network_security_group" "mysecgroup" {
     destination_address_prefix = "*"
   }
 
-  tags = {
-    workspace = local.deployment_name
-  }
+  tags = local.tags
 }
 
 # IBSM

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -119,6 +119,7 @@ module "drbd_node" {
   tenant_id                 = data.azurerm_subscription.current.tenant_id
   fence_agent_app_id        = var.fence_agent_app_id
   fence_agent_client_secret = var.fence_agent_client_secret
+  tags                      = local.tags
 }
 
 module "netweaver_node" {
@@ -157,6 +158,7 @@ module "netweaver_node" {
   tenant_id                 = data.azurerm_subscription.current.tenant_id
   fence_agent_app_id        = var.fence_agent_app_id
   fence_agent_client_secret = var.fence_agent_client_secret
+  tags                      = local.tags
 }
 
 module "hana_node" {
@@ -191,6 +193,7 @@ module "hana_node" {
   tenant_id                 = data.azurerm_subscription.current.tenant_id
   fence_agent_app_id        = var.fence_agent_app_id
   fence_agent_client_secret = var.fence_agent_client_secret
+  tags                      = local.tags
   # passed to majority_maker module
   majority_maker_vm_size = var.hana_majority_maker_vm_size
   majority_maker_ip      = local.hana_majority_maker_ip
@@ -210,6 +213,7 @@ module "monitoring" {
   monitoring_uri      = local.monitoring_os_image_uri
   os_image            = local.monitoring_os_image
   monitoring_srv_ip   = local.monitoring_ip
+  tags                = local.tags
 }
 
 module "iscsi_server" {
@@ -228,4 +232,5 @@ module "iscsi_server" {
   host_ips            = local.iscsi_ips
   lun_count           = var.iscsi_lun_count
   iscsi_disk_size     = var.iscsi_disk_size
+  tags                = local.tags
 }

--- a/terraform/azure/modules/drbd_node/main.tf
+++ b/terraform/azure/modules/drbd_node/main.tf
@@ -14,10 +14,7 @@ resource "azurerm_availability_set" "drbd-availability-set" {
   resource_group_name         = var.resource_group_name
   managed                     = "true"
   platform_fault_domain_count = 2
-
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags                        = var.tags
 }
 
 # drbd load balancer items
@@ -35,9 +32,7 @@ resource "azurerm_lb" "drbd-load-balancer" {
     private_ip_address            = var.common_variables["drbd"]["cluster_vip"]
   }
 
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags = var.tags
 }
 
 resource "azurerm_lb_backend_address_pool" "drbd-backend-pool" {
@@ -119,10 +114,7 @@ resource "azurerm_public_ip" "drbd" {
   resource_group_name     = var.resource_group_name
   allocation_method       = "Static"
   idle_timeout_in_minutes = 30
-
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags                    = var.tags
 }
 
 resource "azurerm_network_interface" "drbd" {
@@ -139,9 +131,7 @@ resource "azurerm_network_interface" "drbd" {
     public_ip_address_id          = element(azurerm_public_ip.drbd.*.id, count.index)
   }
 
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags = var.tags
 }
 
 # drbd custom image. only available is drbd_image_uri is used
@@ -160,9 +150,7 @@ resource "azurerm_image" "drbd-image" {
     storage_type = "Premium_LRS"
   }
 
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags = var.tags
 }
 
 # drbd instances
@@ -180,6 +168,7 @@ resource "azurerm_managed_disk" "drbd_data_disk" {
   storage_account_type = "Standard_LRS"
   create_option        = "Empty"
   disk_size_gb         = 10
+  tags                 = var.tags
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "drbd_data_disk_attachment" {
@@ -228,7 +217,5 @@ resource "azurerm_linux_virtual_machine" "drbd" {
     storage_account_uri = var.storage_account
   }
 
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags = var.tags
 }

--- a/terraform/azure/modules/drbd_node/variables.tf
+++ b/terraform/azure/modules/drbd_node/variables.tf
@@ -91,3 +91,9 @@ variable "fence_agent_client_secret" {
   description = "Secret for the azure service principal / application that is used for native fencing."
   type        = string
 }
+
+variable "tags" {
+  description = "A map of tags to add to all resources in this module"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/azure/modules/hana_node/main.tf
+++ b/terraform/azure/modules/hana_node/main.tf
@@ -30,10 +30,7 @@ resource "azurerm_availability_set" "hana-availability-set" {
   resource_group_name         = var.resource_group_name
   managed                     = "true"
   platform_fault_domain_count = 2 + local.create_scale_out
-
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags                        = var.tags
 }
 
 # hana load balancer items
@@ -62,9 +59,7 @@ resource "azurerm_lb" "hana-load-balancer" {
     }
   }
 
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags = var.tags
 }
 
 # backend pools
@@ -168,9 +163,7 @@ resource "azurerm_network_interface" "hana" {
     public_ip_address_id          = element(azurerm_public_ip.hana.*.id, count.index)
   }
 
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags = var.tags
 }
 
 resource "azurerm_public_ip" "hana" {
@@ -180,10 +173,7 @@ resource "azurerm_public_ip" "hana" {
   resource_group_name     = var.resource_group_name
   allocation_method       = "Static"
   idle_timeout_in_minutes = 30
-
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags                    = var.tags
 }
 
 resource "azurerm_image" "sles4sap" {
@@ -200,9 +190,7 @@ resource "azurerm_image" "sles4sap" {
     storage_type = "Premium_LRS"
   }
 
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags = var.tags
 }
 
 # ANF volumes
@@ -240,6 +228,8 @@ resource "azurerm_netapp_volume" "hana-netapp-volume-data" {
   #   remote_volume_resource_id = azurerm_netapp_volume.example_primary.id
   #   replication_frequency     = "10minutes"
   # }
+
+  tags = var.tags
 }
 
 resource "azurerm_netapp_volume" "hana-netapp-volume-log" {
@@ -276,6 +266,8 @@ resource "azurerm_netapp_volume" "hana-netapp-volume-log" {
   #   remote_volume_resource_id = azurerm_netapp_volume.example_primary.id
   #   replication_frequency     = "10minutes"
   # }
+
+  tags = var.tags
 }
 
 resource "azurerm_netapp_volume" "hana-netapp-volume-backup" {
@@ -312,6 +304,8 @@ resource "azurerm_netapp_volume" "hana-netapp-volume-backup" {
   #   remote_volume_resource_id = azurerm_netapp_volume.example_primary.id
   #   replication_frequency     = "10minutes"
   # }
+
+  tags = var.tags
 }
 
 resource "azurerm_netapp_volume" "hana-netapp-volume-shared" {
@@ -348,6 +342,8 @@ resource "azurerm_netapp_volume" "hana-netapp-volume-shared" {
   #   remote_volume_resource_id = azurerm_netapp_volume.example_primary.id
   #   replication_frequency     = "10minutes"
   # }
+
+  tags = var.tags
 }
 
 
@@ -374,6 +370,7 @@ resource "azurerm_managed_disk" "hana_data_disk_01" {
   storage_account_type = element(local.disks_type, 0)
   create_option        = "Empty"
   disk_size_gb         = element(local.disks_size, 0)
+  tags                 = var.tags
 }
 
 resource "azurerm_managed_disk" "hana_data_disk_02" {
@@ -384,6 +381,7 @@ resource "azurerm_managed_disk" "hana_data_disk_02" {
   storage_account_type = element(local.disks_type, 1)
   create_option        = "Empty"
   disk_size_gb         = element(local.disks_size, 1)
+  tags                 = var.tags
 }
 
 resource "azurerm_managed_disk" "hana_data_disk_03" {
@@ -394,6 +392,7 @@ resource "azurerm_managed_disk" "hana_data_disk_03" {
   storage_account_type = element(local.disks_type, 2)
   create_option        = "Empty"
   disk_size_gb         = element(local.disks_size, 2)
+  tags                 = var.tags
 }
 
 resource "azurerm_managed_disk" "hana_data_disk_04" {
@@ -404,6 +403,7 @@ resource "azurerm_managed_disk" "hana_data_disk_04" {
   storage_account_type = element(local.disks_type, 3)
   create_option        = "Empty"
   disk_size_gb         = element(local.disks_size, 3)
+  tags                 = var.tags
 }
 
 resource "azurerm_managed_disk" "hana_data_disk_05" {
@@ -414,6 +414,7 @@ resource "azurerm_managed_disk" "hana_data_disk_05" {
   storage_account_type = element(local.disks_type, 4)
   create_option        = "Empty"
   disk_size_gb         = element(local.disks_size, 4)
+  tags                 = var.tags
 }
 
 resource "azurerm_managed_disk" "hana_data_disk_06" {
@@ -424,6 +425,7 @@ resource "azurerm_managed_disk" "hana_data_disk_06" {
   storage_account_type = element(local.disks_type, 5)
   create_option        = "Empty"
   disk_size_gb         = element(local.disks_size, 5)
+  tags                 = var.tags
 }
 
 resource "azurerm_managed_disk" "hana_data_disk_07" {
@@ -434,6 +436,7 @@ resource "azurerm_managed_disk" "hana_data_disk_07" {
   storage_account_type = element(local.disks_type, 6)
   create_option        = "Empty"
   disk_size_gb         = element(local.disks_size, 6)
+  tags                 = var.tags
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "hana_data_disk_attachment_01" {
@@ -651,9 +654,7 @@ resource "azurerm_linux_virtual_machine" "hana" {
     storage_account_uri = var.storage_account
   }
 
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags = var.tags
 }
 
 module "hana_majority_maker" {
@@ -678,4 +679,5 @@ module "hana_majority_maker" {
   tenant_id                 = var.tenant_id
   fence_agent_app_id        = var.fence_agent_app_id
   fence_agent_client_secret = var.fence_agent_client_secret
+  tags                      = var.tags
 }

--- a/terraform/azure/modules/hana_node/variables.tf
+++ b/terraform/azure/modules/hana_node/variables.tf
@@ -174,3 +174,9 @@ variable "disk_attachment_delay" {
   description = "Time to wait between disk attachments."
   default     = "10s"
 }
+
+variable "tags" {
+  description = "A map of tags to add to all resources in this module"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/azure/modules/iscsi_server/main.tf
+++ b/terraform/azure/modules/iscsi_server/main.tf
@@ -19,9 +19,7 @@ resource "azurerm_network_interface" "iscsisrv" {
     public_ip_address_id          = element(azurerm_public_ip.iscsisrv.*.id, count.index)
   }
 
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags = var.tags
 }
 
 resource "azurerm_public_ip" "iscsisrv" {
@@ -31,10 +29,7 @@ resource "azurerm_public_ip" "iscsisrv" {
   resource_group_name     = var.resource_group_name
   allocation_method       = "Static"
   idle_timeout_in_minutes = 30
-
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags                    = var.tags
 }
 
 # iscsi server custom image. only available if iscsi_image_uri is used
@@ -53,9 +48,7 @@ resource "azurerm_image" "iscsi_srv" {
     storage_type = "Premium_LRS"
   }
 
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags = var.tags
 }
 
 # iSCSI server VM
@@ -73,6 +66,7 @@ resource "azurerm_managed_disk" "iscsisrv_data" {
   storage_account_type = "StandardSSD_LRS"
   create_option        = "Empty"
   disk_size_gb         = var.iscsi_disk_size
+  tags                 = var.tags
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "iscsisrv_data" {
@@ -121,7 +115,5 @@ resource "azurerm_linux_virtual_machine" "iscsisrv" {
     storage_account_uri = var.storage_account
   }
 
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags = var.tags
 }

--- a/terraform/azure/modules/iscsi_server/variables.tf
+++ b/terraform/azure/modules/iscsi_server/variables.tf
@@ -66,3 +66,9 @@ variable "lun_count" {
   type        = number
   default     = 3
 }
+
+variable "tags" {
+  description = "A map of tags to add to all resources in this module"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/azure/modules/majority_maker_node/main.tf
+++ b/terraform/azure/modules/majority_maker_node/main.tf
@@ -20,9 +20,7 @@ resource "azurerm_network_interface" "majority_maker" {
     public_ip_address_id          = element(azurerm_public_ip.majority_maker.*.id, count.index)
   }
 
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags = var.tags
 }
 
 resource "azurerm_public_ip" "majority_maker" {
@@ -32,10 +30,7 @@ resource "azurerm_public_ip" "majority_maker" {
   resource_group_name     = var.resource_group_name
   allocation_method       = "Static"
   idle_timeout_in_minutes = 30
-
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags                    = var.tags
 }
 
 # majority maker instance
@@ -54,9 +49,7 @@ resource "azurerm_image" "sles4sap" {
     storage_type = "Premium_LRS"
   }
 
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags = var.tags
 }
 
 module "os_image_reference" {
@@ -104,7 +97,5 @@ resource "azurerm_linux_virtual_machine" "majority_maker" {
     storage_account_uri = var.storage_account
   }
 
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags = var.tags
 }

--- a/terraform/azure/modules/majority_maker_node/variables.tf
+++ b/terraform/azure/modules/majority_maker_node/variables.tf
@@ -86,3 +86,9 @@ variable "fence_agent_client_secret" {
   description = "Secret for the azure service principal / application that is used for native fencing."
   type        = string
 }
+
+variable "tags" {
+  description = "A map of tags to add to all resources in this module"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/azure/modules/monitoring/main.tf
+++ b/terraform/azure/modules/monitoring/main.tf
@@ -19,9 +19,7 @@ resource "azurerm_network_interface" "monitoring" {
     public_ip_address_id          = azurerm_public_ip.monitoring.0.id
   }
 
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags = var.tags
 }
 
 resource "azurerm_public_ip" "monitoring" {
@@ -31,10 +29,7 @@ resource "azurerm_public_ip" "monitoring" {
   resource_group_name     = var.resource_group_name
   allocation_method       = "Static"
   idle_timeout_in_minutes = 30
-
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags                    = var.tags
 }
 
 # monitoring custom image. only available if monitoring_image_uri is used
@@ -53,9 +48,7 @@ resource "azurerm_image" "monitoring" {
     storage_type = "Premium_LRS"
   }
 
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags = var.tags
 }
 
 # monitoring VM
@@ -73,6 +66,7 @@ resource "azurerm_managed_disk" "monitoring_data" {
   storage_account_type = "Standard_LRS"
   create_option        = "Empty"
   disk_size_gb         = 10
+  tags                 = var.tags
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "monitoring_data" {
@@ -120,7 +114,5 @@ resource "azurerm_linux_virtual_machine" "monitoring" {
     storage_account_uri = var.storage_account
   }
 
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags = var.tags
 }

--- a/terraform/azure/modules/monitoring/variables.tf
+++ b/terraform/azure/modules/monitoring/variables.tf
@@ -61,3 +61,9 @@ variable "monitoring_srv_ip" {
   type        = string
   default     = ""
 }
+
+variable "tags" {
+  description = "A map of tags to add to all resources in this module"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/azure/modules/netweaver_node/main.tf
+++ b/terraform/azure/modules/netweaver_node/main.tf
@@ -36,10 +36,7 @@ resource "azurerm_availability_set" "netweaver-xscs-availability-set" {
   resource_group_name         = var.resource_group_name
   managed                     = "true"
   platform_fault_domain_count = 2
-
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags                        = var.tags
 }
 
 resource "azurerm_availability_set" "netweaver-app-availability-set" {
@@ -50,10 +47,7 @@ resource "azurerm_availability_set" "netweaver-app-availability-set" {
   managed                      = "true"
   platform_fault_domain_count  = 2
   platform_update_domain_count = 10
-
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags                         = var.tags
 }
 
 # netweaver load balancer items
@@ -78,9 +72,7 @@ resource "azurerm_lb" "netweaver-load-balancer" {
     private_ip_address            = element(var.virtual_host_ips, 1)
   }
 
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags = var.tags
 }
 
 # backend pools
@@ -196,10 +188,7 @@ resource "azurerm_public_ip" "netweaver" {
   resource_group_name     = var.resource_group_name
   allocation_method       = "Static"
   idle_timeout_in_minutes = 30
-
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags                    = var.tags
 }
 
 resource "azurerm_network_interface" "netweaver" {
@@ -253,9 +242,7 @@ resource "azurerm_network_interface" "netweaver" {
     }
   }
 
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags = var.tags
 }
 
 # netweaver custom image. only available is netweaver_image_uri is used
@@ -274,9 +261,7 @@ resource "azurerm_image" "netweaver-image" {
     storage_type = "Premium_LRS"
   }
 
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags = var.tags
 }
 
 # ANF volumes
@@ -314,6 +299,8 @@ resource "azurerm_netapp_volume" "netweaver-netapp-volume-sapmnt" {
   #   remote_volume_resource_id = azurerm_netapp_volume.example_primary.id
   #   replication_frequency     = "10minutes"
   # }
+
+  tags = var.tags
 }
 
 # APP server disk
@@ -326,6 +313,7 @@ resource "azurerm_managed_disk" "app_server_disk" {
   storage_account_type = var.data_disk_type
   create_option        = "Empty"
   disk_size_gb         = var.data_disk_size
+  tags                 = var.tags
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "app_server_disk" {
@@ -384,7 +372,5 @@ resource "azurerm_linux_virtual_machine" "netweaver" {
     storage_account_uri = var.storage_account
   }
 
-  tags = {
-    workspace = var.common_variables["deployment_name"]
-  }
+  tags = var.tags
 }

--- a/terraform/azure/modules/netweaver_node/variables.tf
+++ b/terraform/azure/modules/netweaver_node/variables.tf
@@ -163,3 +163,9 @@ variable "netweaver_anf_quota_sapmnt" {
   description = "Quota for ANF shared storage volume Netweaver"
   type        = number
 }
+
+variable "tags" {
+  description = "A map of tags to add to all resources in this module"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -908,3 +908,9 @@ variable "allowed_ssh_cidr_csv" {
     error_message = "The value must be a valid CIDR or a comma-separated list of valid CIDRs."
   }
 }
+
+variable "custom_tags" {
+  description = "Optional custom tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
This PR adds the ability to have custom tags (key-value pairs) provided via tfvars, that will be added to all azure resources that are taggable. In tfvars, an entry like the following should be added:

```
custom_tags = {
  "my_custom_tag" = "BillWasHere"
}
```

It was tested manually and worked as expected (tag was added). Below are VRs that do not add anything to tfvars, and they also work as expected (they have the same behavior as before).

- Related ticket: https://jira.suse.com/browse/TEAM-11207
- Verification runs:
https://openqa.suse.de/tests/22434831 (saptune)
https://openqa.suse.de/tests/22434838 (hanaSR)