### PR TITLE
Add sleeps between hana-load-balancers

### DIFF
--- a/terraform/azure/modules/hana_node/lb_rules_chain/main.tf
+++ b/terraform/azure/modules/hana_node/lb_rules_chain/main.tf
@@ -1,0 +1,178 @@
+variable "loadbalancer_id" {}
+variable "hana_instance_number" {}
+variable "backend_address_pool_id" {}
+variable "probe_id" {}
+variable "name_suffix" { default = "" }
+variable "frontend_ip_configuration_name" {}
+
+locals {
+  ports = [
+    "3${var.hana_instance_number}13",
+    "3${var.hana_instance_number}14",
+    "3${var.hana_instance_number}40",
+    "3${var.hana_instance_number}41",
+    "3${var.hana_instance_number}42",
+    "3${var.hana_instance_number}15",
+    "3${var.hana_instance_number}17",
+    "5${var.hana_instance_number}13"
+  ]
+}
+
+resource "azurerm_lb_rule" "hana_lb_rule_30013" {
+  loadbalancer_id                = var.loadbalancer_id
+  name                           = "lbrule-hana-tcp-${local.ports[0]}${var.name_suffix}"
+  protocol                       = "Tcp"
+  frontend_ip_configuration_name = var.frontend_ip_configuration_name
+  frontend_port                  = tonumber(local.ports[0])
+  backend_port                   = tonumber(local.ports[0])
+  backend_address_pool_ids       = [var.backend_address_pool_id]
+  probe_id                       = var.probe_id
+  idle_timeout_in_minutes        = 30
+  floating_ip_enabled            = "true"
+}
+
+resource "time_sleep" "wait_30013" {
+  create_duration = "6s"
+  depends_on      = [azurerm_lb_rule.hana_lb_rule_30013]
+}
+
+resource "azurerm_lb_rule" "hana_lb_rule_30014" {
+  loadbalancer_id                = var.loadbalancer_id
+  name                           = "lbrule-hana-tcp-${local.ports[1]}${var.name_suffix}"
+  protocol                       = "Tcp"
+  frontend_ip_configuration_name = var.frontend_ip_configuration_name
+  frontend_port                  = tonumber(local.ports[1])
+  backend_port                   = tonumber(local.ports[1])
+  backend_address_pool_ids       = [var.backend_address_pool_id]
+  probe_id                       = var.probe_id
+  idle_timeout_in_minutes        = 30
+  floating_ip_enabled            = "true"
+
+  depends_on = [time_sleep.wait_30013]
+}
+
+resource "time_sleep" "wait_30014" {
+  create_duration = "6s"
+  depends_on      = [azurerm_lb_rule.hana_lb_rule_30014]
+}
+
+resource "azurerm_lb_rule" "hana_lb_rule_30040" {
+  loadbalancer_id                = var.loadbalancer_id
+  name                           = "lbrule-hana-tcp-${local.ports[2]}${var.name_suffix}"
+  protocol                       = "Tcp"
+  frontend_ip_configuration_name = var.frontend_ip_configuration_name
+  frontend_port                  = tonumber(local.ports[2])
+  backend_port                   = tonumber(local.ports[2])
+  backend_address_pool_ids       = [var.backend_address_pool_id]
+  probe_id                       = var.probe_id
+  idle_timeout_in_minutes        = 30
+  floating_ip_enabled            = "true"
+
+  depends_on = [time_sleep.wait_30014]
+}
+
+resource "time_sleep" "wait_30040" {
+  create_duration = "6s"
+  depends_on      = [azurerm_lb_rule.hana_lb_rule_30040]
+}
+
+resource "azurerm_lb_rule" "hana_lb_rule_30041" {
+  loadbalancer_id                = var.loadbalancer_id
+  name                           = "lbrule-hana-tcp-${local.ports[3]}${var.name_suffix}"
+  protocol                       = "Tcp"
+  frontend_ip_configuration_name = var.frontend_ip_configuration_name
+  frontend_port                  = tonumber(local.ports[3])
+  backend_port                   = tonumber(local.ports[3])
+  backend_address_pool_ids       = [var.backend_address_pool_id]
+  probe_id                       = var.probe_id
+  idle_timeout_in_minutes        = 30
+  floating_ip_enabled            = "true"
+
+  depends_on = [time_sleep.wait_30040]
+}
+
+resource "time_sleep" "wait_30041" {
+  create_duration = "6s"
+  depends_on      = [azurerm_lb_rule.hana_lb_rule_30041]
+}
+
+resource "azurerm_lb_rule" "hana_lb_rule_30042" {
+  loadbalancer_id                = var.loadbalancer_id
+  name                           = "lbrule-hana-tcp-${local.ports[4]}${var.name_suffix}"
+  protocol                       = "Tcp"
+  frontend_ip_configuration_name = var.frontend_ip_configuration_name
+  frontend_port                  = tonumber(local.ports[4])
+  backend_port                   = tonumber(local.ports[4])
+  backend_address_pool_ids       = [var.backend_address_pool_id]
+  probe_id                       = var.probe_id
+  idle_timeout_in_minutes        = 30
+  floating_ip_enabled            = "true"
+
+  depends_on = [time_sleep.wait_30041]
+}
+
+resource "time_sleep" "wait_30042" {
+  create_duration = "6s"
+  depends_on      = [azurerm_lb_rule.hana_lb_rule_30042]
+}
+
+resource "azurerm_lb_rule" "hana_lb_rule_30015" {
+  loadbalancer_id                = var.loadbalancer_id
+  name                           = "lbrule-hana-tcp-${local.ports[5]}${var.name_suffix}"
+  protocol                       = "Tcp"
+  frontend_ip_configuration_name = var.frontend_ip_configuration_name
+  frontend_port                  = tonumber(local.ports[5])
+  backend_port                   = tonumber(local.ports[5])
+  backend_address_pool_ids       = [var.backend_address_pool_id]
+  probe_id                       = var.probe_id
+  idle_timeout_in_minutes        = 30
+  floating_ip_enabled            = "true"
+
+  depends_on = [time_sleep.wait_30042]
+}
+
+resource "time_sleep" "wait_30015" {
+  create_duration = "6s"
+  depends_on      = [azurerm_lb_rule.hana_lb_rule_30015]
+}
+
+resource "azurerm_lb_rule" "hana_lb_rule_30017" {
+  loadbalancer_id                = var.loadbalancer_id
+  name                           = "lbrule-hana-tcp-${local.ports[6]}${var.name_suffix}"
+  protocol                       = "Tcp"
+  frontend_ip_configuration_name = var.frontend_ip_configuration_name
+  frontend_port                  = tonumber(local.ports[6])
+  backend_port                   = tonumber(local.ports[6])
+  backend_address_pool_ids       = [var.backend_address_pool_id]
+  probe_id                       = var.probe_id
+  idle_timeout_in_minutes        = 30
+  floating_ip_enabled            = "true"
+
+  depends_on = [time_sleep.wait_30015]
+}
+
+resource "time_sleep" "wait_30017" {
+  create_duration = "6s"
+  depends_on      = [azurerm_lb_rule.hana_lb_rule_30017]
+}
+
+resource "azurerm_lb_rule" "hana_lb_rule_50013" {
+  loadbalancer_id                = var.loadbalancer_id
+  name                           = "lbrule-hana-tcp-${local.ports[7]}${var.name_suffix}"
+  protocol                       = "Tcp"
+  frontend_ip_configuration_name = var.frontend_ip_configuration_name
+  frontend_port                  = tonumber(local.ports[7])
+  backend_port                   = tonumber(local.ports[7])
+  backend_address_pool_ids       = [var.backend_address_pool_id]
+  probe_id                       = var.probe_id
+  idle_timeout_in_minutes        = 30
+  floating_ip_enabled            = "true"
+
+  depends_on = [time_sleep.wait_30017]
+}
+
+resource "time_sleep" "wait_50013" {
+  create_duration = "6s"
+  depends_on      = [azurerm_lb_rule.hana_lb_rule_50013]
+}
+

