### PR TITLE
Harden hana_prevalidate selectattr filters against missing keys

### DIFF
--- a/ansible/playbooks/roles/hana_prevalidate/tasks/main.yaml
+++ b/ansible/playbooks/roles/hana_prevalidate/tasks/main.yaml
@@ -143,18 +143,18 @@
 
     - name: Get legacy site lss status
       ansible.builtin.set_fact:
-        hana_prevalidate_online_sites: "{{ hana_prevalidate_hana_sr_attrs.Site.values() | selectattr('lss', 'in', ['4', 'online']) | list }}"
+        hana_prevalidate_online_sites: "{{ hana_prevalidate_hana_sr_attrs.Site.values() | selectattr('lss', 'defined') | selectattr('lss', 'in', ['4', 'online']) | list }}"
       when: not hana_prevalidate_pacemaker_ge_2_1_7
 
     - name: Get modern site lss status
       ansible.builtin.set_fact:
-        hana_prevalidate_online_sites: "{{ hana_prevalidate_hana_sr_attrs.Site.values() | selectattr('lss', 'regex', '^[0-9]+$') | list }}"
+        hana_prevalidate_online_sites: "{{ hana_prevalidate_hana_sr_attrs.Site.values() | selectattr('lss', 'defined') | selectattr('lss', 'regex', '^[0-9]+$') | list }}"
       when: hana_prevalidate_pacemaker_ge_2_1_7
 
     - name: Get site srPoll status
       ansible.builtin.set_fact:
-        hana_prevalidate_prim_sites: "{{ hana_prevalidate_hana_sr_attrs.Site.values() | selectattr('srPoll', 'equalto', 'PRIM') | list }}"
-        hana_prevalidate_sok_sites: "{{ hana_prevalidate_hana_sr_attrs.Site.values() | selectattr('srPoll', 'equalto', 'SOK') | list }}"
+        hana_prevalidate_prim_sites: "{{ hana_prevalidate_hana_sr_attrs.Site.values() | selectattr('srPoll', 'defined') | selectattr('srPoll', 'equalto', 'PRIM') | list }}"
+        hana_prevalidate_sok_sites: "{{ hana_prevalidate_hana_sr_attrs.Site.values() | selectattr('srPoll', 'defined') | selectattr('srPoll', 'equalto', 'SOK') | list }}"
 
     - name: "Assert all HANA sites are online"
       ansible.builtin.assert:


### PR DESCRIPTION
This is a robustness change, not a bug fix: `SAPHanaSR-showAttr --format=json` (SAPHanaSR-angi) omits keys whose value is empty, while the legacy `--format=script` output keeps them as blank columns. As a consequence, a perfectly valid angi response may produce a `Site` entry without `lss`, `srPoll`, etc. The existing `selectattr('lss', ...)` and `selectattr('srPoll', ...)` calls dereference the attribute before testing it.
Guard each selector by chaining `selectattr(<key>, 'defined')` ahead of the real predicate. The Jinja `'defined'` test is the only common test designed to inspect a value without using it.


# Verification
 - sle-15-SP6-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE15_6-qesap_aws_angi_test -> http://openqaworker15.qe.prg2.suse.org/tests/372221