### PR TITLE
Tolerate instance-flavor-check FileNotFoundError crash (bsc#1267739)

### DIFF
--- a/ansible/playbooks/registration.yaml
+++ b/ansible/playbooks/registration.yaml
@@ -22,21 +22,45 @@
       ansible.builtin.command: which SUSEConnect
       changed_when: false
 
-    - name: Check for image type with instance-flavor-check
+    - name: Run instance-flavor-check
       ansible.builtin.command: instance-flavor-check
       register: flavor
-      failed_when: flavor.rc not in [10, 11, 12]
+      failed_when: false
       changed_when: false
       when: ifc_bin.rc == 0
+
+    - name: Classify instance-flavor-check outcome
+      ansible.builtin.set_fact:
+        flavor_ok: "{{ flavor.rc in [10, 11, 12] and (('BYOS' in flavor.stdout) or ('PAYG' in flavor.stdout)) }}"
+        flavor_known_bug: "{{ flavor.rc == 1 and 'FileNotFoundError: [Errno 2] No such file or directory' in flavor.stderr }}"
+      when: ifc_bin.rc == 0
+
+    - name: Fail on unexpected instance-flavor-check result
+      ansible.builtin.fail:
+        msg: "instance-flavor-check unexpected result: rc={{ flavor.rc }} stdout={{ flavor.stdout }} stderr={{ flavor.stderr }}"
+      when:
+        - ifc_bin.rc == 0
+        - not flavor_ok
+        - not flavor_known_bug
+
+    - name: Softfail for instance-flavor-check FileNotFoundError crash
+      ansible.builtin.debug:
+        msg:
+          - "[OSADO][softfail] bsc#1267739 instance-flavor-check crashed with FileNotFoundError"
+          - "Falling back to SUSEConnect -s to detect registration status"
+      when:
+        - ifc_bin.rc == 0
+        - flavor_known_bug
 
     - name: Set registration flag based on instance-flavor-check
       ansible.builtin.set_fact:
         to_be_registered: "{{ 'BYOS' in flavor.stdout }}"
-      when: ifc_bin.rc == 0
+      when:
+        - ifc_bin.rc == 0
+        - flavor_ok
 
-    # If instance-flavor-check is not available
-    # try to figure it out if image is PAYG or BYOS looking
-    # for not registered repos
+    # Fallback to SUSEConnect when instance-flavor-check is missing
+    # or hit the bsc#1267739 crash
     - name: Check for registration
       ansible.builtin.command: SUSEConnect -s
       register: repos
@@ -45,13 +69,12 @@
       delay: 120
       failed_when: repos.rc != 0
       changed_when: false
-      when: ifc_bin.rc != 0
+      when: ifc_bin.rc != 0 or (flavor_known_bug | default(false))
 
-    # Check if there are instances of `Not Registered` in it
     - name: Check for 'Not Registered'
       ansible.builtin.set_fact:
         to_be_registered: "{{ 'Not Registered' in repos.stdout }}"
-      when: ifc_bin.rc != 0
+      when: ifc_bin.rc != 0 or (flavor_known_bug | default(false))
 
     # Is registercloudguest available?
     # Only check about it if there any chance that it needs to be used


### PR DESCRIPTION
On fresh, never-registered images, instance-flavor-check can exit 1 with an unhandled FileNotFoundError raised from cloudregister.registerutils when /var/cache/cloudregister/ does not yet exist. The previous logic treated any rc outside [10, 11, 12] as fatal, aborting the play before the existing SUSEConnect fallback could run.
Change the playbook to:
1. runs instance-flavor-check unconditionally (never fails the task) and classifies the outcome into flavor_ok / flavor_known_bug,
2. proceeds as before when rc is in [10, 11, 12] and stdout reports BYOS or PAYG,
3. softfail for bsc#1267739 and falls back to SUSEConnect -s when rc is 1 and stderr contains the FileNotFoundError signature,
4. fails explicitly on any other unexpected combination.

Ticket https://jira.suse.com/browse/TEAM-11311

# Verification

## 16.0
- sle-16.0-Qesap-Aws-Byos-x86_64-BuildLATEST_AWS_SLE16_0-qesap_aws_saptune_angi_test -> http://openqaworker15.qe.prg2.suse.org/tests/372233 :green_circle:  get the failure https://openqaworker15.qe.prg2.suse.org/tests/372233/logfile?filename=deploy-ansible.registration.log.txt#line-42 but then fallback on `SUSEConnect -s` https://openqaworker15.qe.prg2.suse.org/tests/372233/logfile?filename=deploy-ansible.registration.log.txt#line-81

- sle-16.0-HanaSr-Aws-Payg-x86_64-Build16.0_2026-06-09T02:03:23Z-hanasr_aws_test_fencing_native_stop_kill ec2_r4.8xlarge -> http://openqaworker15.qe.prg2.suse.org/tests/372267 :green_circle: `instance-flavor-check` just work at first try on PAYG https://openqaworker15.qe.prg2.suse.org/tests/372267/logfile?filename=deploy_qesap_ansible-ansible.registration.log.txt#line-307
  
  
- sle-16.0-HanaSr-Azure-Byos-x86_64-Build16.0_2026-06-09T02:03:23Z-hanasr_azure_test_msi az_Standard_E4s_v3 -> http://openqaworker15.qe.prg2.suse.org/tests/372268  :green_circle:  exception occurred https://openqaworker15.qe.prg2.suse.org/tests/372268/logfile?filename=deploy_qesap_ansible-ansible.registration.log.txt#line-284 and detected https://openqaworker15.qe.prg2.suse.org/tests/372268/logfile?filename=deploy_qesap_ansible-ansible.registration.log.txt#line-364 . Fall back to `SUSEConnect -s` https://openqaworker15.qe.prg2.suse.org/tests/372268/logfile?filename=deploy_qesap_ansible-ansible.registration.log.txt#line-447 and register https://openqaworker15.qe.prg2.suse.org/tests/372268/logfile?filename=deploy_qesap_ansible-ansible.registration.log.txt#line-779 

- sle-16.0-HanaSr-Gcp-Byos-x86_64-Build16.0_2026-06-09T02:03:23Z-hanasr_gcp_test_fencing_native_stop_kill gce_n1_highmem_32 -> http://openqaworker15.qe.prg2.suse.org/tests/372269


## 12sp5
PAYG :  - sle-12-SP5-Qesap-Azure-Payg-x86_64-BuildLATEST_AZURE_SLE12_5-qesap_azure_ltss_test -> http://openqaworker15.qe.prg2.suse.org/tests/372234 :green_circle: no fallback needed https://openqaworker15.qe.prg2.suse.org/tests/372234/logfile?filename=deploy-ansible.registration.log.txt#line-343