--- a/terraform/azure/modules/hana_node/main.tf
+++ b/terraform/azure/modules/hana_node/main.tf
@@ -7,20 +7,8 @@ locals {
   sites                      = var.common_variables["hana"]["ha_enabled"] ? 2 : 1
   create_active_active_infra = local.create_ha_infra == 1 && var.common_variables["hana"]["cluster_vip_secondary"] != "" ? 1 : 0
   provisioning_addresses     = data.azurerm_public_ip.hana.*.ip_address
-  hana_lb_rules_ports = local.create_ha_infra == 1 ? toset([
-    "3${var.hana_instance_number}13",
-    "3${var.hana_instance_number}14",
-    "3${var.hana_instance_number}40",
-    "3${var.hana_instance_number}41",
-    "3${var.hana_instance_number}42",
-    "3${var.hana_instance_number}15",
-    "3${var.hana_instance_number}17",
-    "5${var.hana_instance_number}13" # S4HANA DB import checks sapctrl port
-  ]) : toset([])
-
-  hana_lb_rules_ports_secondary = local.create_active_active_infra == 1 ? local.hana_lb_rules_ports : toset([])
-  hostname                      = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
-  disk_attachment_delay         = coalesce(var.disk_attachment_delay, "10s")
+  hostname                   = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
+  disk_attachment_delay      = coalesce(var.disk_attachment_delay, "10s")
 }
 
 resource "azurerm_availability_set" "hana-availability-set" {
@@ -100,35 +88,31 @@ resource "azurerm_lb_probe" "hana-load-balancer-secondary" {
 }
 
 # Load balancing rules for HANA 2.0
-resource "azurerm_lb_rule" "hana-lb-rules" {
-  for_each = local.hana_lb_rules_ports
-  #resource_group_name            = var.resource_group_name
+module "hana_primary_lb_rules" {
+  source = "./lb_rules_chain"
+  count  = local.create_ha_infra == 1 ? 1 : 0
+
   loadbalancer_id                = azurerm_lb.hana-load-balancer[0].id
-  name                           = "lbrule-hana-tcp-${each.value}"
-  protocol                       = "Tcp"
-  frontend_ip_configuration_name = "lbfe-hana"
-  frontend_port                  = tonumber(each.value)
-  backend_port                   = tonumber(each.value)
-  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.hana-load-balancer[0].id]
+  hana_instance_number           = var.hana_instance_number
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.hana-load-balancer[0].id
   probe_id                       = azurerm_lb_probe.hana-load-balancer[0].id
-  idle_timeout_in_minutes        = 30
-  floating_ip_enabled            = "true"
+  frontend_ip_configuration_name = "lbfe-hana"
+  name_suffix                    = ""
 }
 
 # Load balancing rules for the Active/Active setup
-resource "azurerm_lb_rule" "hana-lb-rules-secondary" {
-  for_each = local.hana_lb_rules_ports_secondary
-  #resource_group_name            = var.resource_group_name
+module "hana_secondary_lb_rules" {
+  source = "./lb_rules_chain"
+  count  = local.create_active_active_infra == 1 ? 1 : 0
+
   loadbalancer_id                = azurerm_lb.hana-load-balancer[0].id
-  name                           = "lbrule-hana-tcp-${each.value}-secondary"
-  protocol                       = "Tcp"
-  frontend_ip_configuration_name = "lbfe-hana-secondary"
-  frontend_port                  = tonumber(each.value)
-  backend_port                   = tonumber(each.value)
-  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.hana-load-balancer[0].id]
+  hana_instance_number           = var.hana_instance_number
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.hana-load-balancer[0].id
   probe_id                       = azurerm_lb_probe.hana-load-balancer-secondary[0].id
-  idle_timeout_in_minutes        = 30
-  floating_ip_enabled            = "true"
+  frontend_ip_configuration_name = "lbfe-hana-secondary"
+  name_suffix                    = "-secondary"
+
+  depends_on = [module.hana_primary_lb_rules]
 }
 
 resource "azurerm_lb_rule" "hanadb_exporter" {


### PR DESCRIPTION
there is a problem when running deploy_qesap_terraform module like [this](https://openqa.suse.de/tests/22438945/logfile?filename=deploy_qesap_terraform-qesap_exec_terraform.log.txt):
```
ERROR    OUTPUT: module.hana_node.azurerm_lb_rule.hana-lb-rules["50013"]: Creation complete after 4s [id=/subscriptions/0f2a99ba-10c7-4dd8-83fe-90c313f48030/resourceGroups/rg-ha-sap-hanasr22438945/providers/Microsoft.Network/loadBalancers/lb-hana/loadBalancingRules/lbrule-hana-tcp-50013]
ERROR    OUTPUT: module.hana_node.azurerm_lb_rule.hana-lb-rules["30042"]: Creating...
ERROR    OUTPUT: module.hana_node.azurerm_lb_rule.hana-lb-rules["30013"]: Creating...
ERROR    OUTPUT: module.hana_node.azurerm_lb_rule.hana-lb-rules["30013"]: Creation complete after 4s [id=/subscriptions/0f2a99ba-10c7-4dd8-83fe-90c313f48030/resourceGroups/rg-ha-sap-hanasr22438945/providers/Microsoft.Network/loadBalancers/lb-hana/loadBalancingRules/lbrule-hana-tcp-30013]
...
...
ERROR    OUTPUT: 
ERROR    OUTPUT: Error: updating Load Balancing Rule (Subscription: "0f2a99ba-10c7-4dd8-83fe-90c313f48030"
ERROR    OUTPUT: Resource Group Name: "rg-ha-sap-hanasr22438945"
ERROR    OUTPUT: Load Balancer Name: "lb-hana"
ERROR    OUTPUT: Load Balancing Rule Name: "lbrule-hana-tcp-30042"): performing CreateOrUpdate: unexpected status 409 (409 Conflict) with error: ConflictingConcurrentWriteNotAllowed: The operation was interrupted by a conflicting concurrent write on the same entity. Please retry later.
ERROR    OUTPUT: 
ERROR    OUTPUT:   with module.hana_node.azurerm_lb_rule.hana-lb-rules["30042"],
ERROR    OUTPUT:   on modules/hana_node/main.tf line 107, in resource "azurerm_lb_rule" "hana-lb-rules":
ERROR    OUTPUT:  107: resource "azurerm_lb_rule" "hana-lb-rules" {
ERROR    OUTPUT: 
DEBUG    Terraform process return ret:1
DEBUG    Write terraform.apply.log.txt getcwd:/root/community.sles-for-sap
ERROR    command:terraform -chdir=/root/qe-sap-deployment/terraform/azure apply -parallelism=1 -auto-approve plan.zip -no-color returned non zero 1
ERROR    Error rc: 1 at terraform -chdir=/root/qe-sap-deployment/terraform/azure apply -parallelism=1 -auto-approve plan.zip -no-color
```
there are many requests from **azurerm_lb_rule** at the same time, this results in the conflict issue between rule 30042 and rule 30013, so I create this PR to add sleeps between different **hana-lb-rules**, and this is the output with this PR, it works:

```
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].azurerm_lb_rule.hana_lb_rule_30013: Creating...
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].azurerm_lb_rule.hana_lb_rule_30013: Creation complete after 4s [id=/subscriptions/0f2a99ba-10c7-4dd8-83fe-90c313f48030/resourceGroups/rg-ha-sap-hanasr22525658/providers/Microsoft.Network/loadBalancers/lb-hana/loadBalancingRules/lbrule-hana-tcp-30013]
DEBUG    OUTPUT: module.hana_node.time_sleep.wait_after_attachment_01: Creating...
DEBUG    OUTPUT: module.hana_node.time_sleep.wait_after_attachment_01: Still creating... [10s elapsed]
DEBUG    OUTPUT: module.hana_node.time_sleep.wait_after_attachment_01: Creation complete after 10s [id=2026-05-27T07:51:53Z]
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].time_sleep.wait_30013: Creating...
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].time_sleep.wait_30013: Creation complete after 6s [id=2026-05-27T07:51:59Z]
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_02[1]: Creating...
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_02[1]: Creation complete after 10s [id=/subscriptions/0f2a99ba-10c7-4dd8-83fe-90c313f48030/resourceGroups/rg-ha-sap-hanasr22525658/providers/Microsoft.Compute/virtualMachines/vmhana02/dataDisks/disk-vmhana02-Data02]
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_02[0]: Creating...
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_02[0]: Still creating... [10s elapsed]
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_02[0]: Creation complete after 12s [id=/subscriptions/0f2a99ba-10c7-4dd8-83fe-90c313f48030/resourceGroups/rg-ha-sap-hanasr22525658/providers/Microsoft.Compute/virtualMachines/vmhana01/dataDisks/disk-vmhana01-Data02]
DEBUG    OUTPUT: local_file.ansible_inventory: Creating...
DEBUG    OUTPUT: local_file.ansible_inventory: Creation complete after 0s [id=2453040188dd08f979ca79c5c683c11e42faef10]
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].azurerm_lb_rule.hana_lb_rule_30014: Creating...
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].azurerm_lb_rule.hana_lb_rule_30014: Creation complete after 4s [id=/subscriptions/0f2a99ba-10c7-4dd8-83fe-90c313f48030/resourceGroups/rg-ha-sap-hanasr22525658/providers/Microsoft.Network/loadBalancers/lb-hana/loadBalancingRules/lbrule-hana-tcp-30014]
DEBUG    OUTPUT: module.hana_node.time_sleep.wait_after_attachment_02: Creating...
DEBUG    OUTPUT: module.hana_node.time_sleep.wait_after_attachment_02: Still creating... [10s elapsed]
DEBUG    OUTPUT: module.hana_node.time_sleep.wait_after_attachment_02: Creation complete after 10s [id=2026-05-27T07:52:35Z]
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].time_sleep.wait_30014: Creating...
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].time_sleep.wait_30014: Creation complete after 6s [id=2026-05-27T07:52:41Z]
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_03[0]: Creating...
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_03[0]: Still creating... [10s elapsed]
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_03[0]: Creation complete after 12s [id=/subscriptions/0f2a99ba-10c7-4dd8-83fe-90c313f48030/resourceGroups/rg-ha-sap-hanasr22525658/providers/Microsoft.Compute/virtualMachines/vmhana01/dataDisks/disk-vmhana01-Data03]
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_03[1]: Creating...
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_03[1]: Still creating... [10s elapsed]
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_03[1]: Creation complete after 10s [id=/subscriptions/0f2a99ba-10c7-4dd8-83fe-90c313f48030/resourceGroups/rg-ha-sap-hanasr22525658/providers/Microsoft.Compute/virtualMachines/vmhana02/dataDisks/disk-vmhana02-Data03]
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].azurerm_lb_rule.hana_lb_rule_30040: Creating...
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].azurerm_lb_rule.hana_lb_rule_30040: Creation complete after 4s [id=/subscriptions/0f2a99ba-10c7-4dd8-83fe-90c313f48030/resourceGroups/rg-ha-sap-hanasr22525658/providers/Microsoft.Network/loadBalancers/lb-hana/loadBalancingRules/lbrule-hana-tcp-30040]
DEBUG    OUTPUT: module.hana_node.time_sleep.wait_after_attachment_03: Creating...
DEBUG    OUTPUT: module.hana_node.time_sleep.wait_after_attachment_03: Still creating... [10s elapsed]
DEBUG    OUTPUT: module.hana_node.time_sleep.wait_after_attachment_03: Creation complete after 10s [id=2026-05-27T07:53:18Z]
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].time_sleep.wait_30040: Creating...
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].time_sleep.wait_30040: Creation complete after 6s [id=2026-05-27T07:53:24Z]
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_04[0]: Creating...
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_04[0]: Still creating... [10s elapsed]
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_04[0]: Creation complete after 12s [id=/subscriptions/0f2a99ba-10c7-4dd8-83fe-90c313f48030/resourceGroups/rg-ha-sap-hanasr22525658/providers/Microsoft.Compute/virtualMachines/vmhana01/dataDisks/disk-vmhana01-Data04]
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_04[1]: Creating...
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_04[1]: Creation complete after 10s [id=/subscriptions/0f2a99ba-10c7-4dd8-83fe-90c313f48030/resourceGroups/rg-ha-sap-hanasr22525658/providers/Microsoft.Compute/virtualMachines/vmhana02/dataDisks/disk-vmhana02-Data04]
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].azurerm_lb_rule.hana_lb_rule_30041: Creating...
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].azurerm_lb_rule.hana_lb_rule_30041: Creation complete after 4s [id=/subscriptions/0f2a99ba-10c7-4dd8-83fe-90c313f48030/resourceGroups/rg-ha-sap-hanasr22525658/providers/Microsoft.Network/loadBalancers/lb-hana/loadBalancingRules/lbrule-hana-tcp-30041]
DEBUG    OUTPUT: module.hana_node.time_sleep.wait_after_attachment_04: Creating...
DEBUG    OUTPUT: module.hana_node.time_sleep.wait_after_attachment_04: Still creating... [10s elapsed]
DEBUG    OUTPUT: module.hana_node.time_sleep.wait_after_attachment_04: Creation complete after 10s [id=2026-05-27T07:53:59Z]
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].time_sleep.wait_30041: Creating...
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].time_sleep.wait_30041: Creation complete after 6s [id=2026-05-27T07:54:05Z]
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_05[0]: Creating...
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_05[0]: Creation complete after 10s [id=/subscriptions/0f2a99ba-10c7-4dd8-83fe-90c313f48030/resourceGroups/rg-ha-sap-hanasr22525658/providers/Microsoft.Compute/virtualMachines/vmhana01/dataDisks/disk-vmhana01-Data05]
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_05[1]: Creating...
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_05[1]: Still creating... [10s elapsed]
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_05[1]: Creation complete after 13s [id=/subscriptions/0f2a99ba-10c7-4dd8-83fe-90c313f48030/resourceGroups/rg-ha-sap-hanasr22525658/providers/Microsoft.Compute/virtualMachines/vmhana02/dataDisks/disk-vmhana02-Data05]
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].azurerm_lb_rule.hana_lb_rule_30042: Creating...
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].azurerm_lb_rule.hana_lb_rule_30042: Creation complete after 5s [id=/subscriptions/0f2a99ba-10c7-4dd8-83fe-90c313f48030/resourceGroups/rg-ha-sap-hanasr22525658/providers/Microsoft.Network/loadBalancers/lb-hana/loadBalancingRules/lbrule-hana-tcp-30042]
DEBUG    OUTPUT: module.hana_node.time_sleep.wait_after_attachment_05: Creating...
DEBUG    OUTPUT: module.hana_node.time_sleep.wait_after_attachment_05: Still creating... [10s elapsed]
DEBUG    OUTPUT: module.hana_node.time_sleep.wait_after_attachment_05: Creation complete after 10s [id=2026-05-27T07:54:43Z]
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].time_sleep.wait_30042: Creating...
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].time_sleep.wait_30042: Creation complete after 6s [id=2026-05-27T07:54:49Z]
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_06[0]: Creating...
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_06[0]: Creation complete after 9s [id=/subscriptions/0f2a99ba-10c7-4dd8-83fe-90c313f48030/resourceGroups/rg-ha-sap-hanasr22525658/providers/Microsoft.Compute/virtualMachines/vmhana01/dataDisks/disk-vmhana01-Data06]
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_06[1]: Creating...
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_06[1]: Still creating... [10s elapsed]
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_06[1]: Creation complete after 10s [id=/subscriptions/0f2a99ba-10c7-4dd8-83fe-90c313f48030/resourceGroups/rg-ha-sap-hanasr22525658/providers/Microsoft.Compute/virtualMachines/vmhana02/dataDisks/disk-vmhana02-Data06]
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].azurerm_lb_rule.hana_lb_rule_30015: Creating...
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].azurerm_lb_rule.hana_lb_rule_30015: Creation complete after 4s [id=/subscriptions/0f2a99ba-10c7-4dd8-83fe-90c313f48030/resourceGroups/rg-ha-sap-hanasr22525658/providers/Microsoft.Network/loadBalancers/lb-hana/loadBalancingRules/lbrule-hana-tcp-30015]
DEBUG    OUTPUT: module.hana_node.time_sleep.wait_after_attachment_06: Creating...
DEBUG    OUTPUT: module.hana_node.time_sleep.wait_after_attachment_06: Still creating... [10s elapsed]
DEBUG    OUTPUT: module.hana_node.time_sleep.wait_after_attachment_06: Creation complete after 10s [id=2026-05-27T07:55:23Z]
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].time_sleep.wait_30015: Creating...
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].time_sleep.wait_30015: Creation complete after 6s [id=2026-05-27T07:55:29Z]
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_07[1]: Creating...
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_07[1]: Creation complete after 10s [id=/subscriptions/0f2a99ba-10c7-4dd8-83fe-90c313f48030/resourceGroups/rg-ha-sap-hanasr22525658/providers/Microsoft.Compute/virtualMachines/vmhana02/dataDisks/disk-vmhana02-Data07]
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_07[0]: Creating...
DEBUG    OUTPUT: module.hana_node.azurerm_virtual_machine_data_disk_attachment.hana_data_disk_attachment_07[0]: Creation complete after 10s [id=/subscriptions/0f2a99ba-10c7-4dd8-83fe-90c313f48030/resourceGroups/rg-ha-sap-hanasr22525658/providers/Microsoft.Compute/virtualMachines/vmhana01/dataDisks/disk-vmhana01-Data07]
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].azurerm_lb_rule.hana_lb_rule_30017: Creating...
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].azurerm_lb_rule.hana_lb_rule_30017: Creation complete after 4s [id=/subscriptions/0f2a99ba-10c7-4dd8-83fe-90c313f48030/resourceGroups/rg-ha-sap-hanasr22525658/providers/Microsoft.Network/loadBalancers/lb-hana/loadBalancingRules/lbrule-hana-tcp-30017]
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].time_sleep.wait_30017: Creating...
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].time_sleep.wait_30017: Creation complete after 6s [id=2026-05-27T07:55:59Z]
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].azurerm_lb_rule.hana_lb_rule_50013: Creating...
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].azurerm_lb_rule.hana_lb_rule_50013: Creation complete after 5s [id=/subscriptions/0f2a99ba-10c7-4dd8-83fe-90c313f48030/resourceGroups/rg-ha-sap-hanasr22525658/providers/Microsoft.Network/loadBalancers/lb-hana/loadBalancingRules/lbrule-hana-tcp-50013]
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].time_sleep.wait_50013: Creating...
DEBUG    OUTPUT: module.hana_node.module.hana_primary_lb_rules[0].time_sleep.wait_50013: Creation complete after 6s [id=2026-05-27T07:56:09Z]
```

- Related ticket: https://jira.suse.com/browse/TEAM-10828
- Needles: None
- Verification run:
    https://openqa.suse.de/tests/22525658 (15-SP7 - job failed, but it is not related to this issue)
    https://openqa.suse.de/tests/22525606 (12-SP5)