### PR TITLE
Add explicit purge-kernels before reboot

### DIFF
--- a/ansible/playbooks/fully-patch-system.yaml
+++ b/ansible/playbooks/fully-patch-system.yaml
@@ -36,6 +36,20 @@
       failed_when: zypper_patch.rc not in [0, 102, 103]
       changed_when: zypper_patch.rc == 102 or zypper_patch.changed
 
+    - name: Proactively run zypper purge-kernels if reboot is requested
+      ansible.builtin.command: zypper purge-kernels
+      register: purge_kernels_result
+      when: zypper_patch.rc in [102, 103]
+      changed_when: true
+      failed_when: false
+
+    - name: Display the time taken for zypper purge-kernels
+      ansible.builtin.debug:
+        msg: "zypper purge-kernels execution time: {{ purge_kernels_result.delta }}"
+      when:
+        - zypper_patch.rc in [102, 103]
+        - purge_kernels_result.rc == 0
+
     - name: Trigger reboot+zypp_wait handler if zypper exit code requires it
       ansible.builtin.debug:
         msg: "Patches applied (zypper rc={{ zypper_patch.rc }}), triggering reboot"


### PR DESCRIPTION
This PR adds a task in Ansile to purge the kernel before reboot, instead of waiting for the automatic purging after reboot. This way we can know how much time the purge takes. 

- Related ticket: https://jira.suse.com/browse/TEAM-11124
- Verification Run: https://openqa.suse.de/tests/22774494, https://openqa.suse.de/tests/22775514